### PR TITLE
Fix template variable naming for picker session

### DIFF
--- a/webapp/auth/templates/auth/picker.html
+++ b/webapp/auth/templates/auth/picker.html
@@ -11,8 +11,8 @@
     <a href="{{ url_for('photo_view.home', session_id=session_id) }}" target="_blank" rel="noopener" class="btn btn-secondary">{{ _('Open Photo View') }}</a>
 </p>
 <script>
-  const rawInterval = {{ (poll_interval or 0)|tojson }};
-  const sessionName = {{ session_name|tojson }};
+  const rawInterval = {{ poll_interval|default(0)|tojson }};
+  const sessionId = {{ session_name|tojson }};
   function parseInterval(v) {
     if (typeof v === 'string' && v.endsWith('s')) {
       return parseFloat(v) * 1000;
@@ -25,7 +25,7 @@
       await fetch('/api/picker/session/mediaItems', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: sessionName })
+        body: JSON.stringify({ sessionId })
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Summary
- ensure poll interval defaults to 0 via Jinja's default filter
- rename sessionName variable to sessionId and simplify JSON body

## Testing
- `pytest tests/test_picker_session_api.py::test_create_ok -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4910ed5ec832399f5c6b06c488c4d