### PR TITLE
Add CLI configuration loader and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# Flask application
+SECRET_KEY=replace-with-secret
+DATABASE_URI=mysql+pymysql://user:pass@dbhost/dbname
+# FEATURE_X_DB_URI=
+BABEL_DEFAULT_LOCALE=ja
+BABEL_DEFAULT_TIMEZONE=Asia/Tokyo
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+# OAUTH token encryption key for web (base64 urlsafe 32 bytes)
+OAUTH_TOKEN_KEY=base64-encoded-32bytes
+# Or specify path to key file
+# OAUTH_TOKEN_KEY_FILE=/path/to/keyfile
+
+# ---------------------------------------------------------------------------
+# PhotoNest CLI (fpv)
+# Values below typically mirror the Flask configuration above
+#
+FPV_DB_URL=${DATABASE_URI}
+
+# NAS paths (absolute)
+FPV_NAS_ORIG_DIR=/mnt/nas/photos/originals
+FPV_NAS_PLAY_DIR=/mnt/nas/photos/playback
+FPV_NAS_THUMBS_DIR=/mnt/nas/photos/thumbs
+FPV_TMP_DIR=/mnt/nas/photos/tmp
+
+# Transcode
+FPV_TRANSCODE_WORKERS=2
+FPV_TRANSCODE_CRF=20
+
+# Retry policy
+FPV_MAX_RETRIES=3
+
+# Google OAuth (server-side)
+FPV_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+FPV_GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+
+# Token encryption key
+# Recommended: specify base64-encoded 32byte AES-256 key with prefix
+FPV_OAUTH_KEY=base64:${OAUTH_TOKEN_KEY}
+
+# Optional strict check for path existence (default: false)
+FPV_STRICT_PATH_CHECK=false
+

--- a/README.md
+++ b/README.md
@@ -63,3 +63,22 @@ flask db downgrade base
 モデルを修正 → **1** に戻って再実行。
 
 
+## Configuration
+
+環境変数で設定します。`.env.example` をコピーして `.env` を作成してください（python-dotenv は使わず、標準の環境変数で読み込みます）。
+
+```bash
+cp .env.example .env
+# 値を編集
+```
+
+表示と検証:
+
+```bash
+fpv config show          # マスク付きで表示
+fpv config check         # 形式検証（既定）
+fpv config check --strict-path   # パス存在チェックも実施
+```
+
+`FPV_OAUTH_KEY` は `base64:<32bytes>` を推奨（AES-256鍵）。あるいは暫定で32文字以上の文字列でも可。
+

--- a/cli/src/fpv/cli.py
+++ b/cli/src/fpv/cli.py
@@ -1,7 +1,11 @@
 from typing import Optional
 import typer
 from rich.console import Console
+from rich.table import Table
+
 from .version import __version__
+from .config import PhotoNestConfig
+
 
 console = Console()
 app = typer.Typer(
@@ -11,69 +15,158 @@ app = typer.Typer(
     add_completion=False,
 )
 
+# ---------------------------------------------------------------------------
+# sub-app: config
+config_app = typer.Typer(name="config", help="設定の表示と検証")
+app.add_typer(config_app, name="config")
+
+
 @app.callback()
 def main(
     version: Optional[bool] = typer.Option(
-        None, "--version", callback=lambda v: (_print_version() if v else None),
-        is_eager=True, help="Show version and exit."
+        None,
+        "--version",
+        callback=lambda v: (_print_version() if v else None),
+        is_eager=True,
+        help="Show version and exit.",
     )
 ):
-    """
-    PhotoNest CLI entrypoint.
-    """
     return
 
-def _print_version():
+
+def _print_version() -> None:
     console.print(f"[bold]fpv[/] version {__version__}")
     raise typer.Exit(code=0)
 
-# ----- sync ---------------------------------------------------------------
+
+@config_app.command("show", help="環境変数から読み込んだ設定を表示（秘匿情報はマスク）")
+def config_show() -> None:
+    cfg = PhotoNestConfig.from_env()
+    masked = cfg.masked()
+    table = Table(title="PhotoNest Config (masked)")
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+
+    for k, v in masked.items():
+        table.add_row(k, str(v))
+    console.print(table)
+
+
+@config_app.command("check", help="設定を検証してエラー/警告を表示")
+def config_check(
+    strict_path: bool = typer.Option(
+        False, "--strict-path", help="パス存在チェックを有効化"
+    )
+) -> None:
+    base = PhotoNestConfig.from_env()
+    cfg = PhotoNestConfig(
+        **{**base.__dict__, "strict_path_check": strict_path or base.strict_path_check}
+    )
+    warns, errs = cfg.validate()
+    if warns:
+        console.print("[yellow]WARN[/] " + " | ".join(warns))
+    if errs:
+        console.print("[red]ERROR[/] " + " | ".join(errs))
+        raise typer.Exit(code=1)
+    console.print("[green]OK[/] 設定は有効です")
+
+
+# ---------------------------------------------------------------------------
+# existing commands
+
+
 @app.command(help="Google Photos 差分取得（複数アカウント対応）")
 def sync(
     all_accounts: bool = typer.Option(
-        True, "--all-accounts/--single-account",
-        help="すべてのactiveアカウントを処理（既定: True）"),
+        True,
+        "--all-accounts/--single-account",
+        help="すべてのactiveアカウントを処理（既定: True）",
+    ),
     account_id: Optional[int] = typer.Option(
-        None, "--account-id", help="単一アカウントIDを指定する場合に利用"),
-):
+        None, "--account-id", help="単一アカウントIDを指定する場合に利用"
+    ),
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
     console.print("[cyan]TODO[/]: sync（差分取得）の実装")
 
