### PR TITLE
Persist application logs to database and surface server errors

### DIFF
--- a/core/db_log_handler.py
+++ b/core/db_log_handler.py
@@ -1,0 +1,26 @@
+import logging
+from sqlalchemy import insert
+
+from .db import db
+from .models.log import Log
+
+
+class DBLogHandler(logging.Handler):
+    """Logging handler that persists logs to the database."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            trace = None
+            if record.exc_info:
+                formatter = logging.Formatter()
+                trace = formatter.formatException(record.exc_info)
+            with db.engine.begin() as conn:
+                stmt = insert(Log).values(
+                    level=record.levelname,
+                    message=record.getMessage(),
+                    trace=trace,
+                    path=getattr(record, "path", None),
+                )
+                conn.execute(stmt)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add database log handler to capture application log records
- log HTTP 5xx responses and exceptions via Flask error/after_request hooks
- test that 500 and 502 responses are written to the log table

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68a2d85888348323be58929cb43e5526