### PR TITLE
picker_selection ステータス拡張と追跡フィールド追加

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -135,8 +135,8 @@ class PickedMediaItem(db.Model):
     )
     status = db.Column(
         db.Enum(
-            'pending', 'imported', 'dup', 'failed', 'expired', 'skipped',
-            name='picked_media_item_status'
+            'pending', 'enqueued', 'running', 'imported', 'dup',
+            'failed', 'expired', 'skipped', name='picked_media_item_status'
         ),
         nullable=False,
         default='pending',
@@ -147,6 +147,12 @@ class PickedMediaItem(db.Model):
         backref=db.backref('picked_media_items', cascade='all, delete-orphan')
     )
     create_time = db.Column(db.DateTime)
+    enqueued_at = db.Column(db.DateTime)
+    started_at = db.Column(db.DateTime)
+    finished_at = db.Column(db.DateTime)
+    attempts = db.Column(db.Integer, nullable=False, default=0, server_default='0')
+    base_url_fetched_at = db.Column(db.DateTime)
+    base_url_valid_until = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     __table_args__ = (

--- a/migrations/versions/f6b6320b86d4_picker_selection_updates.py
+++ b/migrations/versions/f6b6320b86d4_picker_selection_updates.py
@@ -1,0 +1,77 @@
+"""Add picker_selection tracking fields
+
+Revision ID: f6b6320b86d4
+Revises: 02a871f6064b
+Create Date: 2025-08-20 18:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f6b6320b86d4'
+down_revision = '02a871f6064b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('picked_media_item', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('enqueued_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('started_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('finished_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('attempts', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('base_url_fetched_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('base_url_valid_until', sa.DateTime(), nullable=True))
+
+        old_status = sa.Enum(
+            'pending', 'imported', 'dup', 'failed', 'expired', 'skipped',
+            name='picked_media_item_status'
+        )
+        new_status = sa.Enum(
+            'pending', 'enqueued', 'running', 'imported', 'dup', 'failed', 'expired', 'skipped',
+            name='picked_media_item_status'
+        )
+        batch_op.alter_column(
+            'status',
+            existing_type=old_status,
+            type_=new_status,
+            existing_nullable=False,
+            existing_server_default='pending'
+        )
+
+        batch_op.drop_constraint('uq_picked_media_item_session_media', type_='unique')
+        batch_op.create_unique_constraint('uq_picked_media_item_session_media', ['picker_session_id', 'media_item_id'])
+
+    op.execute("UPDATE picked_media_item SET status='pending'")
+
+
+def downgrade():
+    op.execute("UPDATE picked_media_item SET status='pending' WHERE status IN ('enqueued', 'running')")
+    with op.batch_alter_table('picked_media_item', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_picked_media_item_session_media', type_='unique')
+
+        new_status = sa.Enum(
+            'pending', 'enqueued', 'running', 'imported', 'dup', 'failed', 'expired', 'skipped',
+            name='picked_media_item_status'
+        )
+        old_status = sa.Enum(
+            'pending', 'imported', 'dup', 'failed', 'expired', 'skipped',
+            name='picked_media_item_status'
+        )
+        batch_op.alter_column(
+            'status',
+            existing_type=new_status,
+            type_=old_status,
+            existing_nullable=False,
+            existing_server_default='pending'
+        )
+
+        batch_op.drop_column('base_url_valid_until')
+        batch_op.drop_column('base_url_fetched_at')
+        batch_op.drop_column('attempts')
+        batch_op.drop_column('finished_at')
+        batch_op.drop_column('started_at')
+        batch_op.drop_column('enqueued_at')
+
+        batch_op.create_unique_constraint('uq_picked_media_item_session_media', ['picker_session_id', 'media_item_id'])


### PR DESCRIPTION
## Summary
- picker_selection(picked_media_item) にキュー処理の時刻や試行回数を保存する列を追加
- ステータスに `enqueued` と `running` を含め、既存データの status を `pending` にリセット
- `(picker_session_id, media_item_id)` のユニーク制約を維持し重複を防止

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7bf1875b08323a7b80f6852b061e4