### PR TITLE
Integrate media metadata into MediaItem

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -113,14 +113,16 @@ class MediaItem(db.Model):
     )
     mime_type = db.Column(db.String(255))
     filename = db.Column(db.String(255))
+    width = db.Column(db.Integer)
+    height = db.Column(db.Integer)
+    camera_make = db.Column(db.String(255))
+    camera_model = db.Column(db.String(255))
+    photo_metadata_id = db.Column(BigInt, db.ForeignKey('photo_metadata.id'))
+    video_metadata_id = db.Column(BigInt, db.ForeignKey('video_metadata.id'))
+    photo_metadata = db.relationship('PhotoMetadata', backref='media_item', uselist=False)
+    video_metadata = db.relationship('VideoMetadata', backref='media_item', uselist=False)
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
-    media_file_metadata = db.relationship(
-        'MediaFileMetadata',
-        backref='media_item',
-        cascade='all, delete-orphan',
-        uselist=False,
-    )
 
 
 class PickedMediaItem(db.Model):
@@ -150,21 +152,6 @@ class PickedMediaItem(db.Model):
         db.UniqueConstraint('picker_session_id', 'media_item_id',
                             name='uq_picked_media_item_session_media'),
     )
-
-
-class MediaFileMetadata(db.Model):
-    id = db.Column(BigInt, primary_key=True, autoincrement=True)
-    media_item_id = db.Column(
-        db.String(255), db.ForeignKey('media_item.id'), nullable=False, unique=True
-    )
-    width = db.Column(db.Integer)
-    height = db.Column(db.Integer)
-    camera_make = db.Column(db.String(255))
-    camera_model = db.Column(db.String(255))
-    photo_metadata_id = db.Column(BigInt, db.ForeignKey('photo_metadata.id'))
-    video_metadata_id = db.Column(BigInt, db.ForeignKey('video_metadata.id'))
-    photo_metadata = db.relationship('PhotoMetadata', backref='media_file_metadata', uselist=False)
-    video_metadata = db.relationship('VideoMetadata', backref='media_file_metadata', uselist=False)
 
 
 class PhotoMetadata(db.Model):

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -13,7 +13,6 @@ from core.models.picker_session import PickerSession
 from core.models.photo_models import (
     PickedMediaItem,
     MediaItem,
-    MediaFileMetadata,
     PhotoMetadata,
     VideoMetadata,
 )
@@ -324,10 +323,6 @@ def api_picker_session_media_items():
                         picker_session_id=ps.id, media_item_id=item_id, status="pending"
                     )
 
-                mf = MediaFileMetadata.query.filter_by(media_item_id=item_id).first()
-                if not mf:
-                    mf = MediaFileMetadata(media_item_id=item_id)
-
                 mf_dict = item.get("mediaFile")
                 if isinstance(mf_dict, dict):
                     mi.mime_type = mf_dict.get("mimeType")
@@ -340,46 +335,44 @@ def api_picker_session_media_items():
                 height = meta.get("height")
                 if width is not None:
                     try:
-                        mf.width = int(width)
+                        mi.width = int(width)
                     except Exception:
-                        mf.width = None
+                        mi.width = None
                 if height is not None:
                     try:
-                        mf.height = int(height)
+                        mi.height = int(height)
                     except Exception:
-                        mf.height = None
-                mf.camera_make = meta.get("cameraMake")
-                mf.camera_model = meta.get("cameraModel")
+                        mi.height = None
+                mi.camera_make = meta.get("cameraMake")
+                mi.camera_model = meta.get("cameraModel")
 
                 photo_meta = meta.get("photoMetadata") or {}
                 video_meta = meta.get("videoMetadata") or {}
 
                 if photo_meta:
-                    if mf.photo_metadata:
-                        pm = mf.photo_metadata
+                    if mi.photo_metadata:
+                        pm = mi.photo_metadata
                     else:
                         pm = PhotoMetadata()
                     pm.focal_length = photo_meta.get("focalLength")
                     pm.aperture_f_number = photo_meta.get("apertureFNumber")
                     pm.iso_equivalent = photo_meta.get("isoEquivalent")
                     pm.exposure_time = photo_meta.get("exposureTime")
-                    mf.photo_metadata = pm
+                    mi.photo_metadata = pm
                     mi.type = "PHOTO"
 
                 if video_meta:
-                    if mf.video_metadata:
-                        vm = mf.video_metadata
+                    if mi.video_metadata:
+                        vm = mi.video_metadata
                     else:
                         vm = VideoMetadata()
                     vm.fps = video_meta.get("fps")
                     vm.processing_status = video_meta.get("processingStatus")
-                    mf.video_metadata = vm
+                    mi.video_metadata = vm
                     mi.type = "VIDEO"
 
-                mi.media_file_metadata = mf
                 pmi.updated_at = datetime.now(timezone.utc)
                 db.session.add(mi)
-                db.session.add(mf)
                 db.session.add(pmi)
                 if is_dup:
                     dup += 1


### PR DESCRIPTION
## Summary
- merge MediaFileMetadata fields into MediaItem model
- adapt picker session API to use MediaItem fields directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5803d61f88323a0fc7d94f8b64e8d