### PR TITLE
Improve picker session error logs

### DIFF
--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -195,12 +195,13 @@ def api_picker_session_create():
         )
         token_data = token_res.json()
         if "access_token" not in token_data:
-            current_app.logger.info(
+            current_app.logger.error(
                 json.dumps(
                     {
                         "ts": datetime.now(timezone.utc).isoformat(),
                         "event": "picker.create.fail",
                         "account_id": account_id,
+                        "response": token_data,
                     }
                 )
             )
@@ -214,12 +215,13 @@ def api_picker_session_create():
                 401,
             )
     except Exception as e:
-        current_app.logger.info(
+        current_app.logger.exception(
             json.dumps(
                 {
                     "ts": datetime.now(timezone.utc).isoformat(),
                     "event": "picker.create.fail",
                     "account_id": account_id,
+                    "message": str(e),
                 }
             )
         )
@@ -238,12 +240,13 @@ def api_picker_session_create():
         picker_res.raise_for_status()
         picker_data = picker_res.json()
     except Exception as e:
-        current_app.logger.info(
+        current_app.logger.exception(
             json.dumps(
                 {
                     "ts": datetime.now(timezone.utc).isoformat(),
                     "event": "picker.create.fail",
                     "account_id": account_id,
+                    "message": str(e),
                 }
             )
         )


### PR DESCRIPTION
## Summary
- log token response when OAuth fails to return an access token
- log full exception details when OAuth or picker requests raise errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e6d9b7348323ac46e5322a8ccece