### PR TITLE
Add health check API endpoints

### DIFF
--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,0 +1,64 @@
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.fixture
+def app(tmp_path):
+    db_path = tmp_path / "test.db"
+    os.environ["SECRET_KEY"] = "test"
+    os.environ["DATABASE_URI"] = f"sqlite:///{db_path}"
+    thumbs = tmp_path / "thumbs"
+    play = tmp_path / "play"
+    thumbs.mkdir()
+    play.mkdir()
+    os.environ["FPV_NAS_THUMBS_DIR"] = str(thumbs)
+    os.environ["FPV_NAS_PLAY_DIR"] = str(play)
+
+    import importlib, sys
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+
+    app = create_app()
+    app.config.update(TESTING=True)
+    app.config["LAST_BEAT_AT"] = datetime.now(timezone.utc)
+
+    from webapp.extensions import db
+    with app.app_context():
+        db.create_all()
+
+    yield app
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_health_live(client):
+    resp = client.get("/api/health/live")
+    assert resp.status_code == 200
+    assert resp.json["status"] == "ok"
+
+
+def test_health_ready(client):
+    resp = client.get("/api/health/ready")
+    assert resp.status_code == 200
+    assert resp.json["status"] == "ok"
+
+
+def test_health_beat(client, app):
+    resp = client.get("/api/health/beat")
+    assert resp.status_code == 200
+    assert resp.json["lastBeatAt"] == app.config["LAST_BEAT_AT"].isoformat()
+    assert "GMT" in resp.json["serverTimeRFC1123"]
+

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -15,6 +15,7 @@ from flask_babel import gettext as _
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
+    app.config.setdefault("LAST_BEAT_AT", None)
 
     # 拡張初期化
     db.init_app(app)

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -1,3 +1,6 @@
 from flask import Blueprint
+
 bp = Blueprint("api", __name__, template_folder="templates")
+
 from . import routes  # noqa
+from . import health  # noqa

--- a/webapp/api/health.py
+++ b/webapp/api/health.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from email.utils import formatdate
+import os
+
+from flask import current_app, jsonify
+from sqlalchemy import text
+
+from . import bp
+from ..extensions import db
+
+
+@bp.get("/health/live")
+def health_live():
+    """Simple liveness probe."""
+    return jsonify({"status": "ok"}), 200
+
+
+@bp.get("/health/ready")
+def health_ready():
+    """Readiness probe checking database and NAS paths."""
+    ok = True
+    details = {}
+
+    try:
+        db.session.execute(text("SELECT 1"))
+        details["db"] = "ok"
+    except Exception:
+        ok = False
+        details["db"] = "error"
+
+    for key in ("FPV_NAS_THUMBS_DIR", "FPV_NAS_PLAY_DIR"):
+        path = current_app.config.get(key)
+        field = key.lower()
+        if path and os.path.exists(path):
+            details[field] = "ok"
+        else:
+            ok = False
+            details[field] = "missing"
+
+    redis_url = current_app.config.get("REDIS_URL")
+    if redis_url:
+        try:  # pragma: no cover - optional dependency
+            import redis
+
+            r = redis.from_url(redis_url)
+            r.ping()
+            details["redis"] = "ok"
+        except Exception:
+            ok = False
+            details["redis"] = "error"
+
+    status = 200 if ok else 503
+    details["status"] = "ok" if ok else "error"
+    return jsonify(details), status
+
+
+@bp.get("/health/beat")
+def health_beat():
+    """Return last beat timestamp and current server time."""
+    last = current_app.config.get("LAST_BEAT_AT")
+    return (
+        jsonify(
+            {
+                "lastBeatAt": last.isoformat() if isinstance(last, datetime) else None,
+                "serverTimeRFC1123": formatdate(usegmt=True),
+            }
+        ),
+        200,
+    )
+


### PR DESCRIPTION
## Summary
- implement `/api/health/live`, `/ready`, and `/beat` endpoints
- expose health routes via API blueprint and initialize beat timestamp
- cover health checks with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2bc011d148323945a347b3140b83c