### PR TITLE
Encrypt Google OAuth tokens with AES-256-GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ pybabel compile -d app/translations -f
 
 
 
+## Google OAuth Token Encryption
+
+`google_account.oauth_token_json` は AES-256-GCM で暗号化して保存します。
+`OAUTH_TOKEN_KEY`（Base64）または `OAUTH_TOKEN_KEY_FILE` で 32 バイト鍵を指定してください。
+鍵は OS の KMS もしくは鍵ファイルで管理できます。
+
 ## Flask-Migrate マイグレーション手順
 
 ### 1. モデル変更後にマイグレーションファイルを作成

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -8,6 +8,7 @@ from . import bp
 from ..extensions import db
 from ..models.user import User
 from ..models.google_account import GoogleAccount
+from ..crypto import encrypt
 from .totp import new_totp_secret, verify_totp, provisioning_uri, qr_code_data_uri
 
 @bp.route("/login", methods=["GET", "POST"])
@@ -223,7 +224,7 @@ def google_oauth_callback():
     else:
         account.scopes = ",".join(scopes)
         account.status = "active"
-    account.oauth_token_json = json.dumps(tokens)
+    account.oauth_token_json = encrypt(json.dumps(tokens))
     account.last_synced_at = datetime.utcnow()
     db.session.commit()
 

--- a/app/config.py
+++ b/app/config.py
@@ -28,4 +28,7 @@ class Config:
     # Google OAuth
     GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
     GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
-    print("GOOGLE_CLIENT_SECRET:", os.environ.get("GOOGLE_CLIENT_SECRET"))
+
+    # Encryption for OAuth tokens
+    OAUTH_TOKEN_KEY = os.environ.get("OAUTH_TOKEN_KEY")
+    OAUTH_TOKEN_KEY_FILE = os.environ.get("OAUTH_TOKEN_KEY_FILE")

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -1,0 +1,51 @@
+import base64
+import os
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+_KEY_ENV = "OAUTH_TOKEN_KEY"
+_KEY_FILE_ENV = "OAUTH_TOKEN_KEY_FILE"
+
+
+def _load_key() -> bytes:
+    """Load 32-byte encryption key from env var or file."""
+    key_b64 = os.environ.get(_KEY_ENV)
+    if key_b64:
+        key = base64.urlsafe_b64decode(key_b64)
+    else:
+        path = os.environ.get(_KEY_FILE_ENV)
+        if not path:
+            raise RuntimeError("Encryption key not configured")
+        with open(path, "rb") as f:
+            key = base64.urlsafe_b64decode(f.read().strip())
+    if len(key) != 32:
+        raise ValueError("AES-256-GCM key must be 32 bytes")
+    return key
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt text using AES-256-GCM.
+
+    Returns base64 encoded nonce + ciphertext.
+    """
+    if plaintext is None:
+        return ""
+    key = _load_key()
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(12)
+    ct = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+    return base64.urlsafe_b64encode(nonce + ct).decode("utf-8")
+
+
+def decrypt(token: Optional[str]) -> str:
+    """Decrypt base64 encoded nonce + ciphertext."""
+    if not token:
+        return ""
+    key = _load_key()
+    raw = base64.urlsafe_b64decode(token.encode("utf-8"))
+    nonce, ct = raw[:12], raw[12:]
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(nonce, ct, None).decode("utf-8")
+

--- a/app/models/google_account.py
+++ b/app/models/google_account.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 import json
 
 from ..extensions import db
+from ..crypto import decrypt
 
 
 class GoogleAccount(db.Model):
@@ -27,7 +28,7 @@ class GoogleAccount(db.Model):
         if not self.oauth_token_json:
             return None
         try:
-            data = json.loads(self.oauth_token_json)
+            data = json.loads(decrypt(self.oauth_token_json))
         except Exception:
             return None
 

--- a/requirements.md
+++ b/requirements.md
@@ -716,7 +716,7 @@ sequenceDiagram
   GA->>API: GET /auth/google/callback?code=...
   API->>GA: /tokenでコード交換（access+refresh）
   GA-->>API: tokens返却
-  API->>API: refresh_token を暗号化保存（google_account）
+  API->>API: refresh_token を AES-256-GCM で暗号化保存（google_account）
   API-->>UI: 連携成功（メール/スコープ/状態）
   UI-->>U: 一覧に追加 & トークンOK表示
 ```
@@ -738,7 +738,7 @@ sequenceDiagram
 
 #### 19.6 DB/セキュリティ
 
-* `google_account.oauth_token_json` は**アプリ側で暗号化**（OS KMS or ファイル鍵）
+* `google_account.oauth_token_json` は**AES-256-GCM で暗号化**（OS KMS or ファイル鍵）
 * `state` パラメータ検証、`redirect_uri` 厳密一致、`PKCE` 併用可（追加防御）。
 * トークンは**最小権限**（scopes最小化）。
 * 監査ログ：連携追加／再認証／削除／失敗。

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv
 qrcode
 Pillow
 requests
+cryptography


### PR DESCRIPTION
## Summary
- Add AES-256-GCM helper for encrypting/decrypting Google OAuth tokens
- Store `google_account.oauth_token_json` encrypted and load it via key file or KMS-provided key
- Document encryption setup and add `cryptography` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c0a438ef8832391f5be40e772cb32