### PR TITLE
Refactor media and picked item models

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -105,16 +105,32 @@ class MediaPlayback(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
 
-
-class PickedMediaItem(db.Model):
+class MediaItem(db.Model):
     id = db.Column(db.String(255), primary_key=True)
     type = db.Column(
-        db.Enum('TYPE_UNSPECIFIED', 'PHOTO', 'VIDEO', name='picked_media_item_type'),
+        db.Enum('TYPE_UNSPECIFIED', 'PHOTO', 'VIDEO', name='media_item_type'),
         nullable=False,
     )
-    base_url = db.Column(db.String(255))
     mime_type = db.Column(db.String(255))
     filename = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
+    media_file_metadata = db.relationship(
+        'MediaFileMetadata',
+        backref='media_item',
+        cascade='all, delete-orphan',
+        uselist=False,
+    )
+
+
+class PickedMediaItem(db.Model):
+    id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    picker_session_id = db.Column(
+        BigInt, db.ForeignKey('picker_session.id'), nullable=False
+    )
+    media_item_id = db.Column(
+        db.String(255), db.ForeignKey('media_item.id'), nullable=False
+    )
     status = db.Column(
         db.Enum(
             'pending', 'imported', 'dup', 'failed', 'expired', 'skipped',
@@ -124,19 +140,22 @@ class PickedMediaItem(db.Model):
         default='pending',
         server_default='pending',
     )
-    media_file_metadata = db.relationship(
-        'MediaFileMetadata',
-        backref='picked_media_item',
-        cascade='all, delete-orphan',
+    media_item = db.relationship(
+        'MediaItem',
+        backref=db.backref('picked_media_items', cascade='all, delete-orphan')
     )
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint('picker_session_id', 'media_item_id',
+                            name='uq_picked_media_item_session_media'),
+    )
 
 
 class MediaFileMetadata(db.Model):
     id = db.Column(BigInt, primary_key=True, autoincrement=True)
-    picked_media_item_id = db.Column(
-        db.String(255), db.ForeignKey('picked_media_item.id'), nullable=False, unique=True
+    media_item_id = db.Column(
+        db.String(255), db.ForeignKey('media_item.id'), nullable=False, unique=True
     )
     width = db.Column(db.Integer)
     height = db.Column(db.Integer)

--- a/core/models/picker_import_task.py
+++ b/core/models/picker_import_task.py
@@ -17,7 +17,7 @@ class PickerImportTask(db.Model):
         BigInt, db.ForeignKey("picker_session.id"), nullable=False
     )
     picked_media_item_id = db.Column(
-        db.String(255), db.ForeignKey("picked_media_item.id"), nullable=False
+        BigInt, db.ForeignKey("picked_media_item.id"), nullable=False
     )
 
     # 進捗とリトライ管理

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -414,12 +414,21 @@ def test_media_items_endpoint(monkeypatch, client, app):
     assert data["duplicates"] == 0
     assert data["nextCursor"] is None
 
-    from core.models.photo_models import PickedMediaItem
+    from core.models.photo_models import MediaItem, PickedMediaItem
+    from core.models.picker_session import PickerSession
     with app.app_context():
-        pmi1 = PickedMediaItem.query.get("m1")
-        pmi2 = PickedMediaItem.query.get("m2")
+        mi1 = MediaItem.query.get("m1")
+        mi2 = MediaItem.query.get("m2")
+        assert mi1 is not None and mi2 is not None
+        assert mi1.filename == "a.jpg"
+        ps = PickerSession.query.filter_by(session_id=session_name).first()
+        pmi1 = PickedMediaItem.query.filter_by(
+            picker_session_id=ps.id, media_item_id="m1"
+        ).first()
+        pmi2 = PickedMediaItem.query.filter_by(
+            picker_session_id=ps.id, media_item_id="m2"
+        ).first()
         assert pmi1 is not None and pmi2 is not None
-        assert pmi1.base_url == "https://base/1"
 
 
 def test_media_items_retry_on_429(monkeypatch, client, app):


### PR DESCRIPTION
## Summary
- split media item data into master `MediaItem`
- treat `PickedMediaItem` as join table linking sessions and media items
- adjust API and tests for new schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a56c83319483238e53027c8887494f