### PR TITLE
Support FPV_OAUTH_TOKEN_KEY_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pybabel compile -d webapp/translations -f
 ## Google OAuth Token Encryption
 
 `google_account.oauth_token_json` は AES-256-GCM で暗号化して保存します。
-`OAUTH_TOKEN_KEY`（Base64）または `OAUTH_TOKEN_KEY_FILE` で 32 バイト鍵を指定してください。
+`OAUTH_TOKEN_KEY`（Base64）または `OAUTH_TOKEN_KEY_FILE` / `FPV_OAUTH_TOKEN_KEY_FILE` で 32 バイト鍵を指定してください。
 鍵は OS の KMS もしくは鍵ファイルで管理できます。
 
 ## Flask-Migrate マイグレーション手順
@@ -80,5 +80,5 @@ fpv config check               # basic validation
 fpv config check --strict-path # also verify path existence
 ```
 
-`FPV_OAUTH_KEY` references the existing `OAUTH_TOKEN_KEY` (set `FPV_OAUTH_KEY=${OAUTH_TOKEN_KEY}` in `.env`). `OAUTH_TOKEN_KEY` should specify a 32-byte key in the form `base64:xxxxxxxxxx`.
+`FPV_OAUTH_KEY` references the existing `OAUTH_TOKEN_KEY` (set `FPV_OAUTH_KEY=${OAUTH_TOKEN_KEY}` in `.env`). Alternatively, specify `FPV_OAUTH_TOKEN_KEY_FILE` to load the key from a file (e.g. `FPV_OAUTH_TOKEN_KEY_FILE=${OAUTH_TOKEN_KEY_FILE}`). `OAUTH_TOKEN_KEY` should specify a 32-byte key in the form `base64:xxxxxxxxxx`.
 

--- a/cli/src/fpv/config.py
+++ b/cli/src/fpv/config.py
@@ -95,6 +95,12 @@ class PhotoNestConfig:
 
         if env.get("FPV_OAUTH_KEY"):
             oauth_key = env.get("FPV_OAUTH_KEY", "").strip()
+        elif env.get("FPV_OAUTH_TOKEN_KEY_FILE"):
+            try:
+                with open(env.get("FPV_OAUTH_TOKEN_KEY_FILE"), "r") as f:
+                    oauth_key = f.read().strip()
+            except OSError:
+                oauth_key = ""
         elif env.get("OAUTH_TOKEN_KEY"):
             oauth_key = env.get("OAUTH_TOKEN_KEY", "").strip()
         elif env.get("OAUTH_TOKEN_KEY_FILE"):

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 _KEY_ENV = "OAUTH_TOKEN_KEY"
 _KEY_FILE_ENV = "OAUTH_TOKEN_KEY_FILE"
+_FPV_KEY_FILE_ENV = "FPV_OAUTH_TOKEN_KEY_FILE"
 
 
 def _decode_key(raw: str) -> bytes:
@@ -49,7 +50,7 @@ def _load_key(raw: Optional[str] = None) -> bytes:
     if key_str:
         return _decode_key(key_str)
 
-    path = os.environ.get(_KEY_FILE_ENV)
+    path = os.environ.get(_KEY_FILE_ENV) or os.environ.get(_FPV_KEY_FILE_ENV)
     if path:
         with open(path, "r") as f:
             return _decode_key(f.read().strip())

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -40,3 +40,20 @@ def test_config_check_missing_required(tmp_path):
     result = runner.invoke(app, ['config', 'check'], env=env)
     assert result.exit_code != 0
     assert 'FPV_DB_URL: not set' in result.stdout
+
+
+def test_config_fpv_oauth_token_key_file(tmp_path):
+    env = _base_env(tmp_path)
+    key_val = env['FPV_OAUTH_KEY']
+    key_file = tmp_path / 'keyfile'
+    key_file.write_text(key_val)
+    del env['FPV_OAUTH_KEY']
+    env['FPV_OAUTH_TOKEN_KEY_FILE'] = str(key_file)
+    cfg = PhotoNestConfig.from_env(env)
+    assert cfg.oauth_key == key_val
+    warns, errs = cfg.validate()
+    assert errs == []
+    runner = CliRunner()
+    result = runner.invoke(app, ['config', 'check'], env=env)
+    assert result.exit_code == 0
+    assert 'Configuration is valid' in result.stdout

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -23,3 +23,13 @@ def test_encrypt_none_returns_empty():
 def test_decrypt_empty_returns_empty():
     assert decrypt('') == ''
     assert decrypt(None) == ''
+
+
+def test_encrypt_decrypt_with_fpv_key_file(monkeypatch, tmp_path):
+    key = base64.urlsafe_b64encode(b'0' * 32).decode('utf-8')
+    key_file = tmp_path / 'keyfile'
+    key_file.write_text(key)
+    monkeypatch.delenv('OAUTH_TOKEN_KEY', raising=False)
+    monkeypatch.setenv('FPV_OAUTH_TOKEN_KEY_FILE', str(key_file))
+    token = encrypt('hello')
+    assert decrypt(token) == 'hello'

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -31,4 +31,6 @@ class Config:
 
     # Encryption for OAuth tokens
     OAUTH_TOKEN_KEY = os.environ.get("OAUTH_TOKEN_KEY")
-    OAUTH_TOKEN_KEY_FILE = os.environ.get("OAUTH_TOKEN_KEY_FILE")
+    OAUTH_TOKEN_KEY_FILE = os.environ.get("OAUTH_TOKEN_KEY_FILE") or os.environ.get(
+        "FPV_OAUTH_TOKEN_KEY_FILE"
+    )


### PR DESCRIPTION
## Summary
- allow loading OAuth token key from `FPV_OAUTH_TOKEN_KEY_FILE`
- document new `FPV_OAUTH_TOKEN_KEY_FILE` env var
- test FPV key file handling for CLI config and crypto helpers

## Testing
- `PYTHONPATH=cli/src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd80979888323b1666b6671a21e15