### PR TITLE
Add picker callback handling and import storage

### DIFF
--- a/core/models/picker_import_item.py
+++ b/core/models/picker_import_item.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timezone
+
+from core.db import db
+
+BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+class PickerImportItem(db.Model):
+    __tablename__ = "picker_import_item"
+
+    id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    picker_session_id = db.Column(
+        BigInt, db.ForeignKey("picker_session.id"), nullable=False, index=True
+    )
+    media_item_id = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "picker_session_id", "media_item_id", name="uniq_picker_session_media"
+        ),
+    )

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -37,6 +37,7 @@ def create_app():
     from core.models import photo_models as _photo_models    # noqa: F401
     from core.models import job_sync as _job_sync    # noqa: F401
     from core.models import picker_session as _picker_session  # noqa: F401
+    from core.models import picker_import_item as _picker_import_item  # noqa: F401
 
 
     # Blueprint 登録


### PR DESCRIPTION
## Summary
- add `PickerImportItem` model for storing selected media IDs
- expose `/api/picker/session/<id>/callback` endpoint to record selections and mark session ready
- load stored selections during import and skip remote lookup when available

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c32c2aa0832381bb81aac5b60054