### PR TITLE
Add role and permission management screens

### DIFF
--- a/app/admin/templates/admin/permission_edit.html
+++ b/app/admin/templates/admin/permission_edit.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}{{ permission and _('Edit Permission') or _('Add Permission') }}{% endblock %}
+{% block content %}
+<h2>{{ permission and _('Edit Permission') or _('Add Permission') }}</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">{{ _('Code') }}</label>
+    <input type="text" class="form-control" name="code" value="{{ permission.code if permission else '' }}">
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
+  <a href="{{ url_for('admin.permissions') }}" class="btn btn-secondary">{{ _('Cancel') }}</a>
+</form>
+{% endblock %}
+

--- a/app/admin/templates/admin/permissions.html
+++ b/app/admin/templates/admin/permissions.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Permission Management') }}{% endblock %}
+{% block content %}
+<h2>{{ _('Permission Management') }}</h2>
+<div class="mb-3">
+  <a href="{{ url_for('admin.permission_add') }}" class="btn btn-success">{{ _('Add Permission') }}</a>
+  <a href="{{ url_for('admin.roles') }}" class="btn btn-secondary ms-2">{{ _('Role Management') }}</a>
+  <a href="{{ url_for('admin.users') }}" class="btn btn-secondary ms-2">{{ _('User Management') }}</a>
+  <a href="{{ url_for('admin.show_config') }}" class="btn btn-info ms-2">{{ _('Show Config Settings') }}</a>
+  
+</div>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>{{ _('Code') }}</th>
+      <th>{{ _('Actions') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for perm in permissions %}
+    <tr>
+      <td>{{ perm.id }}</td>
+      <td>{{ perm.code }}</td>
+      <td>
+        <a href="{{ url_for('admin.permission_edit', perm_id=perm.id) }}" class="btn btn-primary btn-sm">{{ _('Edit') }}</a>
+        <form method="post" action="{{ url_for('admin.permission_delete', perm_id=perm.id) }}" class="d-inline" onsubmit="return confirm('{{ _('Are you sure you want to delete this permission?') }}');">
+          <button type="submit" class="btn btn-danger btn-sm">{{ _('Delete') }}</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+

--- a/app/admin/templates/admin/role_edit.html
+++ b/app/admin/templates/admin/role_edit.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}{{ role and _('Edit Role') or _('Add Role') }}{% endblock %}
+{% block content %}
+<h2>{{ role and _('Edit Role') or _('Add Role') }}</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">{{ _('Name') }}</label>
+    <input type="text" class="form-control" name="name" value="{{ role.name if role else '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">{{ _('Permissions') }}</label>
+    {% for perm in permissions %}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" name="permissions" value="{{ perm.id }}" id="perm{{ perm.id }}" {% if perm.id in selected %}checked{% endif %}>
+      <label class="form-check-label" for="perm{{ perm.id }}">{{ perm.code }}</label>
+    </div>
+    {% endfor %}
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
+  <a href="{{ url_for('admin.roles') }}" class="btn btn-secondary">{{ _('Cancel') }}</a>
+</form>
+{% endblock %}
+

--- a/app/admin/templates/admin/roles.html
+++ b/app/admin/templates/admin/roles.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Role Management') }}{% endblock %}
+{% block content %}
+<h2>{{ _('Role Management') }}</h2>
+<div class="mb-3">
+  <a href="{{ url_for('admin.role_add') }}" class="btn btn-success">{{ _('Add Role') }}</a>
+  <a href="{{ url_for('admin.permissions') }}" class="btn btn-secondary ms-2">{{ _('Permission Management') }}</a>
+  <a href="{{ url_for('admin.users') }}" class="btn btn-secondary ms-2">{{ _('User Management') }}</a>
+  <a href="{{ url_for('admin.show_config') }}" class="btn btn-info ms-2">{{ _('Show Config Settings') }}</a>
+</div>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>{{ _('Name') }}</th>
+      <th>{{ _('Permissions') }}</th>
+      <th>{{ _('Actions') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for role in roles %}
+    <tr>
+      <td>{{ role.id }}</td>
+      <td>{{ role.name }}</td>
+      <td>
+        {% for perm in role.permissions %}
+          <span class="badge bg-secondary">{{ perm.code }}</span>
+        {% endfor %}
+      </td>
+      <td>
+        <a href="{{ url_for('admin.role_edit', role_id=role.id) }}" class="btn btn-primary btn-sm">{{ _('Edit') }}</a>
+        <form method="post" action="{{ url_for('admin.role_delete', role_id=role.id) }}" class="d-inline" onsubmit="return confirm('{{ _('Are you sure you want to delete this role?') }}');">
+          <button type="submit" class="btn btn-danger btn-sm">{{ _('Delete') }}</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -41,6 +41,16 @@
             <a class="nav-link" href="{{ url_for('admin.users') }}">{{ _('User Management') }}</a>
           </li>
           {% endif %}
+          {% if current_user.can('role:manage') %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('admin.roles') }}">{{ _('Role Management') }}</a>
+          </li>
+          {% endif %}
+          {% if current_user.can('permission:manage') %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('admin.permissions') }}">{{ _('Permission Management') }}</a>
+          </li>
+          {% endif %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.logout') }}">{{ _('Logout') }}</a>
           </li>


### PR DESCRIPTION
## Summary
- add CRUD routes for permissions and roles
- include admin templates for managing permissions and roles
- expose navigation links for new management screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689be2f6785083238fb07b8cd5a67446