### PR TITLE
Disable multiple form submissions

### DIFF
--- a/app/auth/templates/auth/google_accounts.html
+++ b/app/auth/templates/auth/google_accounts.html
@@ -90,20 +90,22 @@ document.addEventListener('DOMContentLoaded', () => {
   if (addBtn) {
     addBtn.addEventListener('click', async (e) => {
       e.preventDefault();
-      try {
-        const resp = await fetch('{{ url_for("api.google_oauth_start") }}', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ scopes: [], redirect: '{{ url_for("auth.google_accounts") }}' })
-        });
-        const data = await resp.json();
-        if (data.auth_url) {
-          window.location.href = data.auth_url;
+      await withLoading(e.currentTarget, async () => {
+        try {
+          const resp = await fetch('{{ url_for("api.google_oauth_start") }}', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ scopes: [], redirect: '{{ url_for("auth.google_accounts") }}' })
+          });
+          const data = await resp.json();
+          if (data.auth_url) {
+            window.location.href = data.auth_url;
+          }
+        } catch (err) {
+          console.error(err);
+          alert('Failed to start OAuth.');
         }
-      } catch (err) {
-        console.error(err);
-        alert('Failed to start OAuth.');
-      }
+      });
     });
   }
 
@@ -111,23 +113,25 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.btn-reauth').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.preventDefault();
-      const group = e.target.closest('[data-id]');
-      const scopes = (group?.dataset.scopes || '')
-        .split(',').map(s => s.trim()).filter(Boolean);
-      try {
-        const resp = await fetch('{{ url_for("api.google_oauth_start") }}', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ scopes, redirect: '{{ url_for("auth.google_accounts") }}' })
-        });
-        const data = await resp.json();
-        if (data.auth_url) {
-          window.location.href = data.auth_url;
+      await withLoading(e.currentTarget, async () => {
+        const group = e.target.closest('[data-id]');
+        const scopes = (group?.dataset.scopes || '')
+          .split(',').map(s => s.trim()).filter(Boolean);
+        try {
+          const resp = await fetch('{{ url_for("api.google_oauth_start") }}', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ scopes, redirect: '{{ url_for("auth.google_accounts") }}' })
+          });
+          const data = await resp.json();
+          if (data.auth_url) {
+            window.location.href = data.auth_url;
+          }
+        } catch (err) {
+          console.error(err);
+          alert('Failed to start re-auth.');
         }
-      } catch (err) {
-        console.error(err);
-        alert('Failed to start re-auth.');
-      }
+      });
     });
   });
 
@@ -135,14 +139,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.btn-disable').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.preventDefault();
-      const id = e.target.closest('[data-id]')?.dataset.id;
-      if (!id) return;
-      const resp = await fetch(`/api/google/accounts/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'disabled' })
+      await withLoading(e.currentTarget, async () => {
+        const id = e.target.closest('[data-id]')?.dataset.id;
+        if (!id) return;
+        const resp = await fetch(`/api/google/accounts/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'disabled' })
+        });
+        if (resp.ok) location.reload();
       });
-      if (resp.ok) location.reload();
     });
   });
 
@@ -150,11 +156,13 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.btn-delete').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.preventDefault();
-      const id = e.target.closest('[data-id]')?.dataset.id;
-      if (!id) return;
-      if (!confirm('Delete this account?')) return;
-      const resp = await fetch(`/api/google/accounts/${id}`, { method: 'DELETE' });
-      if (resp.ok) location.reload();
+      await withLoading(e.currentTarget, async () => {
+        const id = e.target.closest('[data-id]')?.dataset.id;
+        if (!id) return;
+        if (!confirm('Delete this account?')) return;
+        const resp = await fetch(`/api/google/accounts/${id}`, { method: 'DELETE' });
+        if (resp.ok) location.reload();
+      });
     });
   });
 
