### PR TITLE
Disable multiple form submissions

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,16 @@
+// Disable submit buttons to prevent multiple submissions and show spinner
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('form').forEach(form => {
+    form.addEventListener('submit', () => {
+      const btn = form.querySelector('button[type="submit"]');
+      if (btn && !btn.disabled) {
+        btn.disabled = true;
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner-border spinner-border-sm ms-2';
+        spinner.setAttribute('role', 'status');
+        spinner.setAttribute('aria-hidden', 'true');
+        btn.appendChild(spinner);
+      }
+    });
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -86,6 +86,7 @@
 <footer class="text-center mt-5 mb-3">
   <p class="text-muted">&copy; 2025 FlaskApp</p>
 </footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a client-side script that disables submit buttons and displays a spinner to block repeated form submissions
- load the new script on every page via the base template

## Testing
- `git ls-files -z '*.py' | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_689c0523f564832399702ebb519d016b