### PR TITLE
Add Google account settings page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,7 @@ def create_app():
 
     # モデル import（migrate 用に認識させる）
     from .models import user as _user  # noqa: F401
+    from .models import google_account as _google_account  # noqa: F401
 
     # Blueprint 登録
     from .auth import bp as auth_bp
@@ -38,6 +39,9 @@ def create_app():
 
     from .admin.routes import bp as admin_bp
     app.register_blueprint(admin_bp, url_prefix="/admin")
+
+    from .photo_view import bp as photo_view_bp
+    app.register_blueprint(photo_view_bp, url_prefix="/photo-view")
 
     @app.after_request
     def add_time_header(response):

--- a/app/models/google_account.py
+++ b/app/models/google_account.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from ..extensions import db
+
+
+class GoogleAccount(db.Model):
+    __tablename__ = "google_account"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="active")
+    scopes = db.Column(db.Text, nullable=False)
+    last_synced_at = db.Column(db.DateTime, nullable=True)
+    oauth_token_json = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def scopes_list(self):
+        """Return scopes as list."""
+        if not self.scopes:
+            return []
+        return [s.strip() for s in self.scopes.split(",") if s.strip()]

--- a/app/photo_view/__init__.py
+++ b/app/photo_view/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("photo_view", __name__, template_folder="templates")
+
+from . import routes  # noqa: F401

--- a/app/photo_view/routes.py
+++ b/app/photo_view/routes.py
@@ -1,0 +1,14 @@
+from flask import render_template
+from flask_login import login_required
+from flask_babel import gettext as _
+
+from . import bp
+from ..models.google_account import GoogleAccount
+
+
+@bp.route("/settings/google-accounts")
+@login_required
+def google_accounts():
+    """Display Google account linkage settings."""
+    accounts = GoogleAccount.query.all()
+    return render_template("photo_view/google_accounts.html", accounts=accounts)

--- a/app/photo_view/templates/photo_view/google_accounts.html
+++ b/app/photo_view/templates/photo_view/google_accounts.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Google Accounts') }}{% endblock %}
+{% block content %}
+<div class="alert alert-warning" role="alert">
+  <strong>{{ _('Important:') }}</strong>
+  {{ _('The "photoslibrary.readonly" scope will be deprecated on 2025-03-31. Use appcreateddata scopes or the Photos Picker API for user selected items.') }}
+</div>
+
+<div class="d-flex justify-content-between mb-3">
+  <h2>{{ _('Google Accounts') }}</h2>
+  <a href="#" class="btn btn-primary">{{ _('Add Account') }}</a>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>{{ _('Email') }}</th>
+      <th>{{ _('Status') }}</th>
+      <th>{{ _('Scopes') }}</th>
+      <th>{{ _('Last Synced') }}</th>
+      <th>{{ _('Token') }}</th>
+      <th>{{ _('Actions') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for a in accounts %}
+    <tr>
+      <td>{{ a.email }}</td>
+      <td>
+        {% if a.status == 'active' %}
+        <span class="badge bg-success">{{ _('active') }}</span>
+        {% else %}
+        <span class="badge bg-secondary">{{ a.status }}</span>
+        {% endif %}
+      </td>
+      <td>
+        {% for s in a.scopes_list() %}
+        <span class="badge text-bg-secondary">{{ s }}</span>
+        {% endfor %}
+      </td>
+      <td>{{ a.last_synced_at or '-' }}</td>
+      <td>
+        {% if a.oauth_token_json %}
+        <span class="badge bg-success">OK</span>
+        {% else %}
+        <span class="badge bg-danger">NG</span>
+        {% endif %}
+      </td>
+      <td>
+        <div class="btn-group btn-group-sm" role="group">
+          <a href="#" class="btn btn-outline-secondary">{{ _('Reauth') }}</a>
+          <a href="#" class="btn btn-outline-secondary">{{ _('Disable') }}</a>
+          <a href="#" class="btn btn-outline-secondary">{{ _('Delete') }}</a>
+          <a href="#" class="btn btn-outline-secondary">{{ _('Test') }}</a>
+        </div>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/migrations/versions/a1e8c8d084a9_create_google_account.py
+++ b/migrations/versions/a1e8c8d084a9_create_google_account.py
@@ -1,0 +1,35 @@
+"""create google_account table
+
+Revision ID: a1e8c8d084a9
+Revises: 6d1ad4f0b9a0
+Create Date: 2025-08-13 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a1e8c8d084a9'
+down_revision = '6d1ad4f0b9a0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'google_account',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('email', sa.String(length=255), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('scopes', sa.Text(), nullable=False),
+        sa.Column('last_synced_at', sa.DateTime(), nullable=True),
+        sa.Column('oauth_token_json', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('ix_google_account_email', 'google_account', ['email'], unique=True)
+
+
+def downgrade():
+    op.drop_index('ix_google_account_email', table_name='google_account')
+    op.drop_table('google_account')


### PR DESCRIPTION
## Summary
- add GoogleAccount model and migration
- implement Google account settings UI under `/photo-view/settings/google-accounts`
- register new blueprint

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af172cfbc8323a18d70c32a220e10