### PR TITLE
Add media listing, detail, and signed download APIs

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -86,7 +86,10 @@ class Tag(db.Model):
 class MediaPlayback(db.Model):
     id = db.Column(BigInt, primary_key=True, autoincrement=True)
     media_id = db.Column(BigInt, db.ForeignKey('media.id'), nullable=False)
-    preset = db.Column(db.Enum('original', 'preview', 'mobile', name='media_playback_preset'), nullable=False)
+    preset = db.Column(
+        db.Enum('original', 'preview', 'mobile', 'std1080p', name='media_playback_preset'),
+        nullable=False,
+    )
     rel_path = db.Column(db.String(255))
     width = db.Column(db.Integer)
     height = db.Column(db.Integer)

--- a/tests/test_media_api.py
+++ b/tests/test_media_api.py
@@ -1,0 +1,539 @@
+import os
+import base64
+import json
+import hmac
+import hashlib
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def app(tmp_path):
+    db_path = tmp_path / "test.db"
+    os.environ["SECRET_KEY"] = "test"
+    os.environ["DATABASE_URI"] = f"sqlite:///{db_path}"
+    os.environ["GOOGLE_CLIENT_ID"] = "cid"
+    os.environ["GOOGLE_CLIENT_SECRET"] = "sec"
+    key = base64.urlsafe_b64encode(b"0" * 32).decode()
+    os.environ["OAUTH_TOKEN_KEY"] = key
+    os.environ["FPV_DL_SIGN_KEY"] = base64.urlsafe_b64encode(b"1" * 32).decode()
+    os.environ["FPV_URL_TTL_THUMB"] = "600"
+    os.environ["FPV_URL_TTL_PLAYBACK"] = "600"
+    thumbs = tmp_path / "thumbs"
+    play = tmp_path / "play"
+    thumbs.mkdir()
+    play.mkdir()
+    os.environ["FPV_NAS_THUMBS_DIR"] = str(thumbs)
+    os.environ["FPV_NAS_PLAY_DIR"] = str(play)
+    import importlib, sys
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+
+    app = create_app()
+    app.config.update(TESTING=True)
+
+    from webapp.extensions import db
+    from core.models.user import User
+    from core.models.google_account import GoogleAccount
+
+    with app.app_context():
+        db.create_all()
+        u = User(email="u@example.com")
+        u.set_password("pass")
+        db.session.add(u)
+        acc = GoogleAccount(email="g@example.com", scopes="", oauth_token_json="{}")
+        db.session.add(acc)
+        db.session.commit()
+
+    yield app
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    from core.models.user import User
+
+    app = client.application
+    with app.app_context():
+        user = User.query.first()
+
+    client.post(
+        "/auth/login",
+        data={"email": user.email, "password": "pass"},
+        follow_redirects=True,
+    )
+
+
+def make_token(payload: dict) -> str:
+    canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    key = base64.urlsafe_b64decode(os.environ["FPV_DL_SIGN_KEY"])
+    sig = hmac.new(key, canonical, hashlib.sha256).digest()
+    return (
+        base64.urlsafe_b64encode(canonical).rstrip(b"=").decode()
+        + "."
+        + base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+    )
+
+
+@pytest.fixture
+def seed_media_bulk(app):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    base_shot = datetime(2025, 8, 1, tzinfo=timezone.utc)
+    base_imp = datetime(2025, 8, 2, tzinfo=timezone.utc)
+    with app.app_context():
+        for i in range(250):
+            m = Media(
+                google_media_id=f"gm{i}",
+                account_id=1,
+                local_rel_path=f"{i}.jpg",
+                bytes=1,
+                mime_type="image/jpeg",
+                width=100,
+                height=100,
+                shot_at=base_shot + timedelta(minutes=i),
+                imported_at=base_imp + timedelta(minutes=i),
+                is_video=False,
+                is_deleted=False,
+                has_playback=False,
+            )
+            db.session.add(m)
+        for i in range(5):
+            m = Media(
+                google_media_id=f"del{i}",
+                account_id=1,
+                local_rel_path=f"del{i}.jpg",
+                bytes=1,
+                mime_type="image/jpeg",
+                width=100,
+                height=100,
+                shot_at=base_shot + timedelta(minutes=250 + i),
+                imported_at=base_imp + timedelta(minutes=250 + i),
+                is_video=False,
+                is_deleted=True,
+                has_playback=False,
+            )
+            db.session.add(m)
+        db.session.commit()
+        deleted_ids = [m.id for m in Media.query.filter_by(is_deleted=True).all()]
+        return deleted_ids
+
+
+@pytest.fixture
+def seed_media_range(app):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    with app.app_context():
+        m1 = Media(
+            google_media_id="m1",
+            account_id=1,
+            local_rel_path="m1.jpg",
+            bytes=1,
+            mime_type="image/jpeg",
+            width=1,
+            height=1,
+            shot_at=datetime(2025, 7, 15, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 7, 16, tzinfo=timezone.utc),
+            is_video=False,
+            is_deleted=False,
+            has_playback=False,
+        )
+        m2 = Media(
+            google_media_id="m2",
+            account_id=1,
+            local_rel_path="m2.jpg",
+            bytes=1,
+            mime_type="image/jpeg",
+            width=1,
+            height=1,
+            shot_at=datetime(2025, 8, 15, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 8, 16, tzinfo=timezone.utc),
+            is_video=False,
+            is_deleted=False,
+            has_playback=False,
+        )
+        m3 = Media(
+            google_media_id="m3",
+            account_id=1,
+            local_rel_path="m3.jpg",
+            bytes=1,
+            mime_type="image/jpeg",
+            width=1,
+            height=1,
+            shot_at=datetime(2025, 9, 15, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 9, 16, tzinfo=timezone.utc),
+            is_video=False,
+            is_deleted=False,
+            has_playback=False,
+        )
+        db.session.add_all([m1, m2, m3])
+        db.session.commit()
+
+
+@pytest.fixture
+def seed_media_detail(app):
+    from webapp.extensions import db
+    from core.models.photo_models import (
+        Media,
+        Exif,
+        MediaSidecar,
+        MediaPlayback,
+    )
+
+    with app.app_context():
+        m = Media(
+            google_media_id="detail",
+            account_id=1,
+            local_rel_path="path.jpg",
+            bytes=123,
+            mime_type="image/jpeg",
+            width=4032,
+            height=3024,
+            shot_at=datetime(2025, 8, 17, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 8, 18, tzinfo=timezone.utc),
+            is_video=False,
+            is_deleted=False,
+            has_playback=True,
+        )
+        db.session.add(m)
+        db.session.commit()
+
+        exif = Exif(
+            media_id=m.id,
+            camera_make="Apple",
+            camera_model="iPhone",
+            lens=None,
+            iso=125,
+            shutter="1/120",
+            f_number=1.6,
+            focal_len=26.0,
+            gps_lat=None,
+            gps_lng=None,
+        )
+        side = MediaSidecar(
+            media_id=m.id,
+            type="video",
+            rel_path="2025/08/18/side.mp4",
+            bytes=1234,
+        )
+        pb = MediaPlayback(
+            media_id=m.id,
+            preset="original",
+            rel_path="2025/08/18/pb.mp4",
+            status="done",
+        )
+        db.session.add_all([exif, side, pb])
+        db.session.commit()
+        return m.id
+
+
+@pytest.fixture
+def seed_thumb_media(app):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    rel = "2025/08/18/pic.jpg"
+    with app.app_context():
+        m = Media(
+            google_media_id="thumb",
+            account_id=1,
+            local_rel_path=rel,
+            bytes=10,
+            mime_type="image/jpeg",
+            width=100,
+            height=100,
+            is_video=False,
+            is_deleted=False,
+            has_playback=False,
+        )
+        db.session.add(m)
+        db.session.commit()
+        mid = m.id
+
+    base = os.environ["FPV_NAS_THUMBS_DIR"]
+    path = os.path.join(base, "1024", rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"jpg")
+    return mid, rel
+
+
+@pytest.fixture
+def seed_playback_media(app):
+    from webapp.extensions import db
+    from core.models.photo_models import Media, MediaPlayback
+
+    with app.app_context():
+        m_ok = Media(
+            google_media_id="v1",
+            account_id=1,
+            local_rel_path="v1.mp4",
+            bytes=20,
+            mime_type="video/mp4",
+            width=100,
+            height=100,
+            is_video=True,
+            is_deleted=False,
+            has_playback=True,
+        )
+        m_run = Media(
+            google_media_id="v2",
+            account_id=1,
+            local_rel_path="v2.mp4",
+            bytes=20,
+            mime_type="video/mp4",
+            width=100,
+            height=100,
+            is_video=True,
+            is_deleted=False,
+            has_playback=True,
+        )
+        m_none = Media(
+            google_media_id="v3",
+            account_id=1,
+            local_rel_path="v3.mp4",
+            bytes=20,
+            mime_type="video/mp4",
+            width=100,
+            height=100,
+            is_video=True,
+            is_deleted=False,
+            has_playback=False,
+        )
+        db.session.add_all([m_ok, m_run, m_none])
+        db.session.commit()
+        ok_id, run_id, none_id = m_ok.id, m_run.id, m_none.id
+
+        pb_ok = MediaPlayback(
+            media_id=m_ok.id,
+            preset="std1080p",
+            rel_path="2025/08/18/ok.mp4",
+            status="done",
+        )
+        pb_run = MediaPlayback(
+            media_id=m_run.id,
+            preset="std1080p",
+            rel_path="2025/08/18/run.mp4",
+            status="processing",
+        )
+        db.session.add_all([pb_ok, pb_run])
+        db.session.commit()
+        ok_rel = pb_ok.rel_path
+
+    base = os.environ["FPV_NAS_PLAY_DIR"]
+    ok_path = os.path.join(base, ok_rel)
+    os.makedirs(os.path.dirname(ok_path), exist_ok=True)
+    with open(ok_path, "wb") as f:
+        f.write(os.urandom(2048))
+
+    return ok_id, run_id, none_id
+
+
+@pytest.fixture
+def seed_deleted_media(app):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    with app.app_context():
+        m = Media(
+            google_media_id="delm",
+            account_id=1,
+            local_rel_path="del.jpg",
+            bytes=1,
+            mime_type="image/jpeg",
+            width=1,
+            height=1,
+            is_video=False,
+            is_deleted=True,
+            has_playback=False,
+        )
+        db.session.add(m)
+        db.session.commit()
+        mid = m.id
+        return mid
+
+
+def test_list_first_page(client, seed_media_bulk):
+    _ = seed_media_bulk
+    login(client)
+    res = client.get("/api/media?limit=200")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert len(data["items"]) == 200
+    assert data["nextCursor"] is not None
+    assert data["nextCursor"] < data["items"][-1]["id"]
+    ids = [item["id"] for item in data["items"]]
+    assert ids == sorted(ids, reverse=True)
+    assert data["serverTimeRFC1123"].endswith("GMT")
+
+
+def test_list_second_page(client, seed_media_bulk):
+    _ = seed_media_bulk
+    login(client)
+    res1 = client.get("/api/media?limit=200")
+    cursor = res1.get_json()["nextCursor"]
+    res = client.get(f"/api/media?cursor={cursor}&limit=200")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert len(data["items"]) <= 50
+    assert data["nextCursor"] is None
+
+
+def test_list_deleted_excluded(client, seed_media_bulk):
+    deleted_ids = seed_media_bulk
+    login(client)
+    res = client.get("/api/media?include_deleted=0")
+    assert res.status_code == 200
+    data = res.get_json()
+    returned_ids = {item["id"] for item in data["items"]}
+    for did in deleted_ids:
+        assert did not in returned_ids
+
+
+def test_list_range_after_before(client, seed_media_range):
+    login(client)
+    res = client.get(
+        "/api/media?after=2025-08-01T00:00:00Z&before=2025-08-31T23:59:59Z"
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert len(data["items"]) == 1
+    shot = data["items"][0]["shot_at"]
+    dt = datetime.fromisoformat(shot.replace("Z", "+00:00")).replace(tzinfo=None)
+    assert datetime(2025, 8, 1) <= dt <= datetime(2025, 8, 31, 23, 59, 59)
+
+
+def test_detail_ok(client, seed_media_detail):
+    media_id = seed_media_detail
+    login(client)
+    res = client.get(f"/api/media/{media_id}")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["id"] == media_id
+    assert data["exif"]["camera_make"] == "Apple"
+    assert data["sidecars"]
+    assert data["playback"]["available"] is True
+    assert data["serverTimeRFC1123"].endswith("GMT")
+
+
+def test_detail_404(client):
+    login(client)
+    res = client.get("/api/media/999999")
+    assert res.status_code == 404
+
+
+def test_thumb_url_ok(client, seed_thumb_media):
+    media_id, _ = seed_thumb_media
+    login(client)
+    res = client.post(f"/api/media/{media_id}/thumb-url", json={"size": 1024})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["url"].startswith("/api/dl/")
+    dl = client.get(data["url"])
+    assert dl.status_code == 200
+    assert dl.headers["Content-Type"] == "image/jpeg"
+
+
+def test_thumb_url_not_found(client, seed_thumb_media):
+    media_id, _ = seed_thumb_media
+    login(client)
+    res = client.post(f"/api/media/{media_id}/thumb-url", json={"size": 2048})
+    assert res.status_code == 404
+    assert res.get_json()["error"] == "not_found"
+
+
+def test_playback_url_states(client, seed_playback_media):
+    ok_id, run_id, none_id = seed_playback_media
+    login(client)
+    res_ok = client.post(f"/api/media/{ok_id}/playback-url")
+    assert res_ok.status_code == 200
+    res_run = client.post(f"/api/media/{run_id}/playback-url")
+    assert res_run.status_code == 409
+    assert res_run.get_json()["error"] == "not_ready"
+    res_none = client.post(f"/api/media/{none_id}/playback-url")
+    assert res_none.status_code == 404
+
+
+def test_token_tamper(client, seed_thumb_media):
+    media_id, _ = seed_thumb_media
+    login(client)
+    res = client.post(f"/api/media/{media_id}/thumb-url", json={"size": 1024})
+    token = res.get_json()["url"].split("/api/dl/")[1]
+    tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+    res2 = client.get(f"/api/dl/{tampered}")
+    assert res2.status_code == 403
+    assert res2.get_json()["error"] == "invalid_token"
+
+
+def test_token_expired(client, seed_thumb_media):
+    media_id, rel = seed_thumb_media
+    payload = {
+        "v": 1,
+        "typ": "thumb",
+        "mid": media_id,
+        "size": 1024,
+        "path": f"thumbs/1024/{rel}",
+        "ct": "image/jpeg",
+        "exp": int(time.time()) - 10,
+        "nonce": "n",
+    }
+    token = make_token(payload)
+    res = client.get(f"/api/dl/{token}")
+    assert res.status_code == 403
+    assert res.get_json()["error"] == "expired"
+
+
+def test_range_video(client, seed_playback_media):
+    ok_id, _, _ = seed_playback_media
+    login(client)
+    res = client.post(f"/api/media/{ok_id}/playback-url")
+    url = res.get_json()["url"]
+    res2 = client.get(url, headers={"Range": "bytes=0-1023"})
+    assert res2.status_code == 206
+    assert res2.headers["Content-Range"].startswith("bytes 0-")
+    assert res2.headers["Accept-Ranges"] == "bytes"
+
+
+def test_ct_mismatch(client):
+    rel = "2025/08/18/foo.png"
+    base = os.environ["FPV_NAS_THUMBS_DIR"]
+    path = os.path.join(base, "256", rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"png")
+    payload = {
+        "v": 1,
+        "typ": "thumb",
+        "mid": 0,
+        "size": 256,
+        "path": f"thumbs/256/{rel}",
+        "ct": "image/jpeg",
+        "exp": int(time.time()) + 600,
+        "nonce": "x",
+    }
+    token = make_token(payload)
+    res = client.get(f"/api/dl/{token}")
+    assert res.status_code == 403
+    assert res.get_json()["error"] == "forbidden"
+
+
+def test_thumb_url_deleted_media(client, seed_deleted_media):
+    media_id = seed_deleted_media
+    login(client)
+    res = client.post(f"/api/media/{media_id}/thumb-url", json={"size": 256})
+    assert res.status_code == 410
+

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timezone
+import base64
+import hashlib
+import hmac
 import json
+import mimetypes
+import os
+import re
 import secrets
+import time
 from urllib.parse import urlencode
 from email.utils import formatdate
 from uuid import uuid4
@@ -23,6 +30,7 @@ from . import bp
 from ..extensions import db
 from core.models.google_account import GoogleAccount
 from core.models.picker_session import PickerSession
+from core.models.photo_models import Media, Exif, MediaSidecar, MediaPlayback
 from core.crypto import decrypt, encrypt
 
 
@@ -369,3 +377,459 @@ def api_picker_session_import(picker_session_id):
         )
     )
     return jsonify({"enqueued": True, "celeryTaskId": task_id}), 202
