### PR TITLE
feat: add dry-run sync scaffolding

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -3,6 +3,26 @@
 最小のCLIスケルトン。`fpv --help` が表示でき、各サブコマンドのヘルプも出ます。
 
 ## Install (editable)
+
 ```bash
 cd cli
 python -m pip install -e .
+```
+
+## Sync (外形テスト: dry-run)
+
+まずはDDL適用と設定チェック:
+
+```bash
+fpv config check
+```
+
+dry-run 実行（ジョブ履歴が記録され、構造化ログが出ます）:
+
+```bash
+fpv sync --dry-run
+# 単一IDのみ:
+# fpv sync --single-account --account-id 1 --dry-run
+```
+
+`--no-dry-run` は次ステップ以降（実API実装）で有効になります。

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # PhotoNest CLI (`fpv`)
 
-最小のCLIスケルトン。`fpv --help` が表示でき、各サブコマンドのヘルプも出ます。
+Minimal CLI skeleton. `fpv --help` shows the help screen and subcommand usage.
 
 ## Install (editable)
 
@@ -9,20 +9,20 @@ cd cli
 python -m pip install -e .
 ```
 
-## Sync (外形テスト: dry-run)
+## Sync (dry-run outline)
 
-まずはDDL適用と設定チェック:
+First apply the DDL and check configuration:
 
 ```bash
 fpv config check
 ```
 
-dry-run 実行（ジョブ履歴が記録され、構造化ログが出ます）:
+Run dry-run (records job history and outputs structured logs):
 
 ```bash
 fpv sync --dry-run
