### PR TITLE
Add TOTP verification at registration with optional path

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,10 +1,10 @@
-from flask import render_template, request, redirect, url_for, flash
+from flask import render_template, request, redirect, url_for, flash, session
 from flask_login import login_user, logout_user, login_required, current_user
 from flask_babel import gettext as _
 from . import bp
 from ..extensions import db
 from ..models.user import User
-from .totp import new_totp_secret, verify_totp
+from .totp import new_totp_secret, verify_totp, provisioning_uri, qr_code_data_uri
 
 @bp.route("/login", methods=["GET", "POST"])
 def login():
@@ -28,9 +28,6 @@ def login():
 
 @bp.route("/register", methods=["GET", "POST"])
 def register():
-    # Roleテーブルからロール一覧を取得
-    from ..models.user import Role
-    roles = Role.query.all()
     if request.method == "POST":
         email = request.form.get("email")
         password = request.form.get("password")
@@ -40,19 +37,72 @@ def register():
         if User.query.filter_by(email=email).first():
             flash(_("Email already exists"), "error")
             return render_template("auth/register.html")
+        secret = new_totp_secret()
+        session["reg_email"] = email
+        session["reg_password"] = password
+        session["reg_secret"] = secret
+        return redirect(url_for("auth.register_totp"))
+    return render_template("auth/register.html")
+
+
+@bp.route("/register/totp", methods=["GET", "POST"])
+def register_totp():
+    from ..models.user import Role
+    email = session.get("reg_email")
+    password = session.get("reg_password")
+    secret = session.get("reg_secret")
+    if not email or not password or not secret:
+        flash(_("Session expired. Please register again."), "error")
+        return redirect(url_for("auth.register"))
+    uri = provisioning_uri(email, secret)
+    qr_data = qr_code_data_uri(uri)
+    if request.method == "POST":
+        token = request.form.get("token")
+        if not token or not verify_totp(secret, token):
+            flash(_("Invalid authentication code"), "error")
+            return render_template("auth/register_totp.html", qr_data=qr_data)
         u = User(email=email)
         u.set_password(password)
-        u.totp_secret = new_totp_secret()
+        u.totp_secret = secret
         member_role = Role.query.filter_by(name='member').first()
         if not member_role:
             flash(_("Default role 'member' does not exist"), "error")
-            return render_template("auth/register.html")
+            return redirect(url_for("auth.register"))
         u.roles.append(member_role)
         db.session.add(u)
         db.session.commit()
-        flash(_("Registration successful. Set up your authenticator with code: %(code)s", code=u.totp_secret), "success")
+        session.pop("reg_email", None)
+        session.pop("reg_password", None)
+        session.pop("reg_secret", None)
+        flash(_("Registration successful"), "success")
         return redirect(url_for("auth.login"))
-    return render_template("auth/register.html")
+    return render_template("auth/register_totp.html", qr_data=qr_data)
+
+
+@bp.route("/register/no_totp", methods=["GET", "POST"])
+def register_no_totp():
+    from ..models.user import Role
+    if request.method == "POST":
+        email = request.form.get("email")
+        password = request.form.get("password")
+        if not email or not password:
+            flash(_("Email and password are required"), "error")
+            return render_template("auth/register_no_totp.html")
+        if User.query.filter_by(email=email).first():
+            flash(_("Email already exists"), "error")
+            return render_template("auth/register_no_totp.html")
+        u = User(email=email)
+        u.set_password(password)
+        member_role = Role.query.filter_by(name='member').first()
+        if not member_role:
+            flash(_("Default role 'member' does not exist"), "error")
+            return render_template("auth/register_no_totp.html")
+        u.roles.append(member_role)
+        db.session.add(u)
+        db.session.commit()
+        flash(_("Registration successful"), "success")
+        return redirect(url_for("auth.login"))
+    return render_template("auth/register_no_totp.html")
 
 @bp.route("/edit", methods=["GET", "POST"])
 @login_required

--- a/app/auth/templates/auth/register_no_totp.html
+++ b/app/auth/templates/auth/register_no_totp.html
@@ -7,7 +7,7 @@
   <input type="email" name="email" required>
   <label>{{ _('Password') }}</label>
   <input type="password" name="password" required>
-  <button type="submit">{{ _('Next') }}</button>
+  <button type="submit">{{ _('Create account') }}</button>
 </form>
-<p><a href="{{ url_for('auth.register_no_totp') }}">{{ _('Register without two-factor authentication') }}</a></p>
+<p><a href="{{ url_for('auth.register') }}">{{ _('Register with two-factor authentication') }}</a></p>
 {% endblock %}

--- a/app/auth/templates/auth/register_totp.html
+++ b/app/auth/templates/auth/register_totp.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Verify TOTP') }}{% endblock %}
+{% block content %}
+<h2>{{ _('Verify TOTP') }}</h2>
+<p>{{ _('Scan the QR code with your authenticator app and enter the current code.') }}</p>
+<img src="{{ qr_data }}" alt="QR Code">
+<form method="post">
+  <label>{{ _('Authentication Code') }}</label>
+  <input type="text" name="token" required>
+  <button type="submit">{{ _('Complete registration') }}</button>
+</form>
+{% endblock %}

--- a/app/auth/totp.py
+++ b/app/auth/totp.py
@@ -1,4 +1,8 @@
+import base64
+import io
+
 import pyotp
+import qrcode
 
 def new_totp_secret():
     return pyotp.random_base32()
@@ -10,3 +14,12 @@ def verify_totp(secret: str, token: str, valid_window: int = 1):
     # valid_windowで前後コードを許容（時刻ズレ許容）
     totp = pyotp.TOTP(secret)
     return totp.verify(token, valid_window=valid_window)
+
+
+def qr_code_data_uri(uri: str) -> str:
+    """Provisioning URI から QR コードの data URI を生成"""
+    img = qrcode.make(uri)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{b64}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ Flask-Babel
 PyMySQL
 pyotp
 python-dotenv
+qrcode
+Pillow


### PR DESCRIPTION
## Summary
- Generate QR code data URIs for TOTP provisioning
- Add multi-step registration that verifies TOTP tokens and supports registration without two-factor auth
- Include qrcode/Pillow in dependencies

## Testing
- `python -m py_compile app/auth/totp.py app/auth/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689abdcd51e883238f6ae76f209a33f3