### PR TITLE
feat: add search and sorting to permission management

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -125,8 +125,26 @@ def permissions():
     if not current_user.can('permission:manage'):
         flash(_("You do not have permission to access this page."), "error")
         return redirect(url_for("index"))
-    perms = Permission.query.all()
-    return render_template("admin/permissions.html", permissions=perms)
+    search = request.args.get("search", "").strip()
+    sort = request.args.get("sort", "id")
+    order = request.args.get("order", "asc")
+
+    query = Permission.query
+    if search:
+        query = query.filter(Permission.code.contains(search))
+
+    if sort not in ["id", "code"]:
+        sort = "id"
+    sort_column = getattr(Permission, sort)
+    if order == "desc":
+        sort_column = sort_column.desc()
+    else:
+        sort_column = sort_column.asc()
+
+    perms = query.order_by(sort_column).all()
+    return render_template(
+        "admin/permissions.html", permissions=perms, search=search, sort=sort, order=order
+    )
 
 
 @bp.route("/permissions/add", methods=["GET", "POST"])

--- a/app/admin/templates/admin/permissions.html
+++ b/app/admin/templates/admin/permissions.html
@@ -7,13 +7,19 @@
   <a href="{{ url_for('admin.roles') }}" class="btn btn-secondary ms-2">{{ _('Role Management') }}</a>
   <a href="{{ url_for('admin.users') }}" class="btn btn-secondary ms-2">{{ _('User Management') }}</a>
   <a href="{{ url_for('admin.show_config') }}" class="btn btn-info ms-2">{{ _('Show Config Settings') }}</a>
-  
+
 </div>
+<form method="get" class="d-flex mb-3">
+  <input type="text" name="search" class="form-control me-2" placeholder="{{ _('Search by code') }}" value="{{ search }}">
+  <input type="hidden" name="sort" value="{{ sort }}">
+  <input type="hidden" name="order" value="{{ order }}">
+  <button type="submit" class="btn btn-outline-primary">{{ _('Search') }}</button>
+</form>
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>{{ _('Code') }}</th>
+      <th><a href="{{ url_for('admin.permissions', search=search, sort='id', order='asc' if sort!='id' or order=='desc' else 'desc') }}">ID</a></th>
+      <th><a href="{{ url_for('admin.permissions', search=search, sort='code', order='asc' if sort!='code' or order=='desc' else 'desc') }}">{{ _('Code') }}</a></th>
       <th>{{ _('Actions') }}</th>
     </tr>
   </thead>


### PR DESCRIPTION
## Summary
- support filtering and ordering in permissions listing
- add search form and sortable table headers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be6e6b97c832396e3ad91c2f3fe0a