### PR TITLE
Use query params for Photos Picker mediaItems API

### DIFF
--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -255,14 +255,14 @@ def api_picker_session_media_items():
         status = 502 if e.status_code >= 500 else 401
         return jsonify({"error": str(e)}), status
     headers = {"Authorization": f"Bearer {tokens.get('access_token')}"}
-    body = {"sessionId": session_id}
+    params = {"sessionId": session_id, "pageSize": 100}
     if cursor:
-        body["pageToken"] = cursor
+        params["pageToken"] = cursor
     try:
         res = log_requests_and_send(
             "GET",
             "https://photospicker.googleapis.com/v1/mediaItems",
-            json_data=body,
+            params=params,
             headers=headers,
             timeout=15,
         )

--- a/webapp/auth/utils.py
+++ b/webapp/auth/utils.py
@@ -15,7 +15,16 @@ class RefreshTokenError(Exception):
         self.status_code = status_code
 
 
-def log_requests_and_send(method, url, *, headers=None, data=None, json_data=None, timeout=10):
+def log_requests_and_send(
+    method,
+    url,
+    *,
+    headers=None,
+    params=None,
+    data=None,
+    json_data=None,
+    timeout=10,
+):
     """requestsリクエスト・レスポンスをlogに記録して送信する共通関数"""
     import json as _json
 
@@ -25,6 +34,7 @@ def log_requests_and_send(method, url, *, headers=None, data=None, json_data=Non
             {
                 "method": method,
                 "headers": dict(headers) if headers else None,
+                "params": params,
                 "data": data,
                 "json": json_data,
             },
@@ -35,7 +45,14 @@ def log_requests_and_send(method, url, *, headers=None, data=None, json_data=Non
 
     # 実リクエスト
     req_func = getattr(requests, method.lower())
-    res = req_func(url, headers=headers, data=data, json=json_data, timeout=timeout)
+    res = req_func(
+        url,
+        headers=headers,
+        params=params,
+        data=data,
+        json=json_data,
+        timeout=timeout,
+    )
 
     # 受信後ログ
     try:


### PR DESCRIPTION
## Summary
- support query parameters in `log_requests_and_send`
- send sessionId via query params when listing picker media items
- adjust tests for new GET request behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4abd5aa4c8323beb200cca473e7f4