### PR TITLE
Add user self-service profile management with TOTP

### DIFF
--- a/app/auth/templates/auth/edit.html
+++ b/app/auth/templates/auth/edit.html
@@ -2,17 +2,20 @@
 {% block title %}{{ _('Edit Profile') }}{% endblock %}
 {% block content %}
 <h2>{{ _('Edit Profile') }}</h2>
-<form method="post">
-  <label>Email</label>
-  <input type="email" name="email" value="{{ current_user.email }}" required>
-  <label>{{ _('Role') }}</label>
-  <select name="role">
-    {% for r in roles %}
-  <option value="{{ r.id }}" {% if r in current_user.roles %}selected{% endif %}>{{ r.name }}</option>
-    {% endfor %}
-  </select>
-  <label>{{ _('New Password') }}</label>
-  <input type="password" name="password">
-  <button type="submit">{{ _('Update') }}</button>
+<form method="post" class="mt-3 mx-auto form-narrow">
+  <div class="mb-3">
+    <label for="email" class="form-label">{{ _('Email') }}</label>
+    <input type="email" class="form-control" id="email" name="email" value="{{ current_user.email }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">{{ _('New Password') }}</label>
+    <input type="password" class="form-control" id="password" name="password">
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Update') }}</button>
 </form>
+{% if not current_user.totp_secret %}
+<p class="mt-3"><a class="link-primary" href="{{ url_for('auth.setup_totp') }}">{{ _('Enable Two-Factor Authentication') }}</a></p>
+{% else %}
+<p class="mt-3">{{ _('Two-Factor Authentication is enabled.') }}</p>
+{% endif %}
 {% endblock %}

--- a/app/auth/templates/auth/login.html
+++ b/app/auth/templates/auth/login.html
@@ -2,13 +2,19 @@
 {% block title %}{{ _('Login') }}{% endblock %}
 {% block content %}
 <h2>{{ _('Login') }}</h2>
-<form method="post">
-  <label>Email</label>
-  <input type="email" name="email" required>
-  <label>{{ _('Password') }}</label>
-  <input type="password" name="password" required>
-  <label>{{ _('Authentication Code') }}</label>
-  <input type="text" name="token">
-  <button type="submit">{{ _('Login') }}</button>
+<form method="post" class="mt-3 mx-auto form-narrow">
+  <div class="mb-3">
+    <label for="email" class="form-label">{{ _('Email') }}</label>
+    <input type="email" class="form-control" id="email" name="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">{{ _('Password') }}</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <div class="mb-3">
+    <label for="token" class="form-label">{{ _('Authentication Code') }}</label>
+    <input type="text" class="form-control" id="token" name="token">
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Login') }}</button>
 </form>
 {% endblock %}

--- a/app/auth/templates/auth/register.html
+++ b/app/auth/templates/auth/register.html
@@ -2,12 +2,16 @@
 {% block title %}{{ _('Register') }}{% endblock %}
 {% block content %}
 <h2>{{ _('Register') }}</h2>
-<form method="post">
-  <label>Email</label>
-  <input type="email" name="email" required>
-  <label>{{ _('Password') }}</label>
-  <input type="password" name="password" required>
-  <button type="submit">{{ _('Next') }}</button>
+<form method="post" class="mt-3 mx-auto form-narrow">
+  <div class="mb-3">
+    <label for="email" class="form-label">{{ _('Email') }}</label>
+    <input type="email" class="form-control" id="email" name="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">{{ _('Password') }}</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Next') }}</button>
 </form>
-<p><a href="{{ url_for('auth.register_no_totp') }}">{{ _('Register without two-factor authentication') }}</a></p>
+<p class="mt-3"><a class="link-primary" href="{{ url_for('auth.register_no_totp') }}">{{ _('Register without two-factor authentication') }}</a></p>
 {% endblock %}

--- a/app/auth/templates/auth/register_no_totp.html
+++ b/app/auth/templates/auth/register_no_totp.html
@@ -2,12 +2,16 @@
 {% block title %}{{ _('Register') }}{% endblock %}
 {% block content %}
 <h2>{{ _('Register') }}</h2>
-<form method="post">
-  <label>Email</label>
-  <input type="email" name="email" required>
-  <label>{{ _('Password') }}</label>
-  <input type="password" name="password" required>
-  <button type="submit">{{ _('Create account') }}</button>
+<form method="post" class="mt-3 mx-auto form-narrow">
+  <div class="mb-3">
+    <label for="email" class="form-label">{{ _('Email') }}</label>
+    <input type="email" class="form-control" id="email" name="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">{{ _('Password') }}</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Create account') }}</button>
 </form>
-<p><a href="{{ url_for('auth.register') }}">{{ _('Register with two-factor authentication') }}</a></p>
+<p class="mt-3"><a class="link-primary" href="{{ url_for('auth.register') }}">{{ _('Register with two-factor authentication') }}</a></p>
 {% endblock %}

--- a/app/auth/templates/auth/setup_totp.html
+++ b/app/auth/templates/auth/setup_totp.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}{{ _('Verify TOTP') }}{% endblock %}
+{% block title %}{{ _('Setup TOTP') }}{% endblock %}
 {% block content %}
-<h2>{{ _('Verify TOTP') }}</h2>
+<h2>{{ _('Setup TOTP') }}</h2>
 <p>{{ _('Scan the QR code with your authenticator app and enter the current code.') }}</p>
 <img src="{{ qr_data }}" alt="QR Code">
 <form method="post" class="mt-3 mx-auto form-narrow">
@@ -9,6 +9,6 @@
     <label for="token" class="form-label">{{ _('Authentication Code') }}</label>
     <input type="text" class="form-control" id="token" name="token" required>
   </div>
-  <button type="submit" class="btn btn-primary">{{ _('Complete registration') }}</button>
+  <button type="submit" class="btn btn-primary">{{ _('Enable two-factor authentication') }}</button>
 </form>
 {% endblock %}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,1 +1,5 @@
 body { font-family: system-ui, sans-serif; background-color: #f8f9fa; }
+
+.form-narrow {
+  max-width: 400px;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,7 +34,7 @@
         </li>
         {% if current_user.is_authenticated %}
           <li class="nav-item">
-            <span class="navbar-text d-block">{{ current_user.email }}</span>
+            <a class="nav-link" href="{{ url_for('auth.edit') }}">{{ current_user.email }}</a>
           </li>
           {% if current_user.has_role('admin') %}
           <li class="nav-item">


### PR DESCRIPTION
## Summary
- Link navbar username to a new self-service profile editor
- Allow users to change email and password and enable TOTP
- Add route and template for two-factor authentication setup
- Polish login, registration, profile and TOTP setup pages with Bootstrap styling and full-width inputs

## Testing
- `python -m py_compile app/auth/routes.py app/auth/totp.py app/models/user.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac6c504948323b32de2802f576f0c