### PR TITLE
Add user self-service profile management with TOTP

### DIFF
--- a/app/auth/templates/auth/edit.html
+++ b/app/auth/templates/auth/edit.html
@@ -3,16 +3,15 @@
 {% block content %}
 <h2>{{ _('Edit Profile') }}</h2>
 <form method="post">
-  <label>Email</label>
+  <label>{{ _('Email') }}</label>
   <input type="email" name="email" value="{{ current_user.email }}" required>
-  <label>{{ _('Role') }}</label>
-  <select name="role">
-    {% for r in roles %}
-  <option value="{{ r.id }}" {% if r in current_user.roles %}selected{% endif %}>{{ r.name }}</option>
-    {% endfor %}
-  </select>
   <label>{{ _('New Password') }}</label>
   <input type="password" name="password">
   <button type="submit">{{ _('Update') }}</button>
 </form>
+{% if not current_user.totp_secret %}
+<p><a href="{{ url_for('auth.setup_totp') }}">{{ _('Enable Two-Factor Authentication') }}</a></p>
+{% else %}
+<p>{{ _('Two-Factor Authentication is enabled.') }}</p>
+{% endif %}
 {% endblock %}

--- a/app/auth/templates/auth/setup_totp.html
+++ b/app/auth/templates/auth/setup_totp.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Setup TOTP') }}{% endblock %}
+{% block content %}
+<h2>{{ _('Setup TOTP') }}</h2>
+<p>{{ _('Scan the QR code with your authenticator app and enter the current code.') }}</p>
+<img src="{{ qr_data }}" alt="QR Code">
+<form method="post">
+  <label>{{ _('Authentication Code') }}</label>
+  <input type="text" name="token" required>
+  <button type="submit">{{ _('Enable two-factor authentication') }}</button>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,7 +34,7 @@
         </li>
         {% if current_user.is_authenticated %}
           <li class="nav-item">
-            <span class="navbar-text d-block">{{ current_user.email }}</span>
+            <a class="nav-link" href="{{ url_for('auth.edit') }}">{{ current_user.email }}</a>
           </li>
           {% if current_user.has_role('admin') %}
           <li class="nav-item">


### PR DESCRIPTION
## Summary
- Link navbar username to a new self-service profile editor
- Allow users to change email and password and enable TOTP
- Add route and template for two-factor authentication setup

## Testing
- `python -m py_compile app/auth/routes.py app/auth/totp.py app/models/user.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ac6c504948323b32de2802f576f0c