-# ----- import -------------------------------------------------------------
+
 @app.command("import", help="既存ローカル取り込み（固定ディレクトリ）")
 def import_(
-    path: str = typer.Option("/mnt/nas/import", "--path", help="取り込み対象ディレクトリ"),
-):
+    path: str = typer.Option(
+        "/mnt/nas/import", "--path", help="取り込み対象ディレクトリ"
+    ),
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
     console.print(f"[cyan]TODO[/]: import from {path}")
 
-# ----- transcode ----------------------------------------------------------
+
 @app.command(help="未変換動画のスキャン→変換キュー投入＆処理")
 def transcode(
-    scan_pending: bool = typer.Option(True, "--scan-pending/--no-scan-pending",
-                                      help="未変換スキャンを実施（既定: True）"),
+    scan_pending: bool = typer.Option(
+        True,
+        "--scan-pending/--no-scan-pending",
+        help="未変換スキャンを実施（既定: True）",
+    ),
     max_workers: int = typer.Option(2, "--max-workers", min=1, help="並列数（既定: 2）"),
-):
-    console.print(f"[cyan]TODO[/]: transcode (scan={scan_pending}, workers={max_workers})")
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
+    console.print(
+        f"[cyan]TODO[/]: transcode (scan={scan_pending}, workers={max_workers})"
+    )
 
-# ----- thumbs -------------------------------------------------------------
+
 @app.command(help="サムネ未生成の検出→生成キュー投入")
 def thumbs(
-    scan_pending: bool = typer.Option(True, "--scan-pending/--no-scan-pending",
-                                      help="未生成スキャン（既定: True）"),
-):
+    scan_pending: bool = typer.Option(
+        True,
+        "--scan-pending/--no-scan-pending",
+        help="未生成スキャン（既定: True）",
+    ),
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
     console.print(f"[cyan]TODO[/]: thumbs (scan={scan_pending})")
 
-# ----- retry --------------------------------------------------------------
+
 @app.command(help="失敗ジョブの再試行")
 def retry(
     older_than: str = typer.Option("1h", "--older-than", help="対象期間（例: 1h, 24h）"),
     max_retries: int = typer.Option(3, "--max-retries", min=1, help="最大再試行回数（既定: 3）"),
-):
-    console.print(f"[cyan]TODO[/]: retry (older_than={older_than}, max_retries={max_retries})")
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
+    console.print(
+        f"[cyan]TODO[/]: retry (older_than={older_than}, max_retries={max_retries})"
+    )
 
-# ----- clean --------------------------------------------------------------
+
 @app.command(help="一時領域のクリーンアップ")
 def clean(
     tmp: bool = typer.Option(True, "--tmp/--no-tmp", help="一時領域を掃除（既定: True）"),
     days: int = typer.Option(7, "--days", min=1, help="保持日数（既定: 7）"),
-):
+) -> None:
+    cfg = PhotoNestConfig.from_env()
+    _, errs = cfg.validate()
+    if errs:
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
+        raise typer.Exit(1)
     console.print(f"[cyan]TODO[/]: clean (tmp={tmp}, days={days})")