-# 単一IDのみ:
+# Single account only:
 # fpv sync --single-account --account-id 1 --dry-run
 ```
 
-`--no-dry-run` は次ステップ以降（実API実装）で有効になります。
+`--no-dry-run` will be effective in later steps when the actual API implementation is added.

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -11,9 +11,11 @@ requires-python = ">=3.11"
 authors = [{ name = "PhotoNest Team" }]
 license = { text = "MIT" }
 dependencies = [
-  "typer>=0.12.0",
+  "typer[all]>=0.12.0",
   "rich>=13.7",
-  "python-dotenv>=1.0"
+  "SQLAlchemy>=2.0",
+  "PyMySQL>=1.1",
+  "httpx>=0.27"
 ]
 
 [project.scripts]

--- a/cli/src/fpv/cli.py
+++ b/cli/src/fpv/cli.py
@@ -5,6 +5,7 @@ from rich.table import Table
 
 from .version import __version__
 from .config import PhotoNestConfig
+from .sync import run_sync
 
 
 console = Console()
@@ -78,23 +79,21 @@ def config_check(
 # existing commands
 
 
-@app.command(help="Sync Google Photos (multi-account)")
+@app.command(help="Google Photos 差分取得（複数アカウント対応, dry-run可）")
 def sync(
-    all_accounts: bool = typer.Option(
-        True,
-        "--all-accounts/--single-account",
-        help="Process all active accounts (default: True)",
-    ),
-    account_id: Optional[int] = typer.Option(
-        None, "--account-id", help="Process a single account by ID"
-    ),
+    all_accounts: bool = typer.Option(True, "--all-accounts/--single-account",
+                                      help="すべてのactiveアカウントを処理（既定: True）"),
+    account_id: Optional[int] = typer.Option(None, "--account-id", help="単一アカウントIDを指定する場合に利用"),
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run",
+                                 help="外形のみ（DBにjob記録し、実ダウンロードなし）。既定: --dry-run"),
 ) -> None:
     cfg = PhotoNestConfig.from_env()
     _, errs = cfg.validate()
     if errs:
-        console.print("[red]Configuration error[/]: " + "; ".join(errs))
+        console.print("[red]設定エラー[/]: " + "; ".join(errs))
         raise typer.Exit(1)
-    console.print("[cyan]TODO[/]: implement sync")
+    code = run_sync(all_accounts=all_accounts, account_id=account_id, dry_run=dry_run)
+    raise typer.Exit(code)
 
 
 @app.command("import", help="Import existing local files (fixed directory)")

--- a/cli/src/fpv/cli.py
+++ b/cli/src/fpv/cli.py
@@ -79,18 +79,28 @@ def config_check(
 # existing commands
 
 
-@app.command(help="Google Photos 差分取得（複数アカウント対応, dry-run可）")
+@app.command(help="Fetch Google Photos delta (multiple accounts, dry-run supported)")
 def sync(
-    all_accounts: bool = typer.Option(True, "--all-accounts/--single-account",
-                                      help="すべてのactiveアカウントを処理（既定: True）"),
-    account_id: Optional[int] = typer.Option(None, "--account-id", help="単一アカウントIDを指定する場合に利用"),
-    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run",
-                                 help="外形のみ（DBにjob記録し、実ダウンロードなし）。既定: --dry-run"),
+    all_accounts: bool = typer.Option(
+        True,
+        "--all-accounts/--single-account",
+        help="Process all active accounts (default: True)",
+    ),
+    account_id: Optional[int] = typer.Option(
+        None,
+        "--account-id",
+        help="Target a single account by ID",
+    ),
+    dry_run: bool = typer.Option(
+        True,
+        "--dry-run/--no-dry-run",
+        help="Outline only (record job, no downloads). default: --dry-run",
+    ),
 ) -> None:
     cfg = PhotoNestConfig.from_env()
     _, errs = cfg.validate()
     if errs:
-        console.print("[red]設定エラー[/]: " + "; ".join(errs))
+        console.print("[red]Configuration error[/]: " + "; ".join(errs))
         raise typer.Exit(1)
     code = run_sync(all_accounts=all_accounts, account_id=account_id, dry_run=dry_run)
     raise typer.Exit(code)

--- a/cli/src/fpv/db.py
+++ b/cli/src/fpv/db.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import os
+from typing import Dict
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+
+def get_engine_from_env(env: Dict[str, str] | None = None) -> Engine:
+    env = env or os.environ
+    url = env.get("FPV_DB_URL") or env.get("DATABASE_URI")
+    if not url:
+        raise RuntimeError("FPV_DB_URL or DATABASE_URI not set")
+    return create_engine(url, future=True)

--- a/cli/src/fpv/google.py
+++ b/cli/src/fpv/google.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from typing import Tuple, Dict, Any
+import json
+
+# 将来: httpxで実装。今回は呼び出しません（dry-run）
+def refresh_access_token(oauth_token_json_enc: str, oauth_key: str) -> Tuple[str, Dict[str, Any]]:
+    """
+    Returns: (access_token, meta)
+    - ここでは未実装。次ステップで暗号復号＆tokenエンドポイント呼び出しを実装する。
+    """
+    raise NotImplementedError("refresh_access_token is not implemented yet")

--- a/cli/src/fpv/logs.py
+++ b/cli/src/fpv/logs.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import json, sys, time, uuid
+from typing import Any, Dict
+
+
+def log(event: str, **fields: Any) -> None:
+    rec: Dict[str, Any] = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "event": event,
+    }
+    rec.update(fields)
+    sys.stdout.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def new_trace_id() -> str:
+    return uuid.uuid4().hex[:16]

--- a/cli/src/fpv/sync.py
+++ b/cli/src/fpv/sync.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+from typing import Optional, Dict, Any, List
+from sqlalchemy import text
+from .db import get_engine_from_env
+from .logs import log, new_trace_id
+
+
+def run_sync(all_accounts: bool = True,
+             account_id: Optional[int] = None,
+             dry_run: bool = True) -> int:
+    """
+    Returns: exit code (0=success, 1=partial/failed)
+    """
+    trace = new_trace_id()
+    eng = get_engine_from_env()
+
+    # アカウント抽出
+    sql = "SELECT id, account_email, oauth_token_json FROM google_account WHERE status='active'"
+    params: Dict[str, Any] = {}
+    if not all_accounts and account_id is not None:
+        sql += " AND id=:id"
+        params["id"] = account_id
+
+    with eng.connect() as conn:
+        rows = conn.execute(text(sql), params).fetchall()
+
+    if not rows:
+        log("sync.no_accounts", trace=trace)
+        return 0
+
+    overall_failed = 0
+
+    for r in rows:
+        aid, email, token_json = int(r[0]), r[1], r[2]
+        log("sync.account.begin", trace=trace, account_id=aid, email=email, dry_run=dry_run)
+
+        # ジョブ開始
+        with eng.begin() as conn:
+            job_id = conn.execute(
+                text("INSERT INTO job_sync (target, account_id, started_at, status, stats_json) "
+                     "VALUES ('google_photos', :aid, UTC_TIMESTAMP(), 'running', :stats)"),
+                {"aid": aid, "stats": "{}"}
+            ).lastrowid
+
+        # ダミー処理（dry-run）: 3件処理した体で統計を出す
+        stats: Dict[str, Any] = {"new": 3, "dup": 0, "failed": 0}
+        status = "success"
+
+        # 例外処理の雛形（将来: API/IOエラーで failed/partial 更新）
+        try:
+            if dry_run:
+                # ここでは何もしない（ログだけ）
+                for i in range(1, 4):
+                    log("sync.dryrun.item", trace=trace, account_id=aid, idx=i)
+            else:
+                # 次ステップで実装: token refresh -> list media -> download -> insert ...
+                pass
+        except Exception as e:
+            status = "failed"
+            stats["failed"] = 1
+            log("sync.account.error", trace=trace, account_id=aid, error=str(e))
+            overall_failed += 1
+        finally:
+            # ジョブ終了
+            with eng.begin() as conn:
+                conn.execute(
+                    text("UPDATE job_sync SET finished_at=UTC_TIMESTAMP(), status=:st, stats_json=:js "
+                         "WHERE account_id=:aid AND id=:jid"),
+                    {"st": status, "js": json_dumps(stats), "aid": aid, "jid": job_id}
+                )
+        log("sync.account.end", trace=trace, account_id=aid, status=status, stats=stats)
+
+    if overall_failed:
+        log("sync.done", trace=trace, result="partial")
+        return 1
+    log("sync.done", trace=trace, result="success")
+    return 0
+
+
+def json_dumps(d: Dict[str, Any]) -> str:
+    import json
+    return json.dumps(d, ensure_ascii=False, separators=(",", ":"))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,82 @@
+import json
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import create_engine, text, event
+
+from fpv.sync import run_sync
+
+
+def _setup_engine(with_account: bool = True):
+    engine = create_engine("sqlite:///:memory:", future=True)
+
+    @event.listens_for(engine, "connect")
+    def _connect(dbapi_connection, connection_record):
+        dbapi_connection.create_function(
+            "UTC_TIMESTAMP", 0, lambda: datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        )
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            """
+            CREATE TABLE google_account (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_email TEXT,
+                oauth_token_json TEXT,
+                status TEXT
+            )
+            """
+        ))
+        conn.execute(text(
+            """
+            CREATE TABLE job_sync (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                target TEXT,
+                account_id INTEGER,
+                started_at TEXT,
+                finished_at TEXT,
+                status TEXT,
+                stats_json TEXT
+            )
+            """
+        ))
+        if with_account:
+            conn.execute(text(
+                "INSERT INTO google_account (account_email, oauth_token_json, status) "
+                "VALUES ('test@example.com', '{}', 'active')"
+            ))
+    return engine
+
+
+def _collect_events(output: str) -> List[str]:
+    lines = [l for l in output.splitlines() if l.strip()]
+    return [json.loads(l)["event"] for l in lines]
+
+
+def test_run_sync_dry_run(monkeypatch, capsys):
+    engine = _setup_engine(with_account=True)
+    monkeypatch.setattr("fpv.sync.get_engine_from_env", lambda: engine)
+    code = run_sync()
+    assert code == 0
+    out = capsys.readouterr().out
+    events = _collect_events(out)
+    assert events[0] == "sync.account.begin"
+    assert events.count("sync.dryrun.item") == 3
+    assert events[-2] == "sync.account.end"
+    assert events[-1] == "sync.done"
+    with engine.connect() as conn:
+        row = conn.execute(text("SELECT status, stats_json FROM job_sync")).fetchone()
+        assert row[0] == "success"
+        assert json.loads(row[1]) == {"new": 3, "dup": 0, "failed": 0}
+
+
+def test_run_sync_no_accounts(monkeypatch, capsys):
+    engine = _setup_engine(with_account=False)
+    monkeypatch.setattr("fpv.sync.get_engine_from_env", lambda: engine)
+    code = run_sync()
+    assert code == 0
+    events = _collect_events(capsys.readouterr().out)
+    assert events == ["sync.no_accounts"]
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT * FROM job_sync")).fetchall()
+        assert rows == []


### PR DESCRIPTION
## Summary
- add httpx, SQLAlchemy and PyMySQL dependencies
- implement structured logging and dry-run sync outline
- expose real `sync` command and document its usage
- cover dry-run sync workflow with tests

## Testing
- `python -m pip install -e cli`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cdf54ca2c8323bee968c4faa3b14b