### PR TITLE
Implement Google token refresh and media listing

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,3 +26,38 @@ fpv sync --dry-run
 ```
 
 `--no-dry-run` will be effective in later steps when the actual API implementation is added.
+
+## Google API 疎通（1ページだけ）
+
+1) 事前に DB へ `google_account` を1件投入（開発初期は **平文JSON** でも可）:
+
+```sql
+INSERT INTO google_account (account_email, oauth_token_json, status)
+VALUES (
+  'you@example.com',
+  '{"refresh_token":"<実際のRefreshToken>"}',
+  'active'
+);
+```
+
+> 本番は `oauth_token_json` を AES-GCM で暗号化したエンベロープにしてください（CLIはどちらも解釈可能）。
+
+2. `.env` に Google クレデンシャルを設定:
+
+```
+FPV_GOOGLE_CLIENT_ID=...apps.googleusercontent.com
+FPV_GOOGLE_CLIENT_SECRET=...
+FPV_OAUTH_KEY=base64:<32bytes>   # 平文JSONを使う場合でも設定してOK
+```
+
+3. 実行:
+
+```bash
+python -m pip install -e .
+fpv db up
+fpv config check
+fpv sync --no-dry-run
+```
+
+* 成功すると `sync.token.ok` → `sync.list.ok` のログが出て、`job_sync` は `success`。
+* `invalid_grant`（失効/削除）は `sync.account.reauth_required` として `failed` になります。

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
   "rich>=13.7",
   "SQLAlchemy>=2.0",
   "PyMySQL>=1.1",
-  "httpx>=0.27"
+  "httpx>=0.27",
+  "cryptography>=42.0.0"
 ]
 
 [project.scripts]

--- a/cli/src/fpv/google.py
+++ b/cli/src/fpv/google.py
@@ -1,11 +1,143 @@
 from __future__ import annotations
-from typing import Tuple, Dict, Any
-import json
+from typing import Tuple, Dict, Any, Optional, List
+import base64, json, os, time
+import httpx
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-# 将来: httpxで実装。今回は呼び出しません（dry-run）
-def refresh_access_token(oauth_token_json_enc: str, oauth_key: str) -> Tuple[str, Dict[str, Any]]:
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+PHOTOS_BASE = "https://photoslibrary.googleapis.com/v1"
+UA = "PhotoNest/0.1 (fpv)"
+
+
+class ReauthRequired(Exception):
+    """invalid_grant 等、再認証が必要な場合に投げる"""
+
+
+def _key_from_env(oauth_key: str) -> bytes:
+    if not oauth_key:
+        raise ValueError("FPV_OAUTH_KEY 未設定")
+    if oauth_key.startswith("base64:"):
+        raw = base64.b64decode(oauth_key.split(":", 1)[1], validate=True)
+    else:
+        raw = oauth_key.encode("utf-8")
+    if len(raw) != 32:
+        raise ValueError(f"FPV_OAUTH_KEY 長さ不正: {len(raw)} bytes (要求: 32)")
+    return raw
+
+
+def _decrypt_envelope(oauth_token_json_enc: str, key: bytes) -> Dict[str, Any]:
+    """
+    期待するエンベロープ形式:
+    {
+      "alg": "AES-256-GCM",
+      "nonce": "<b64>",
+      "ct": "<b64>",
+      "aad": "<optional b64>"
+    }
+    戻り値は復号したJSON(dict)。
+    """
+    env = json.loads(oauth_token_json_enc)
+    if not isinstance(env, dict) or env.get("alg") != "AES-256-GCM":
+        raise ValueError("not envelope")
+    nonce = base64.b64decode(env["nonce"])
+    ct = base64.b64decode(env["ct"])
+    aad = base64.b64decode(env["aad"]) if env.get("aad") else None
+    aes = AESGCM(key)
+    pt = aes.decrypt(nonce, ct, aad)
+    return json.loads(pt.decode("utf-8"))
+
+
+def parse_oauth_payload(oauth_token_json_enc: str, oauth_key: str) -> Dict[str, Any]:
+    """
+    1) AES-GCM envelope を試す
+    2) 失敗したら 平文JSON を試す（開発初期の利便性のため）
+    """
+    key = _key_from_env(oauth_key)
+    try:
+        return _decrypt_envelope(oauth_token_json_enc, key)
+    except Exception:
+        pass
+    try:
+        plain = json.loads(oauth_token_json_enc)
+        if not isinstance(plain, dict):
+            raise ValueError
+        return plain
+    except Exception as e:
+        raise ValueError(
+            "oauth_token_json の形式が不正です（envelope/平文JSON いずれも解釈不可）"
+        ) from e
+
+
+def refresh_access_token(
+    oauth_token_json_enc: str,
+    oauth_key: str,
+    client_id: str,
+    client_secret: str,
+    timeout_sec: float = 15.0,
+    max_retries: int = 3,
+) -> Tuple[str, Dict[str, Any]]:
     """
     Returns: (access_token, meta)
-    - ここでは未実装。次ステップで暗号復号＆tokenエンドポイント呼び出しを実装する。
+      meta = { "expires_in": int, "token_type": str, "scope": str, "raw": dict }
     """
-    raise NotImplementedError("refresh_access_token is not implemented yet")
+    payload = parse_oauth_payload(oauth_token_json_enc, oauth_key)
+    refresh_token = payload.get("refresh_token")
+    if not refresh_token:
+        raise ValueError("refresh_token が存在しません")
+
+    last_err: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            with httpx.Client(timeout=timeout_sec, headers={"User-Agent": UA}) as client:
+                res = client.post(
+                    TOKEN_URL,
+                    data={
+                        "grant_type": "refresh_token",
+                        "refresh_token": refresh_token,
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    },
+                )
+            if res.status_code == 400 and res.headers.get("content-type", "").startswith("application/json"):
+                data = res.json()
+                err = (data.get("error") or "").lower()
+                if err == "invalid_grant":
+                    raise ReauthRequired("invalid_grant: refresh_token が無効/取り消し")
+            res.raise_for_status()
+            data = res.json()
+            access = data["access_token"]
+            meta = {
+                "expires_in": int(data.get("expires_in", 0)),
+                "token_type": data.get("token_type"),
+                "scope": data.get("scope"),
+                "raw": data,
+            }
+            return access, meta
+        except ReauthRequired:
+            raise
+        except Exception as e:
+            last_err = e
+            time.sleep(min(2 ** attempt, 8))
+    assert last_err is not None
+    raise last_err
+
+
+def list_media_items_once(
+    access_token: str,
+    page_size: int = 100,
+    page_token: Optional[str] = None,
+    timeout_sec: float = 20.0,
+) -> Dict[str, Any]:
+    """
+    1ページだけ取得して返す。
+    Returns: { "mediaItems": [...], "nextPageToken": "..."? }
+    """
+    headers = {"Authorization": f"Bearer {access_token}", "User-Agent": UA}
+    params = {"pageSize": page_size}
+    if page_token:
+        params["pageToken"] = page_token
+    url = f"{PHOTOS_BASE}/mediaItems"
+    with httpx.Client(timeout=timeout_sec, headers=headers) as client:
+        r = client.get(url, params=params)
+    r.raise_for_status()
+    return r.json()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,5 @@
 import json
+import json
 from datetime import datetime
 from typing import List
 
@@ -54,7 +55,7 @@ def test_run_sync_dry_run(monkeypatch, capsys):
     with Session(engine) as session:
         job = session.query(JobSync).one()
         assert job.status == "success"
-        assert json.loads(job.stats_json) == {"new": 3, "dup": 0, "failed": 0}
+        assert json.loads(job.stats_json) == {"listed": 3, "new": 0, "dup": 0, "failed": 0}
 
 
 def test_run_sync_no_accounts(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add cryptography dependency
- implement Google OAuth token refresh and mediaItems listing
- hook sync to call Google APIs on non-dry-run and document usage

## Testing
- `pip install 'typer[all]>=0.12.0' 'rich>=13.7' 'SQLAlchemy>=2.0' 'PyMySQL>=1.1' 'httpx>=0.27' 'cryptography>=42.0.0'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0834e9f083239cf33bbe72a8e957