+

--- a/cli/src/fpv/config.py
+++ b/cli/src/fpv/config.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple, Any
+
+from core.crypto import validate_oauth_key as _validate_oauth_key
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _mask(val: str, keep: int = 4) -> str:
+    if val is None:
+        return ""
+    if len(val) <= keep * 2:
+        return "*" * len(val)
+    return f"{val[:keep]}***{val[-keep:]}"
+
+
+def _read_bool(env: Dict[str, str], key: str, default: bool = False) -> bool:
+    raw = env.get(key)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _read_int(
+    env: Dict[str, str], key: str, default: int, min_v: int, max_v: int
+) -> Tuple[int, List[str]]:
+    msgs: List[str] = []
+    raw = env.get(key)
+    if raw is None or raw.strip() == "":
+        return default, msgs
+    try:
+        v = int(raw)
+        if v < min_v or v > max_v:
+            msgs.append(
+                f"{key}: 範囲外({v}), 許容 {min_v}..{max_v} -> 既定 {default} を使用"
+            )
+            return default, msgs
+        return v, msgs
+    except ValueError:
+        msgs.append(f"{key}: 数値として解釈できません -> 既定 {default} を使用")
+        return default, msgs
+
+
+def _is_abs(p: str) -> bool:
+    try:
+        return Path(p).is_absolute()
+    except Exception:
+        return False
+
+
+@dataclass(frozen=True)
+class PhotoNestConfig:
+    db_url: str
+    nas_orig_dir: str
+    nas_play_dir: str
+    nas_thumbs_dir: str
+    tmp_dir: str
+    transcode_workers: int
+    transcode_crf: int
+    max_retries: int
+    google_client_id: str
+    google_client_secret: str
+    oauth_key: str
+    strict_path_check: bool
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def from_env(env: Dict[str, str] | None = None) -> "PhotoNestConfig":
+        env = env or os.environ
+
+        db_url = env.get("FPV_DB_URL") or env.get("DATABASE_URI", "")
+        db_url = db_url.strip()
+        nas_orig = env.get("FPV_NAS_ORIG_DIR", "").strip()
+        nas_play = env.get("FPV_NAS_PLAY_DIR", "").strip()
+        nas_thumbs = env.get("FPV_NAS_THUMBS_DIR", "").strip()
+        tmp_dir = env.get("FPV_TMP_DIR", "").strip()
+        g_id = env.get("FPV_GOOGLE_CLIENT_ID") or env.get("GOOGLE_CLIENT_ID", "")
+        g_id = g_id.strip()
+        g_secret = env.get("FPV_GOOGLE_CLIENT_SECRET") or env.get(
+            "GOOGLE_CLIENT_SECRET", ""
+        )
+        g_secret = g_secret.strip()
+
+        if env.get("FPV_OAUTH_KEY"):
+            oauth_key = env.get("FPV_OAUTH_KEY", "").strip()
+        elif env.get("OAUTH_TOKEN_KEY"):
+            oauth_key = f"base64:{env.get('OAUTH_TOKEN_KEY').strip()}"
+        elif env.get("OAUTH_TOKEN_KEY_FILE"):
+            try:
+                with open(env.get("OAUTH_TOKEN_KEY_FILE"), "r") as f:
+                    oauth_key = f"base64:{f.read().strip()}"
+            except OSError:
+                oauth_key = ""
+        else:
+            oauth_key = ""
+
+        workers, _ = _read_int(env, "FPV_TRANSCODE_WORKERS", 2, 1, 8)
+        crf, _ = _read_int(env, "FPV_TRANSCODE_CRF", 20, 10, 28)
+        retries, _ = _read_int(env, "FPV_MAX_RETRIES", 3, 1, 10)
+
+        strict = _read_bool(env, "FPV_STRICT_PATH_CHECK", False)
+
+        return PhotoNestConfig(
+            db_url=db_url,
+            nas_orig_dir=nas_orig,
+            nas_play_dir=nas_play,
+            nas_thumbs_dir=nas_thumbs,
+            tmp_dir=tmp_dir,
+            transcode_workers=workers,
+            transcode_crf=crf,
+            max_retries=retries,
+            google_client_id=g_id,
+            google_client_secret=g_secret,
+            oauth_key=oauth_key,
+            strict_path_check=strict,
+        )
+
+    # ------------------------------------------------------------------
+    def validate(self) -> Tuple[List[str], List[str]]:
+        """Returns ``(warnings, errors)``"""
+        warns: List[str] = []
+        errs: List[str] = []
+
+        required = {
+            "FPV_DB_URL": self.db_url,
+            "FPV_NAS_ORIG_DIR": self.nas_orig_dir,
+            "FPV_NAS_PLAY_DIR": self.nas_play_dir,
+            "FPV_NAS_THUMBS_DIR": self.nas_thumbs_dir,
+            "FPV_TMP_DIR": self.tmp_dir,
+            "FPV_GOOGLE_CLIENT_ID": self.google_client_id,
+            "FPV_GOOGLE_CLIENT_SECRET": self.google_client_secret,
+            "FPV_OAUTH_KEY": self.oauth_key,
+        }
+
+        for k, v in required.items():
+            if not v:
+                errs.append(f"{k}: 未設定です")
+
+        if self.db_url and not self.db_url.startswith("mysql+pymysql://"):
+            warns.append("FPV_DB_URL: 推奨スキームは mysql+pymysql:// です")
+
+        for key, path in [
+            ("FPV_NAS_ORIG_DIR", self.nas_orig_dir),
+            ("FPV_NAS_PLAY_DIR", self.nas_play_dir),
+            ("FPV_NAS_THUMBS_DIR", self.nas_thumbs_dir),
+            ("FPV_TMP_DIR", self.tmp_dir),
+        ]:
+            if path and not _is_abs(path):
+                errs.append(f"{key}: 絶対パスを指定してください（現在: {path}）")
+            if self.strict_path_check and path and not Path(path).exists():
+                errs.append(f"{key}: パスが存在しません（strict-path-check有効）: {path}")
+
+        ok, why = _validate_oauth_key(self.oauth_key)
+        if not ok:
+            errs.append(f"FPV_OAUTH_KEY: 不正 ({why})")
+
+        if not (1 <= self.transcode_workers <= 8):
+            errs.append("FPV_TRANSCODE_WORKERS: 1..8 の範囲外")
+        if not (10 <= self.transcode_crf <= 28):
+            errs.append("FPV_TRANSCODE_CRF: 10..28 の範囲外")
+        if not (1 <= self.max_retries <= 10):
+            errs.append("FPV_MAX_RETRIES: 1..10 の範囲外")
+
+        return warns, errs
+
+    # ------------------------------------------------------------------
+    def masked(self) -> Dict[str, Any]:
+        return {
+            "db_url": self.db_url,
+            "nas_orig_dir": self.nas_orig_dir,
+            "nas_play_dir": self.nas_play_dir,
+            "nas_thumbs_dir": self.nas_thumbs_dir,
+            "tmp_dir": self.tmp_dir,
+            "transcode_workers": self.transcode_workers,
+            "transcode_crf": self.transcode_crf,
+            "max_retries": self.max_retries,
+            "google_client_id": _mask(self.google_client_id),
+            "google_client_secret": _mask(self.google_client_secret),
+            "oauth_key": _mask(self.oauth_key),
+            "strict_path_check": self.strict_path_check,
+        }
+


### PR DESCRIPTION
## Summary
- add `.env.example` merged with existing Flask config
- implement shared OAuth key validator in `core.crypto`
- add PhotoNest CLI configuration loader and validation commands
- document configuration usage in README

## Testing
- `cd cli && python -m pip install -e .`
- `PYTHONPATH=.. /root/.pyenv/versions/3.11.12/bin/fpv --version`
- `PYTHONPATH=.. /root/.pyenv/versions/3.11.12/bin/fpv config show`
- `PYTHONPATH=.. /root/.pyenv/versions/3.11.12/bin/fpv config check`
- `PYTHONPATH=.. /root/.pyenv/versions/3.11.12/bin/fpv config check --strict-path`


------
https://chatgpt.com/codex/tasks/task_e_689c5e4b44048323bf8dfa501215db3d