+
+
+@bp.get("/media")
+@login_required
+def api_media_list():
+    """Return paginated list of media items."""
+    trace = uuid4().hex
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "media.list.begin",
+                "trace": trace,
+                "cursor": request.args.get("cursor"),
+                "limit": request.args.get("limit"),
+            }
+        )
+    )
+    try:
+        limit = int(request.args.get("limit", 200))
+    except Exception:
+        limit = 200
+    limit = max(1, min(limit, 200))
+    cursor = request.args.get("cursor", type=int)
+    include_deleted = request.args.get("include_deleted", type=int, default=0)
+    after_param = request.args.get("after")
+    before_param = request.args.get("before")
+
+    query = Media.query
+    if not include_deleted:
+        query = query.filter(Media.is_deleted.is_(False))
+    if cursor is not None:
+        query = query.filter(Media.id <= cursor)
+    if after_param:
+        try:
+            after_dt = datetime.fromisoformat(after_param.replace("Z", "+00:00"))
+            query = query.filter(Media.shot_at >= after_dt)
+        except Exception:
+            pass
+    if before_param:
+        try:
+            before_dt = datetime.fromisoformat(before_param.replace("Z", "+00:00"))
+            query = query.filter(Media.shot_at <= before_dt)
+        except Exception:
+            pass
+
+    query = query.order_by(
+        Media.shot_at.is_(None),
+        Media.shot_at.desc(),
+        Media.imported_at.desc(),
+        Media.id.desc(),
+    )
+    items = query.limit(limit).all()
+
+    next_cursor = None
+    if len(items) == limit:
+        last_id = items[-1].id
+        if last_id and last_id > 1:
+            next_cursor = last_id - 1
+
+    data_items = []
+    for m in items:
+        data_items.append(
+            {
+                "id": m.id,
+                "shot_at": m.shot_at.isoformat().replace("+00:00", "Z")
+                if m.shot_at
+                else None,
+                "mime_type": m.mime_type,
+                "width": m.width,
+                "height": m.height,
+                "is_video": int(bool(m.is_video)),
+                "local_rel_path": m.local_rel_path,
+                "has_playback": int(bool(m.has_playback)),
+            }
+        )
+
+    server_time = formatdate(usegmt=True)
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "media.list.success",
+                "trace": trace,
+                "count": len(items),
+                "cursor": cursor,
+                "nextCursor": next_cursor,
+                "serverTimeRFC1123": server_time,
+            }
+        )
+    )
+    return jsonify(
+        {"items": data_items, "nextCursor": next_cursor, "serverTimeRFC1123": server_time}
+    )
+
+
+@bp.get("/media/<int:media_id>")
+@login_required
+def api_media_detail(media_id):
+    """Return detailed info for a single media item."""
+    trace = uuid4().hex
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "media.detail.begin",
+                "media_id": media_id,
+                "trace": trace,
+            }
+        )
+    )
+    media = Media.query.get(media_id)
+    if not media or media.is_deleted:
+        current_app.logger.info(
+            json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "event": "media.detail.not_found",
+                    "media_id": media_id,
+                    "trace": trace,
+                }
+            )
+        )
+        return jsonify({"error": "not_found"}), 404
+
+    exif = media.exif
+    sidecars = [
+        {"type": s.type, "rel_path": s.rel_path, "bytes": s.bytes}
+        for s in media.sidecars
+    ]
+    pb = media.playbacks[0] if media.playbacks else None
+    playback = {
+        "available": bool(pb and pb.status == "done"),
+        "preset": pb.preset if pb else None,
+        "rel_path": pb.rel_path if pb else None,
+        "status": pb.status if pb else None,
+    }
+
+    data = {
+        "id": media.id,
+        "google_media_id": media.google_media_id,
+        "account_id": media.account_id,
+        "local_rel_path": media.local_rel_path,
+        "bytes": media.bytes,
+        "mime_type": media.mime_type,
+        "width": media.width,
+        "height": media.height,
+        "duration_ms": media.duration_ms,
+        "shot_at": media.shot_at.isoformat().replace("+00:00", "Z")
+        if media.shot_at
+        else None,
+        "imported_at": media.imported_at.isoformat().replace("+00:00", "Z")
+        if media.imported_at
+        else None,
+        "is_video": int(bool(media.is_video)),
+        "is_deleted": int(bool(media.is_deleted)),
+        "has_playback": int(bool(media.has_playback)),
+        "exif": {
+            "camera_make": exif.camera_make if exif else None,
+            "camera_model": exif.camera_model if exif else None,
+            "lens": exif.lens if exif else None,
+            "iso": exif.iso if exif else None,
+            "shutter": exif.shutter if exif else None,
+            "f_number": float(exif.f_number)
+            if exif and exif.f_number is not None
+            else None,
+            "focal_len": float(exif.focal_len)
+            if exif and exif.focal_len is not None
+            else None,
+            "gps_lat": float(exif.gps_lat)
+            if exif and exif.gps_lat is not None
+            else None,
+            "gps_lng": float(exif.gps_lng)
+            if exif and exif.gps_lng is not None
+            else None,
+        },
+        "sidecars": sidecars,
+        "playback": playback,
+    }
+
+    server_time = formatdate(usegmt=True)
+    data["serverTimeRFC1123"] = server_time
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "media.detail.success",
+                "media_id": media_id,
+                "trace": trace,
+                "serverTimeRFC1123": server_time,
+            }
+        )
+    )
+    return jsonify(data)
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+
+
+def _sign_payload(payload: dict) -> str:
+    canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    key_b64 = current_app.config.get("FPV_DL_SIGN_KEY")
+    key = _b64url_decode(key_b64) if key_b64 else b""
+    sig = hmac.new(key, canonical, hashlib.sha256).digest()
+    return f"{_b64url_encode(canonical)}.{_b64url_encode(sig)}"
+
+
+def _verify_token(token: str):
+    try:
+        payload_b64, sig_b64 = token.split(".", 1)
+        payload_bytes = _b64url_decode(payload_b64)
+        payload = json.loads(payload_bytes)
+    except Exception:
+        return None, "invalid_token"
+
+    key_b64 = current_app.config.get("FPV_DL_SIGN_KEY")
+    key = _b64url_decode(key_b64) if key_b64 else b""
+    canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    expected_sig = hmac.new(key, canonical, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected_sig, _b64url_decode(sig_b64)):
+        return None, "invalid_token"
+
+    if payload.get("exp", 0) < int(time.time()):
+        return None, "expired"
+
+    return payload, None
+
+
+@bp.post("/media/<int:media_id>/thumb-url")
+@login_required
+def api_media_thumb_url(media_id):
+    data = request.get_json() or {}
+    size = data.get("size")
+    if size not in (256, 1024, 2048):
+        return jsonify({"error": "invalid_size"}), 400
+
+    media = Media.query.get(media_id)
+    if not media:
+        return jsonify({"error": "not_found"}), 404
+    if media.is_deleted:
+        return jsonify({"error": "gone"}), 410
+
+    rel_path = media.local_rel_path
+    token_path = f"thumbs/{size}/{rel_path}"
+    abs_path = os.path.join(current_app.config.get("FPV_NAS_THUMBS_DIR", ""), str(size), rel_path)
+    if not os.path.exists(abs_path):
+        return jsonify({"error": "not_found"}), 404
+
+    ct = mimetypes.guess_type(abs_path)[0] or media.mime_type or "application/octet-stream"
+    ttl = current_app.config.get("FPV_URL_TTL_THUMB", 600)
+    exp = int(time.time()) + ttl
+    payload = {
+        "v": 1,
+        "typ": "thumb",
+        "mid": media_id,
+        "size": size,
+        "path": token_path,
+        "ct": ct,
+        "exp": exp,
+        "nonce": uuid4().hex,
+    }
+    token = _sign_payload(payload)
+    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "url.thumb.issue",
+                "mid": media_id,
+                "size": size,
+                "ttl": ttl,
+                "nonce": payload["nonce"],
+            }
+        )
+    )
+    return (
+        jsonify(
+            {
+                "url": f"/api/dl/{token}",
+                "expiresAt": expires_at,
+                "cacheControl": f"private, max-age={ttl}",
+            }
+        ),
+        200,
+    )
+
+
+@bp.post("/media/<int:media_id>/playback-url")
+@login_required
+def api_media_playback_url(media_id):
+    media = Media.query.get(media_id)
+    if not media or not media.is_video:
+        return jsonify({"error": "not_found"}), 404
+    if media.is_deleted:
+        return jsonify({"error": "gone"}), 410
+
+    pb = MediaPlayback.query.filter_by(media_id=media_id, preset="std1080p").first()
+    if not pb or pb.status == "error":
+        return jsonify({"error": "not_found"}), 404
+    if pb.status in ("pending", "processing"):
+        return jsonify({"error": "not_ready"}), 409
+    if pb.status != "done":
+        return jsonify({"error": "not_found"}), 404
+
+    token_path = f"playback/{pb.rel_path}"
+    abs_path = os.path.join(current_app.config.get("FPV_NAS_PLAY_DIR", ""), pb.rel_path)
+    if not os.path.exists(abs_path):
+        return jsonify({"error": "not_found"}), 404
+    ct = mimetypes.guess_type(abs_path)[0] or "video/mp4"
+    ttl = current_app.config.get("FPV_URL_TTL_PLAYBACK", 600)
+    exp = int(time.time()) + ttl
+    payload = {
+        "v": 1,
+        "typ": "playback",
+        "mid": media_id,
+        "size": None,
+        "path": token_path,
+        "ct": ct,
+        "exp": exp,
+        "nonce": uuid4().hex,
+    }
+    token = _sign_payload(payload)
+    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "url.playback.issue",
+                "mid": media_id,
+                "ttl": ttl,
+                "nonce": payload["nonce"],
+            }
+        )
+    )
+    return (
+        jsonify(
+            {
+                "url": f"/api/dl/{token}",
+                "expiresAt": expires_at,
+                "cacheControl": f"private, max-age={ttl}",
+            }
+        ),
+        200,
+    )
+
+
+@bp.route("/dl/<path:token>", methods=["GET", "HEAD"])
+def api_download(token):
+    payload, err = _verify_token(token)
+    if err:
+        return jsonify({"error": err}), 403
+
+    path = payload.get("path", "")
+    ct = payload.get("ct", "application/octet-stream")
+    if ".." in path.split("/"):
+        current_app.logger.info(
+            json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "event": "dl.forbidden",
+                    "mid": payload.get("mid"),
+                    "nonce": payload.get("nonce"),
+                }
+            )
+        )
+        return jsonify({"error": "forbidden"}), 403
+
+    if payload.get("typ") == "thumb":
+        if not path.startswith("thumbs/"):
+            return jsonify({"error": "forbidden"}), 403
+        rel = path[len("thumbs/") :]
+        base = current_app.config.get("FPV_NAS_THUMBS_DIR", "")
+    else:
+        if not path.startswith("playback/"):
+            return jsonify({"error": "forbidden"}), 403
+        rel = path[len("playback/") :]
+        base = current_app.config.get("FPV_NAS_PLAY_DIR", "")
+    abs_path = os.path.join(base, rel)
+    if not os.path.exists(abs_path):
+        current_app.logger.info(
+            json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "event": "dl.notfound",
+                    "mid": payload.get("mid"),
+                    "nonce": payload.get("nonce"),
+                }
+            )
+        )
+        return jsonify({"error": "not_found"}), 404
+
+    guessed = mimetypes.guess_type(abs_path)[0]
+    if guessed != ct:
+        return jsonify({"error": "forbidden"}), 403
+
+    size = os.path.getsize(abs_path)
+    cache_control = f"private, max-age={current_app.config.get('FPV_URL_TTL_THUMB' if payload.get('typ') == 'thumb' else 'FPV_URL_TTL_PLAYBACK', 600)}"
+    range_header = request.headers.get("Range")
+    if range_header:
+        m = re.match(r"bytes=(\d+)-(\d*)", range_header)
+        if m:
+            start = int(m.group(1))
+            end = int(m.group(2) or size - 1)
+            end = min(end, size - 1)
+            length = end - start + 1
+            with open(abs_path, "rb") as f:
+                f.seek(start)
+                data = f.read(length)
+            resp = current_app.response_class(data, 206, mimetype=ct, direct_passthrough=True)
+            resp.headers["Content-Range"] = f"bytes {start}-{end}/{size}"
+            resp.headers["Accept-Ranges"] = "bytes"
+            resp.headers["Content-Length"] = str(length)
+            resp.headers["Cache-Control"] = cache_control
+            current_app.logger.info(
+                json.dumps(
+                    {
+                        "ts": datetime.now(timezone.utc).isoformat(),
+                        "event": "dl.range",
+                        "mid": payload.get("mid"),
+                        "nonce": payload.get("nonce"),
+                        "start": start,
+                        "end": end,
+                    }
+                )
+            )
+            return resp
+
+    if request.method == "HEAD":
+        resp = current_app.response_class(b"", mimetype=ct)
+        resp.headers["Content-Length"] = str(size)
+        resp.headers["Accept-Ranges"] = "bytes"
+        resp.headers["Cache-Control"] = cache_control
+        return resp
+
+    with open(abs_path, "rb") as f:
+        data = f.read()
+    resp = current_app.response_class(data, mimetype=ct, direct_passthrough=True)
+    resp.headers["Content-Length"] = str(size)
+    resp.headers["Accept-Ranges"] = "bytes"
+    resp.headers["Cache-Control"] = cache_control
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "dl.success",
+                "mid": payload.get("mid"),
+                "nonce": payload.get("nonce"),
+            }
+        )
+    )
+    return resp

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -34,3 +34,10 @@ class Config:
     OAUTH_TOKEN_KEY_FILE = os.environ.get("OAUTH_TOKEN_KEY_FILE") or os.environ.get(
         "FPV_OAUTH_TOKEN_KEY_FILE"
     )
+
+    # Download URL signing
+    FPV_DL_SIGN_KEY = os.environ.get("FPV_DL_SIGN_KEY", "")
+    FPV_URL_TTL_THUMB = int(os.environ.get("FPV_URL_TTL_THUMB", "600"))
+    FPV_URL_TTL_PLAYBACK = int(os.environ.get("FPV_URL_TTL_PLAYBACK", "600"))
+    FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_DIR", "")
+    FPV_NAS_PLAY_DIR = os.environ.get("FPV_NAS_PLAY_DIR", "")


### PR DESCRIPTION
## Summary
- implement signed thumbnail and playback URL issuance with HMAC tokens
- stream media securely via `/api/dl` with token verification and Range support
- cover download URLs with extensive tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2abf80c988323acff9b1f89d0b384