### PR TITLE
Implement thumbnail generation worker and tests

### DIFF
--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -1,5 +1,6 @@
 """Celery-like task modules."""
 
 from .picker_import import picker_import
+from .thumbs_generate import thumbs_generate
 
-__all__ = ["picker_import"]
+__all__ = ["picker_import", "thumbs_generate"]

--- a/core/tasks/thumbs_generate.py
+++ b/core/tasks/thumbs_generate.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+"""Thumbnail generation task for media items.
+
+This module implements a condensed version of the specification in
+``T-WKR-2``.  The implementation focuses on the essential control flow so that
+works in tests without requiring a full Celery deployment or heavy multimedia
+dependencies.  The worker is idempotent and supports both image and video
+sources.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+import os
+
+from PIL import Image, ImageOps
+
+from core.models.photo_models import Media, MediaPlayback
+
+# Target thumbnail sizes (long side)
+SIZES = [256, 1024, 2048]
+
+
+@dataclass
+class _ThumbResult:
+    generated: List[int]
+    skipped: List[int]
+    notes: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _thumb_base_dir() -> Path:
+    """Return thumbnail base directory creating it if necessary."""
+    base = Path(os.environ.get("FPV_NAS_THUMBS_DIR", "/tmp/fpv_thumbs"))
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _orig_dir() -> Path:
+    return Path(os.environ.get("FPV_NAS_ORIG_DIR", "/tmp/fpv_orig"))
+
+
+def _play_dir() -> Path:
+    return Path(os.environ.get("FPV_NAS_PLAY_DIR", "/tmp/fpv_play"))
+
+
+# ---------------------------------------------------------------------------
+# Main task implementation
+# ---------------------------------------------------------------------------
+
+
+def thumbs_generate(*, media_id: int, force: bool = False) -> Dict[str, object]:
+    """Generate thumbnails for a media item.
+
+    The return value is a JSON serialisable dictionary with ``generated`` and
+    ``skipped`` size lists as described in the specification.
+    """
+
+    m = Media.query.get(media_id)
+    if not m:
+        return {"ok": False, "generated": [], "skipped": [], "notes": "not_found"}
+
+    if m.is_deleted:
+        # Deleted media are a successful no-op
+        return {"ok": True, "generated": [], "skipped": SIZES.copy(), "notes": None}
+
+    base_dir = _thumb_base_dir()
+    generated: List[int] = []
+    skipped: List[int] = []
+    notes: str | None = None
+
+    # ------------------------------------------------------------------
+    # Determine base image
+    # ------------------------------------------------------------------
+    if m.is_video:
+        pb = (
+            MediaPlayback.query.filter_by(
+                media_id=m.id, preset="std1080p", status="done"
+            )
+            .order_by(MediaPlayback.id.desc())
+            .first()
+        )
+        if not pb:
+            return {
+                "ok": True,
+                "generated": [],
+                "skipped": SIZES.copy(),
+                "notes": "playback not ready",
+            }
+
+        if pb.poster_rel_path:
+            poster_path = _play_dir() / pb.poster_rel_path
+            if not poster_path.exists():
+                return {
+                    "ok": True,
+                    "generated": [],
+                    "skipped": SIZES.copy(),
+                    "notes": "playback not ready",
+                }
+            img = Image.open(poster_path)
+            img = ImageOps.exif_transpose(img)
+        else:  # pragma: no cover - optional dependency path
+            video_path = _play_dir() / pb.rel_path
+            try:  # Use imageio if available
+                import imageio.v2 as imageio  # type: ignore
+
+                reader = imageio.get_reader(str(video_path))
+                meta = reader.get_meta_data()
+                fps = meta.get("fps", 1)
+                idx = int(fps * 1)
+                try:
+                    frame = reader.get_data(idx)
+                except Exception:
+                    frame = reader.get_data(0)
+                img = Image.fromarray(frame)
+            except Exception:
+                return {
+                    "ok": True,
+                    "generated": [],
+                    "skipped": SIZES.copy(),
+                    "notes": "playback not ready",
+                }
+        img = img.convert("RGB")
+        out_ext = ".jpg"
+        rel_name = Path(m.local_rel_path).with_suffix(out_ext)
+    else:
+        src_path = _orig_dir() / m.local_rel_path
+        if not src_path.exists():
+            return {
+                "ok": False,
+                "generated": [],
+                "skipped": [],
+                "notes": "source missing",
+            }
+        img = Image.open(src_path)
+        img = ImageOps.exif_transpose(img)
+        has_alpha = img.mode in ("RGBA", "LA") or (
+            img.mode == "P" and "transparency" in img.info
+        )
+        out_ext = ".png" if has_alpha else ".jpg"
+        img = img.convert("RGBA" if has_alpha else "RGB")
+        rel_name = Path(m.local_rel_path).with_suffix(out_ext)
+
+    # ------------------------------------------------------------------
+    # Generate thumbnails for each size
+    # ------------------------------------------------------------------
+    for size in SIZES:
+        dest = base_dir / str(size) / rel_name
+        if dest.exists() and not force:
+            skipped.append(size)
+            continue
+
+        long_side = max(img.size)
+        if long_side < size:
+            skipped.append(size)
+            continue
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        scale = size / float(long_side)
+        new_size = (int(img.size[0] * scale), int(img.size[1] * scale))
+        resized = img.resize(new_size, Image.Resampling.LANCZOS)
+        tmp = dest.with_suffix(dest.suffix + ".tmp")
+        if dest.suffix.lower() == ".jpg":
+            resized.save(tmp, "JPEG", quality=85, progressive=True)
+        else:
+            resized.save(tmp, "PNG")
+        tmp.replace(dest)
+        generated.append(size)
+
+    return {"ok": True, "generated": generated, "skipped": skipped, "notes": notes}

--- a/tests/test_thumbs_generate.py
+++ b/tests/test_thumbs_generate.py
@@ -1,0 +1,174 @@
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from core.tasks import thumbs_generate
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Create a minimal app with a temporary database and directories."""
+    db_path = tmp_path / "test.db"
+    orig = tmp_path / "orig"
+    play = tmp_path / "play"
+    thumbs = tmp_path / "thumbs"
+    orig.mkdir()
+    play.mkdir()
+    thumbs.mkdir()
+
+    env_keys = {
+        "SECRET_KEY": "test",
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "FPV_NAS_ORIG_DIR": str(orig),
+        "FPV_NAS_PLAY_DIR": str(play),
+        "FPV_NAS_THUMBS_DIR": str(thumbs),
+    }
+    prev_env = {k: os.environ.get(k) for k in env_keys}
+    os.environ.update(env_keys)
+
+    import importlib, sys
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    from webapp.extensions import db
+    from core.models.google_account import GoogleAccount
+
+    with app.app_context():
+        db.create_all()
+        acc = GoogleAccount(email="acc@example.com", scopes="", oauth_token_json="{}")
+        db.session.add(acc)
+        db.session.commit()
+
+    yield app
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+    for k, v in prev_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_media(app, *, rel_path: str, is_video: bool, width: int, height: int, **extra):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    with app.app_context():
+        m = Media(
+            google_media_id=rel_path,
+            account_id=1,
+            local_rel_path=rel_path,
+            bytes=1,
+            mime_type="video/mp4" if is_video else "image/jpeg",
+            width=width,
+            height=height,
+            shot_at=datetime(2025, 8, 18, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 8, 18, tzinfo=timezone.utc),
+            orientation=None,
+            is_video=is_video,
+            is_deleted=False,
+            has_playback=is_video,
+            **extra,
+        )
+        db.session.add(m)
+        db.session.commit()
+        return m.id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_image_generation(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    path = orig_dir / "2025/08/18/img.jpg"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (4032, 3024), color=(1, 2, 3))
+    exif = Image.Exif()
+    exif[274] = 6  # orientation
+    img.save(path, exif=exif)
+
+    media_id = _make_media(app, rel_path="2025/08/18/img.jpg", is_video=False, width=4032, height=3024)
+    with app.app_context():
+        res = thumbs_generate(media_id=media_id)
+    assert res == {"ok": True, "generated": [256, 1024, 2048], "skipped": [], "notes": None}
+
+    out = Path(os.environ["FPV_NAS_THUMBS_DIR"])
+    im256 = Image.open(out / "256/2025/08/18/img.jpg")
+    assert im256.size == (192, 256)  # orientation applied
+
+
+def test_image_skip_existing(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    path = orig_dir / "2025/08/18/img2.jpg"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (3000, 2000), color=0).save(path)
+    media_id = _make_media(app, rel_path="2025/08/18/img2.jpg", is_video=False, width=3000, height=2000)
+
+    # pre-create 1024 thumb
+    out = Path(os.environ["FPV_NAS_THUMBS_DIR"])
+    pre = out / "1024/2025/08/18/img2.jpg"
+    pre.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (1, 1)).save(pre)
+
+    with app.app_context():
+        res = thumbs_generate(media_id=media_id)
+    assert res["generated"] == [256, 2048]
+    assert res["skipped"] == [1024]
+
+
+def test_video_with_playback(app):
+    play_dir = Path(os.environ["FPV_NAS_PLAY_DIR"])
+    poster_rel = "2025/08/18/poster.jpg"
+    poster_path = play_dir / poster_rel
+    poster_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (3000, 2000), color=(10, 20, 30)).save(poster_path)
+
+    media_id = _make_media(app, rel_path="2025/08/18/video.mp4", is_video=True, width=3000, height=2000)
+
+    from webapp.extensions import db
+    from core.models.photo_models import MediaPlayback
+    with app.app_context():
+        pb = MediaPlayback(
+            media_id=media_id,
+            preset="std1080p",
+            rel_path="2025/08/18/video.mp4",
+            poster_rel_path=poster_rel,
+            status="done",
+        )
+        db.session.add(pb)
+        db.session.commit()
+
+    with app.app_context():
+        res = thumbs_generate(media_id=media_id)
+    assert res["generated"] == [256, 1024, 2048]
+    out = Path(os.environ["FPV_NAS_THUMBS_DIR"])
+    assert (out / "256/2025/08/18/video.jpg").exists()
+
+
+def test_video_playback_not_ready(app):
+    media_id = _make_media(app, rel_path="2025/08/18/vid2.mp4", is_video=True, width=3000, height=2000)
+    with app.app_context():
+        res = thumbs_generate(media_id=media_id)
+    assert res == {
+        "ok": True,
+        "generated": [],
+        "skipped": [256, 1024, 2048],
+        "notes": "playback not ready",
+    }


### PR DESCRIPTION
## Summary
- add `thumbs_generate` worker for creating image/video thumbnails
- export task in `core.tasks`
- test thumbnail generation for images, videos and edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2b7ccd16483238d7924f7b3995304