### PR TITLE
Add video transcode queue and worker tasks

### DIFF
--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -2,5 +2,11 @@
 
 from .picker_import import picker_import
 from .thumbs_generate import thumbs_generate
+from .transcode import transcode_queue_scan, transcode_worker
 
-__all__ = ["picker_import", "thumbs_generate"]
+__all__ = [
+    "picker_import",
+    "thumbs_generate",
+    "transcode_queue_scan",
+    "transcode_worker",
+]

--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+"""Video transcoding queue and worker tasks.
+
+This module implements a lightweight approximation of specification
+``T-WKR-3``.  It provides two callable functions that can be used in tests
+without requiring a full Celery deployment:
+
+``transcode_queue_scan``
+    Scan the ``media`` table for video items lacking playback files and
+    create/update :class:`MediaPlayback` rows with ``preset='std1080p'``.
+
+``transcode_worker``
+    Perform the actual ffmpeg based transcoding for a queued playback
+    record.  The worker is intentionally compact but validates the output
+    and updates the database in a manner compatible with the tests.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Dict, List
+
+from core.db import db
+from core.models.photo_models import Media, MediaPlayback
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _orig_dir() -> Path:
+    return Path(os.environ.get("FPV_NAS_ORIG_DIR", "/tmp/fpv_orig"))
+
+
+def _play_dir() -> Path:
+    return Path(os.environ.get("FPV_NAS_PLAY_DIR", "/tmp/fpv_play"))
+
+
+def _tmp_dir() -> Path:
+    tmp = Path(os.environ.get("FPV_TMP_DIR", "/tmp/fpv_tmp"))
+    tmp.mkdir(parents=True, exist_ok=True)
+    return tmp
+
+
+# ---------------------------------------------------------------------------
+# Queue scan
+# ---------------------------------------------------------------------------
+
+
+def transcode_queue_scan() -> Dict[str, object]:
+    """Detect media requiring playback generation.
+
+    The function follows the contract described in the specification and
+    returns a JSON serialisable dictionary with ``queued`` and ``skipped``
+    counts.  Only minimal error handling is implemented as required for
+    the unit tests.
+    """
+
+    queued = 0
+    skipped = 0
+    now = datetime.now(timezone.utc)
+
+    medias: List[Media] = (
+        Media.query.filter_by(is_video=True, has_playback=False, is_deleted=False)
+        .order_by(Media.id.desc())
+        .all()
+    )
+
+    for m in medias:
+        src_path = _orig_dir() / m.local_rel_path
+        if not src_path.exists():
+            skipped += 1
+            continue
+
+        pb = (
+            MediaPlayback.query.filter_by(media_id=m.id, preset="std1080p")
+            .order_by(MediaPlayback.id.desc())
+            .first()
+        )
+        if pb and pb.status in {"pending", "processing", "done"}:
+            skipped += 1
+            continue
+
+        rel_path = str(Path(m.local_rel_path).with_suffix(".mp4"))
+        if pb:
+            pb.status = "pending"
+            pb.rel_path = rel_path
+            pb.error_msg = None
+            pb.updated_at = now
+        else:
+            pb = MediaPlayback(
+                media_id=m.id,
+                preset="std1080p",
+                rel_path=rel_path,
+                status="pending",
+                created_at=now,
+                updated_at=now,
+            )
+            db.session.add(pb)
+        queued += 1
+
+    db.session.commit()
+    return {"queued": queued, "skipped": skipped, "notes": None}
+
+
+# ---------------------------------------------------------------------------
+# Worker implementation
+# ---------------------------------------------------------------------------
+
+
+def _probe(path: Path) -> Dict[str, object]:
+    """Return ffprobe information for *path* as a dictionary."""
+
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_streams",
+        "-show_format",
+        "-of",
+        "json",
+        str(path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip())
+    return json.loads(proc.stdout)
+
+
+@dataclass
+class _WorkResult:
+    ok: bool
+    duration_ms: int
+    width: int
+    height: int
+    note: str | None = None
+
+
+# --- main worker -----------------------------------------------------------
+
+
+def transcode_worker(*, media_playback_id: int) -> Dict[str, object]:
+    """Transcode a queued playback item using ffmpeg."""
+
+    pb = MediaPlayback.query.get(media_playback_id)
+    if not pb:
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "not_found",
+        }
+
+    if pb.status == "done":
+        return {
+            "ok": True,
+            "duration_ms": pb.duration_ms or 0,
+            "width": pb.width or 0,
+            "height": pb.height or 0,
+            "note": "already_done",
+        }
+
+    if pb.status == "processing":
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "already_running",
+        }
+
+    m = pb.media
+    src_path = _orig_dir() / m.local_rel_path
+    if not src_path.exists():
+        pb.status = "error"
+        pb.error_msg = "missing_input"
+        pb.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "missing_input",
+        }
+
+    pb.status = "processing"
+    pb.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    out_rel = pb.rel_path or str(Path(m.local_rel_path).with_suffix(".mp4"))
+    pb.rel_path = out_rel
+    tmp_dir = _tmp_dir()
+    tmp_out = tmp_dir / f"pb_{pb.id}.mp4"
+
+    crf = int(os.environ.get("FPV_TRANSCODE_CRF", "20"))
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(src_path),
+        "-vf",
+        "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease",
+        "-c:v",
+        "libx264",
+        "-crf",
+        str(crf),
+        "-preset",
+        "veryfast",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-ac",
+        "2",
+        "-movflags",
+        "+faststart",
+        str(tmp_out),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        pb.status = "error"
+        pb.error_msg = proc.stderr[-1000:]
+        pb.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "ffmpeg_error",
+        }
+
+    try:
+        info = _probe(tmp_out)
+    except Exception as exc:  # pragma: no cover - defensive
+        pb.status = "error"
+        pb.error_msg = str(exc)[:1000]
+        pb.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "probe_error",
+        }
+
+    vstreams = [s for s in info.get("streams", []) if s.get("codec_type") == "video"]
+    astreams = [s for s in info.get("streams", []) if s.get("codec_type") == "audio"]
+    if not vstreams or not astreams:
+        pb.status = "error"
+        pb.error_msg = "missing_stream"
+        pb.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        tmp_out.unlink(missing_ok=True)
+        return {
+            "ok": False,
+            "duration_ms": 0,
+            "width": 0,
+            "height": 0,
+            "note": "missing_stream",
+        }
+
+    v = vstreams[0]
+    width = int(v.get("width", 0))
+    height = int(v.get("height", 0))
+    duration = float(info.get("format", {}).get("duration", 0.0))
+    bitrate = int(info.get("format", {}).get("bit_rate", 0))
+
+    dest_path = _play_dir() / out_rel
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(tmp_out), dest_path)
+
+    pb.width = width
+    pb.height = height
+    pb.v_codec = "h264"
+    pb.a_codec = "aac"
+    pb.v_bitrate_kbps = int(bitrate / 1000) if bitrate else None
+    pb.duration_ms = int(duration * 1000)
+    pb.status = "done"
+    pb.updated_at = datetime.now(timezone.utc)
+    m.has_playback = True
+    db.session.commit()
+
+    return {
+        "ok": True,
+        "duration_ms": pb.duration_ms,
+        "width": width,
+        "height": height,
+        "note": None,
+    }

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -1,0 +1,292 @@
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from core.tasks import transcode_queue_scan, transcode_worker
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Create an application with temporary directories and database."""
+    db_path = tmp_path / "test.db"
+    orig = tmp_path / "orig"
+    play = tmp_path / "play"
+    tmpd = tmp_path / "tmp"
+    orig.mkdir()
+    play.mkdir()
+    tmpd.mkdir()
+
+    env_keys = {
+        "SECRET_KEY": "test",
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "FPV_NAS_ORIG_DIR": str(orig),
+        "FPV_NAS_PLAY_DIR": str(play),
+        "FPV_TMP_DIR": str(tmpd),
+    }
+    prev_env = {k: os.environ.get(k) for k in env_keys}
+    os.environ.update(env_keys)
+
+    import importlib, sys
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    from webapp.extensions import db
+    from core.models.google_account import GoogleAccount
+
+    with app.app_context():
+        db.create_all()
+        acc = GoogleAccount(email="acc@example.com", scopes="", oauth_token_json="{}")
+        db.session.add(acc)
+        db.session.commit()
+
+    yield app
+
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+    for k, v in prev_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_media(
+    app,
+    *,
+    rel_path: str,
+    width: int,
+    height: int,
+    has_playback: bool = False,
+    **extra,
+):
+    from webapp.extensions import db
+    from core.models.photo_models import Media
+
+    with app.app_context():
+        m = Media(
+            google_media_id=rel_path,
+            account_id=1,
+            local_rel_path=rel_path,
+            bytes=1,
+            mime_type="video/mp4",
+            width=width,
+            height=height,
+            shot_at=datetime(2025, 8, 18, tzinfo=timezone.utc),
+            imported_at=datetime(2025, 8, 18, tzinfo=timezone.utc),
+            orientation=None,
+            is_video=True,
+            is_deleted=False,
+            has_playback=has_playback,
+            **extra,
+        )
+        db.session.add(m)
+        db.session.commit()
+        return m.id
+
+
+def _make_playback(app, media_id: int, rel_path: str, status: str = "pending") -> int:
+    from webapp.extensions import db
+    from core.models.photo_models import MediaPlayback
+
+    with app.app_context():
+        pb = MediaPlayback(
+            media_id=media_id,
+            preset="std1080p",
+            rel_path=rel_path,
+            status=status,
+        )
+        db.session.add(pb)
+        db.session.commit()
+        return pb.id
+
+
+def _make_video(path: Path, size: str, audio: bool = True) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if audio:
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size={size}:rate=24",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:sample_rate=48000",
+            "-t",
+            "1",
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            str(path),
+        ]
+    else:
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size={size}:rate=24",
+            "-t",
+            "1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+# ---------------------------------------------------------------------------
+# Queue scan tests
+# ---------------------------------------------------------------------------
+
+
+def test_queue_scan_basic(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    for i in range(3):
+        p = orig_dir / f"2025/08/18/v{i}.mp4"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"0")
+        _make_media(app, rel_path=f"2025/08/18/v{i}.mp4", width=640, height=480)
+
+    with app.app_context():
+        res = transcode_queue_scan()
+        assert res == {"queued": 3, "skipped": 0, "notes": None}
+        from core.models.photo_models import MediaPlayback
+
+        assert MediaPlayback.query.count() == 3
+        pb = MediaPlayback.query.first()
+        assert pb.status == "pending"
+
+
+def test_queue_scan_skip_existing(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    names = ["a.mp4", "b.mp4", "c.mp4"]
+    ids = []
+    for name in names:
+        p = orig_dir / f"2025/08/18/{name}"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"0")
+        ids.append(_make_media(app, rel_path=f"2025/08/18/{name}", width=640, height=480))
+
+    from webapp.extensions import db
+    from core.models.photo_models import MediaPlayback
+    with app.app_context():
+        pb1 = MediaPlayback(media_id=ids[0], preset="std1080p", rel_path="2025/08/18/a.mp4", status="done")
+        pb2 = MediaPlayback(media_id=ids[1], preset="std1080p", rel_path="2025/08/18/b.mp4", status="pending")
+        pb3 = MediaPlayback(media_id=ids[2], preset="std1080p", rel_path="2025/08/18/c.mp4", status="error")
+        db.session.add_all([pb1, pb2, pb3])
+        db.session.commit()
+
+        res = transcode_queue_scan()
+        assert res == {"queued": 1, "skipped": 2, "notes": None}
+        assert MediaPlayback.query.get(pb3.id).status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Worker tests
+# ---------------------------------------------------------------------------
+
+
+def test_worker_transcode_basic(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    video_path = orig_dir / "2025/08/18/basic.mp4"
+    _make_video(video_path, "1280x720", audio=True)
+    media_id = _make_media(app, rel_path="2025/08/18/basic.mp4", width=1280, height=720)
+    pb_id = _make_playback(app, media_id, "2025/08/18/basic.mp4")
+
+    with app.app_context():
+        res = transcode_worker(media_playback_id=pb_id)
+        assert res["ok"] is True
+        from core.models.photo_models import MediaPlayback, Media
+
+        pb = MediaPlayback.query.get(pb_id)
+        assert pb.status == "done"
+        assert pb.width == 1280 and pb.height == 720
+        m = Media.query.get(media_id)
+        assert m.has_playback is True
+        out = Path(os.environ["FPV_NAS_PLAY_DIR"]) / pb.rel_path
+        assert out.exists()
+
+
+def test_worker_transcode_downscale(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    video_path = orig_dir / "2025/08/18/large.mp4"
+    _make_video(video_path, "3840x2160", audio=True)
+    media_id = _make_media(app, rel_path="2025/08/18/large.mp4", width=3840, height=2160)
+    pb_id = _make_playback(app, media_id, "2025/08/18/large.mp4")
+
+    with app.app_context():
+        res = transcode_worker(media_playback_id=pb_id)
+        assert res["ok"] is True
+        from core.models.photo_models import MediaPlayback
+
+        pb = MediaPlayback.query.get(pb_id)
+        assert pb.width == 1920 and pb.height == 1080
+
+
+def test_worker_missing_audio(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    video_path = orig_dir / "2025/08/18/noaudio.mp4"
+    _make_video(video_path, "640x480", audio=False)
+    media_id = _make_media(app, rel_path="2025/08/18/noaudio.mp4", width=640, height=480)
+    pb_id = _make_playback(app, media_id, "2025/08/18/noaudio.mp4")
+
+    with app.app_context():
+        res = transcode_worker(media_playback_id=pb_id)
+        assert res["ok"] is False
+        from core.models.photo_models import MediaPlayback
+
+        pb = MediaPlayback.query.get(pb_id)
+        assert pb.status == "error"
+        assert pb.error_msg == "missing_stream"
+
+
+def test_worker_missing_input(app):
+    media_id = _make_media(app, rel_path="2025/08/18/miss.mp4", width=640, height=480)
+    pb_id = _make_playback(app, media_id, "2025/08/18/miss.mp4")
+    with app.app_context():
+        res = transcode_worker(media_playback_id=pb_id)
+        assert res["ok"] is False
+        from core.models.photo_models import MediaPlayback
+
+        pb = MediaPlayback.query.get(pb_id)
+        assert pb.status == "error"
+        assert pb.error_msg == "missing_input"
+
+
+def test_worker_already_running(app):
+    orig_dir = Path(os.environ["FPV_NAS_ORIG_DIR"])
+    video_path = orig_dir / "2025/08/18/run.mp4"
+    _make_video(video_path, "640x480", audio=True)
+    media_id = _make_media(app, rel_path="2025/08/18/run.mp4", width=640, height=480)
+    pb_id = _make_playback(app, media_id, "2025/08/18/run.mp4", status="processing")
+    with app.app_context():
+        res = transcode_worker(media_playback_id=pb_id)
+        assert res["ok"] is False
+        assert res["note"] == "already_running"


### PR DESCRIPTION
## Summary
- implement transcode_queue_scan and transcode_worker for 1080p H.264/AAC playback generation
- integrate helpers and expose tasks
- add tests covering queue detection, transcoding, and failure cases

## Testing
- `pytest tests/test_transcode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2b9eb68d08323b54e3ca62983e617