### PR TITLE
Support string session IDs for picker API routes

### DIFF
--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -175,13 +175,13 @@ def test_status_ok(monkeypatch, client, app):
     monkeypatch.setattr("requests.post", fake_post)
     # create session
     res = client.post("/api/picker/session", json={"account_id": 1})
-    ps_id = res.get_json()["pickerSessionId"]
+    session_id = res.get_json()["sessionId"]
 
     def fake_get(url, *a, **k):
         return FakeResp({"selectedMediaCount": 0})
 
     monkeypatch.setattr("requests.get", fake_get)
-    res = client.get(f"/api/picker/session/{ps_id}")
+    res = client.get(f"/api/picker/session/{session_id}")
     assert res.status_code == 200
     data = res.get_json()
     assert data["status"] == "pending"
@@ -190,7 +190,7 @@ def test_status_ok(monkeypatch, client, app):
 
 def test_status_not_found(monkeypatch, client, app):
     login(client, app)
-    res = client.get("/api/picker/session/999")
+    res = client.get("/api/picker/session/unknown")
     assert res.status_code == 404
 
 
@@ -295,9 +295,10 @@ def test_callback_stores_ids(monkeypatch, client, app):
     monkeypatch.setattr("requests.post", fake_post)
     res = client.post("/api/picker/session", json={"account_id": 1})
     ps_id = res.get_json()["pickerSessionId"]
+    session_id = res.get_json()["sessionId"]
 
     payload = {"mediaItemIds": ["m1", "m2"]}
-    res = client.post(f"/api/picker/session/{ps_id}/callback", json=payload)
+    res = client.post(f"/api/picker/session/{session_id}/callback", json=payload)
     assert res.status_code == 200
     data = res.get_json()
     assert data["count"] == 2
@@ -309,7 +310,7 @@ def test_callback_stores_ids(monkeypatch, client, app):
         assert ps.selected_count == 2
         assert ps.media_items_set is True
 
-    res = client.get(f"/api/picker/session/{ps_id}")
+    res = client.get(f"/api/picker/session/{session_id}")
     assert res.status_code == 200
     status = res.get_json()
     assert status["selectedCount"] == 2

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -160,10 +160,10 @@ def api_picker_session_create():
     )
 
 
-@bp.post("/picker/session/<int:picker_session_id>/callback")
-def api_picker_session_callback(picker_session_id):
+@bp.post("/picker/session/<path:session_id>/callback")
+def api_picker_session_callback(session_id):
     """Receive selected media item IDs from Google Photos Picker."""
-    ps = PickerSession.query.get(picker_session_id)
+    ps = PickerSession.query.filter_by(session_id=session_id).first()
     if not ps:
         return jsonify({"error": "not_found"}), 404
     data = request.get_json(silent=True) or {}
@@ -179,11 +179,11 @@ def api_picker_session_callback(picker_session_id):
     return jsonify({"result": "ok", "count": count})
 
 
-@bp.get("/picker/session/<int:picker_session_id>")
+@bp.get("/picker/session/<path:session_id>")
 @login_required
-def api_picker_session_status(picker_session_id):
+def api_picker_session_status(session_id):
     """Return status of a picker session."""
-    ps = PickerSession.query.get(picker_session_id)
+    ps = PickerSession.query.filter_by(session_id=session_id).first()
     if not ps:
         return jsonify({"error": "not_found"}), 404
     account = GoogleAccount.query.get(ps.account_id)
@@ -216,7 +216,7 @@ def api_picker_session_status(picker_session_id):
         json.dumps(
             {
                 "ts": datetime.now(timezone.utc).isoformat(),
-                "picker_session_id": picker_session_id,
+                "session_id": session_id,
                 "status": ps.status,
             }
         ),


### PR DESCRIPTION
## Summary
- allow `/picker/session/<session_id>` and callback route to accept string session identifiers
- query `PickerSession` by `session_id` instead of numeric id
- update tests to exercise string-based routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5788715c8832396b6a4a525a06282