### PR TITLE
Add placeholders for photo view admin interfaces

### DIFF
--- a/webapp/photo_view/routes.py
+++ b/webapp/photo_view/routes.py
@@ -8,6 +8,8 @@ implementation work.
 
 from flask import render_template
 
+from core.models.authz import require_roles
+
 from . import bp
 
 
@@ -51,3 +53,36 @@ def tags():
 def settings():
     """Photo view settings page."""
     return render_template("photo_view/settings.html")
+
+
+# --- Admin routes ---------------------------------------------------------
+
+
+@bp.route("/admin/settings")
+@require_roles("admin")
+def admin_settings():
+    """Placeholder admin settings page.
+
+    The actual UI will be implemented in later tasks.  Having this route in
+    place allows navigation and access control wiring to be verified.
+    """
+
+    return render_template("photo_view/admin/settings.html")
+
+
+@bp.route("/admin/exports")
+@require_roles("admin")
+def admin_exports():
+    """Placeholder admin exports listing page."""
+
+    return render_template("photo_view/admin/exports.html")
+
+
+@bp.route("/admin/exports/<int:export_id>")
+@require_roles("admin")
+def admin_export_detail(export_id: int):
+    """Placeholder admin export detail page."""
+
+    return render_template(
+        "photo_view/admin/export_detail.html", export_id=export_id
+    )

--- a/webapp/photo_view/templates/admin/export_detail.html
+++ b/webapp/photo_view/templates/admin/export_detail.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Photo View Export {{ export_id }}{% endblock %}
+{% block content %}
+<h1>Export {{ export_id }}</h1>
+<p>Placeholder for export detail.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/admin/exports.html
+++ b/webapp/photo_view/templates/admin/exports.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Photo View Admin Exports{% endblock %}
+{% block content %}
+<h1>Photo View Admin Exports</h1>
+<p>Placeholder for exports list.</p>
+{% endblock %}

--- a/webapp/photo_view/templates/admin/settings.html
+++ b/webapp/photo_view/templates/admin/settings.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Photo View Admin Settings{% endblock %}
+{% block content %}
+<h1>Photo View Admin Settings</h1>
+<p>Placeholder for admin settings UI.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide admin-only routes for photo view settings and exports pages
- add basic templates for admin settings, export list, and export detail views

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68a2be8220dc8323b65290476f871b47