@@ -162,29 +170,18 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.btn-test').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.preventDefault();
-      const target = e.currentTarget;
-      if (target.dataset.loading) return;
-      const id = target.closest('[data-id]')?.dataset.id;
-      if (!id) return;
-      target.dataset.loading = 'true';
-      target.classList.add('disabled');
-      const spinner = document.createElement('span');
-      spinner.className = 'spinner-border spinner-border-sm ms-1';
-      spinner.setAttribute('role', 'status');
-      spinner.setAttribute('aria-hidden', 'true');
-      target.appendChild(spinner);
-      try {
-        const resp = await fetch(`/api/google/accounts/${id}/test`, { method: 'POST' });
-        const data = await resp.json();
-        alert(data.result || data.error || 'OK');
-      } catch (err) {
-        console.error(err);
-        alert('Test failed');
-      } finally {
-        spinner.remove();
-        target.classList.remove('disabled');
-        delete target.dataset.loading;
-      }
+      await withLoading(e.currentTarget, async () => {
+        const id = e.currentTarget.closest('[data-id]')?.dataset.id;
+        if (!id) return;
+        try {
+          const resp = await fetch(`/api/google/accounts/${id}/test`, { method: 'POST' });
+          const data = await resp.json();
+          alert(data.result || data.error || 'OK');
+        } catch (err) {
+          console.error(err);
+          alert('Test failed');
+        }
+      });
     });
   });
 });

--- a/app/auth/templates/auth/google_accounts.html
+++ b/app/auth/templates/auth/google_accounts.html
@@ -162,11 +162,29 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.btn-test').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.preventDefault();
-      const id = e.target.closest('[data-id]')?.dataset.id;
+      const target = e.currentTarget;
+      if (target.dataset.loading) return;
+      const id = target.closest('[data-id]')?.dataset.id;
       if (!id) return;
-      const resp = await fetch(`/api/google/accounts/${id}/test`, { method: 'POST' });
-      const data = await resp.json();
-      alert(data.result || data.error || 'OK');
+      target.dataset.loading = 'true';
+      target.classList.add('disabled');
+      const spinner = document.createElement('span');
+      spinner.className = 'spinner-border spinner-border-sm ms-1';
+      spinner.setAttribute('role', 'status');
+      spinner.setAttribute('aria-hidden', 'true');
+      target.appendChild(spinner);
+      try {
+        const resp = await fetch(`/api/google/accounts/${id}/test`, { method: 'POST' });
+        const data = await resp.json();
+        alert(data.result || data.error || 'OK');
+      } catch (err) {
+        console.error(err);
+        alert('Test failed');
+      } finally {
+        spinner.remove();
+        target.classList.remove('disabled');
+        delete target.dataset.loading;
+      }
     });
   });
 });

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,3 +1,22 @@
+// Helper to block repeated clicks and show a spinner on the target button
+window.withLoading = async (target, callback) => {
+  if (target.dataset.loading) return;
+  target.dataset.loading = 'true';
+  target.classList.add('disabled');
+  const spinner = document.createElement('span');
+  spinner.className = 'spinner-border spinner-border-sm ms-1';
+  spinner.setAttribute('role', 'status');
+  spinner.setAttribute('aria-hidden', 'true');
+  target.appendChild(spinner);
+  try {
+    await callback();
+  } finally {
+    spinner.remove();
+    target.classList.remove('disabled');
+    delete target.dataset.loading;
+  }
+};
+
 // Disable submit buttons to prevent multiple submissions and show spinner
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('form').forEach(form => {

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,16 @@
+// Disable submit buttons to prevent multiple submissions and show spinner
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('form').forEach(form => {
+    form.addEventListener('submit', () => {
+      const btn = form.querySelector('button[type="submit"]');
+      if (btn && !btn.disabled) {
+        btn.disabled = true;
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner-border spinner-border-sm ms-2';
+        spinner.setAttribute('role', 'status');
+        spinner.setAttribute('aria-hidden', 'true');
+        btn.appendChild(spinner);
+      }
+    });
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -86,6 +86,7 @@
 <footer class="text-center mt-5 mb-3">
   <p class="text-muted">&copy; 2025 FlaskApp</p>
 </footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a client-side script that disables submit buttons and displays a spinner to block repeated form submissions
- load the new script on every page via the base template
- prevent repeated clicks on the Google account Test action by disabling the button and showing a spinner during the request

## Testing
- `git ls-files -z '*.py' | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_689c0523f564832399702ebb519d016b