### PR TITLE
Save picker session ID for status tracking

### DIFF
--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -90,6 +90,8 @@ def test_create_ok(monkeypatch, client, app):
     assert data["pickerSessionId"] > 0
     assert data["sessionId"]
     assert data["pickerUri"]
+    with client.session_transaction() as sess:
+        assert sess["picker_session_id"] == data["pickerSessionId"]
 
 
 def test_create_default_account(monkeypatch, client, app):

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -258,6 +258,7 @@ def api_picker_session_create():
     ps.session_id = picker_data.get("sessionId") or picker_data.get("name")
     ps.picker_uri = picker_data.get("pickerUri")
     db.session.commit()
+    session["picker_session_id"] = ps.id
     current_app.logger.info(
         json.dumps(
             {


### PR DESCRIPTION
## Summary
- store picker session ID in Flask session when creating via API
- test session ID persistence after creation

## Testing
- `pytest tests/test_picker_session_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a41472ab788323821b8d7d697b89b6