### PR TITLE
Add placeholder photo view routes and templates

### DIFF
--- a/webapp/photo_view/routes.py
+++ b/webapp/photo_view/routes.py
@@ -1,6 +1,53 @@
+"""Routes for the photo view section.
+
+These endpoints currently render simple placeholder templates that will be
+expanded with full functionality later.  Having them in place allows the UI
+navigation to be wired up and provides a starting point for further
+implementation work.
+"""
+
+from flask import render_template
+
 from . import bp
 
+
 @bp.route("/")
-def index():
-    """Placeholder route for future photo view features."""
-    return ""
+def home():
+    """Photo view home page."""
+    return render_template("photo_view/home.html")
+
+
+@bp.route("/media")
+def media_list():
+    """List of media items with infinite scroll (placeholder)."""
+    return render_template("photo_view/media_list.html")
+
+
+@bp.route("/media/<int:media_id>")
+def media_detail(media_id: int):
+    """Detail view for a single media item."""
+    return render_template("photo_view/media_detail.html", media_id=media_id)
+
+
+@bp.route("/albums")
+def albums():
+    """List of albums."""
+    return render_template("photo_view/albums.html")
+
+
+@bp.route("/albums/<int:album_id>")
+def album_detail(album_id: int):
+    """Detail view for a single album."""
+    return render_template("photo_view/album_detail.html", album_id=album_id)
+
+
+@bp.route("/tags")
+def tags():
+    """List of tags."""
+    return render_template("photo_view/tags.html")
+
+
+@bp.route("/settings")
+def settings():
+    """Photo view settings page."""
+    return render_template("photo_view/settings.html")

--- a/webapp/photo_view/templates/album_detail.html
+++ b/webapp/photo_view/templates/album_detail.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Album Detail{% endblock %}
+{% block content %}
+<h1>Album Detail</h1>
+<p>Placeholder for album ID: {{ album_id }}</p>
+{% endblock %}

--- a/webapp/photo_view/templates/albums.html
+++ b/webapp/photo_view/templates/albums.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Albums{% endblock %}
+{% block content %}
+<h1>Albums</h1>
+<p>Placeholder for album list.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/home.html
+++ b/webapp/photo_view/templates/home.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Photo View{% endblock %}
+{% block content %}
+<h1>Photo View Home</h1>
+<p>Placeholder for recent photos and quick actions.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/media_detail.html
+++ b/webapp/photo_view/templates/media_detail.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Media Detail{% endblock %}
+{% block content %}
+<h1>Media Detail</h1>
+<p>Placeholder for media ID: {{ media_id }}</p>
+{% endblock %}

--- a/webapp/photo_view/templates/media_list.html
+++ b/webapp/photo_view/templates/media_list.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Media List{% endblock %}
+{% block content %}
+<h1>Media List</h1>
+<p>Placeholder for infinite scrolling media grid.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/settings.html
+++ b/webapp/photo_view/templates/settings.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Photo View Settings{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<p>Placeholder for photo view settings.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/tags.html
+++ b/webapp/photo_view/templates/tags.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Tags{% endblock %}
+{% block content %}
+<h1>Tags</h1>
+<p>Placeholder for tag list.</p>
+{% endblock %}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -24,6 +24,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('feature_x.dashboard') }}">{{ _('Dashboard') }}</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('photo_view.home') }}">{{ _('Photo View') }}</a>
+        </li>
       </ul>
       <ul class="navbar-nav">
         <li class="nav-item">


### PR DESCRIPTION
## Summary
- add placeholder routes and templates for photo view section
- hook photo view into main navigation

## Testing
- `pytest` *(fails: FileNotFoundError: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68a2bc4404808323823fa524b14c89d4