### PR TITLE
Add sync pagination docs and tidy error output

### DIFF
--- a/cli/src/fpv/cli.py
+++ b/cli/src/fpv/cli.py
@@ -190,7 +190,7 @@ def sync(
     cfg = PhotoNestConfig.from_env()
     _, errs = cfg.validate()
     if errs:
-        console.print("[red]設定エラー[/]: " + "; ".join(errs))
+        console.print("[red]設定エラー[/]: ", "; ".join(errs))
         raise typer.Exit(1)
     code = run_sync(
         all_accounts=all_accounts,

--- a/cli/src/fpv/sync.py
+++ b/cli/src/fpv/sync.py
@@ -31,6 +31,21 @@ def run_sync(
     page_size: int = 50,
     max_pages: int = 1,
 ) -> int:
+    """Synchronize media items from Google Photos.
+
+    Parameters
+    ----------
+    all_accounts: bool
+        Process all active accounts when ``True``.
+    account_id: Optional[int]
+        Target a single account when provided.
+    dry_run: bool
+        Skip downloads when ``True``.
+    page_size: int
+        Page size to request from the API.
+    max_pages: int
+        Maximum number of pages to retrieve.
+    """
     trace = new_trace_id()
     eng = get_engine()
     cfg = PhotoNestConfig.from_env()


### PR DESCRIPTION
## Summary
- document pagination parameters in `run_sync`
- clean up configuration error message in sync command

## Testing
- `python -m pip install -e .`
- `fpv sync --help` *(fails: ModuleNotFoundError: No module named 'core')*
- `fpv sync --no-dry-run --page-size 50 --max-pages 1` *(fails: SyntaxError in fpv/repo.py)*
- `pytest -q` *(fails: SyntaxError in fpv/repo.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ec06f0db88323a5596e94a035947d