### PR TITLE
Implement per-item picker import task

### DIFF
--- a/core/models/picker_import_task.py
+++ b/core/models/picker_import_task.py
@@ -1,0 +1,9 @@
+"""Dummy model used only for app initialisation in tests."""
+
+from core.db import db
+
+
+class PickerImportTask(db.Model):
+    __tablename__ = "picker_import_task"
+
+    id = db.Column(db.Integer, primary_key=True)

--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -1,6 +1,6 @@
 """Celery-like task modules."""
 
-from .picker_import import picker_import, enqueue_picker_import_item
+from .picker_import import picker_import, enqueue_picker_import_item, picker_import_item
 from .thumbs_generate import thumbs_generate
 from .transcode import transcode_queue_scan, transcode_worker
 
@@ -10,4 +10,5 @@ __all__ = [
     "thumbs_generate",
     "transcode_queue_scan",
     "transcode_worker",
+    "picker_import_item",
 ]

--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -1,0 +1,150 @@
+import os
+import hashlib
+from pathlib import Path
+
+import os
+import hashlib
+
+import pytest
+
+from core.tasks import picker_import_item
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Create a minimal app with temp dirs/database."""
+    db_path = tmp_path / "test.db"
+    tmp_dir = tmp_path / "tmp"
+    orig_dir = tmp_path / "orig"
+    tmp_dir.mkdir()
+    orig_dir.mkdir()
+
+    env = {
+        "SECRET_KEY": "test",
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "FPV_TMP_DIR": str(tmp_dir),
+        "FPV_NAS_ORIG_DIR": str(orig_dir),
+    }
+    prev = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+
+    import importlib, sys
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+    app = create_app()
+    app.config.update(TESTING=True)
+    from webapp.extensions import db
+    from core.models.google_account import GoogleAccount
+    with app.app_context():
+        db.create_all()
+        acc = GoogleAccount(email="acc@example.com", scopes="", oauth_token_json="{}")
+        db.session.add(acc)
+        db.session.commit()
+
+    yield app
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+    for k, v in prev.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _setup_item(app):
+    from webapp.extensions import db
+    from core.models.photo_models import MediaItem, PickedMediaItem
+    from core.models.picker_session import PickerSession
+
+    with app.app_context():
+        ps = PickerSession(account_id=1, status="pending")
+        db.session.add(ps)
+        mi = MediaItem(id="m1", mime_type="image/jpeg", filename="http://example/file", type="PHOTO")
+        db.session.add(mi)
+        db.session.flush()
+        pmi = PickedMediaItem(picker_session_id=ps.id, media_item_id="m1", status="enqueued")
+        db.session.add(pmi)
+        db.session.commit()
+        return ps.id, pmi.id
+
+
+def test_picker_import_item_imports(monkeypatch, app, tmp_path):
+    ps_id, pmi_id = _setup_item(app)
+
+    # fake download
+    import importlib
+    mod = importlib.import_module("core.tasks.picker_import")
+
+    content = b"hello"
+    sha = hashlib.sha256(content).hexdigest()
+
+    def fake_download(url, dest_dir):
+        path = dest_dir / "dl"
+        with open(path, "wb") as fh:
+            fh.write(content)
+        return mod.Downloaded(path, len(content), sha)
+
+    monkeypatch.setattr(mod, "_download", fake_download)
+
+    with app.app_context():
+        res = picker_import_item(selection_id=pmi_id, session_id=ps_id)
+        from core.models.photo_models import PickedMediaItem, Media
+
+        pmi = PickedMediaItem.query.get(pmi_id)
+        assert res["ok"] is True
+        assert pmi.status == "imported"
+        assert pmi.attempts == 1
+        assert pmi.finished_at is not None
+        assert Media.query.count() == 1
+
+
+def test_picker_import_item_dup(monkeypatch, app, tmp_path):
+    ps_id, pmi_id = _setup_item(app)
+
+    import importlib
+    mod = importlib.import_module("core.tasks.picker_import")
+    content = b"hello"
+    sha = hashlib.sha256(content).hexdigest()
+
+    def fake_download(url, dest_dir):
+        path = dest_dir / "dl"
+        with open(path, "wb") as fh:
+            fh.write(content)
+        return mod.Downloaded(path, len(content), sha)
+
+    monkeypatch.setattr(mod, "_download", fake_download)
+
+    # pre-create media with same hash
+    from core.models.photo_models import Media
+    from webapp.extensions import db
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        m = Media(
+            google_media_id="x",
+            account_id=1,
+            local_rel_path="x",
+            hash_sha256=sha,
+            bytes=len(content),
+            mime_type="image/jpeg",
+            width=None,
+            height=None,
+            duration_ms=None,
+            shot_at=datetime.now(timezone.utc),
+            imported_at=datetime.now(timezone.utc),
+            is_video=False,
+        )
+        db.session.add(m)
+        db.session.commit()
+
+        res = picker_import_item(selection_id=pmi_id, session_id=ps_id)
+        from core.models.photo_models import PickedMediaItem
+        pmi = PickedMediaItem.query.get(pmi_id)
+        assert res["ok"] is True
+        assert pmi.status == "dup"
+        assert Media.query.count() == 1

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -361,7 +361,7 @@ def test_media_items_endpoint(monkeypatch, client, app):
     calls = {"n": 0}
 
     def fake_get(url, *a, **k):
-        if url == "https://photospicker.googleapis.com/v1/sessions":
+        if url == f"https://photospicker.googleapis.com/v1/sessions/{session_name}":
             return FakeResp({"id": session_name, "mediaItemsSet": True})
         if url == "https://photospicker.googleapis.com/v1/mediaItems":
             params = k.get("params", {})
@@ -498,7 +498,7 @@ def test_media_items_retry_on_429(monkeypatch, client, app):
     ]
 
     def fake_get(url, *a, **k):
-        if url == "https://photospicker.googleapis.com/v1/sessions":
+        if url == f"https://photospicker.googleapis.com/v1/sessions/{session_name}":
             return FakeResp({"id": session_name, "mediaItemsSet": True})
         if url == "https://photospicker.googleapis.com/v1/mediaItems":
             return responses.pop(0)
@@ -581,7 +581,7 @@ def test_media_items_enqueue_and_skip_duplicate(monkeypatch, client, app):
         db.session.commit()
 
     def fake_get(url, *a, **k):
-        if url == "https://photospicker.googleapis.com/v1/sessions":
+        if url == f"https://photospicker.googleapis.com/v1/sessions/{session_name}":
             return FakeResp({"id": session_name, "mediaItemsSet": True})
         if url == "https://photospicker.googleapis.com/v1/mediaItems":
             return FakeResp(
@@ -689,7 +689,7 @@ def test_media_items_skip_duplicate_in_response(monkeypatch, client, app):
         db.session.commit()
 
     def fake_get(url, *a, **k):
-        if url == "https://photospicker.googleapis.com/v1/sessions":
+        if url == f"https://photospicker.googleapis.com/v1/sessions/{session_name}":
             return FakeResp({"id": session_name, "mediaItemsSet": True})
         if url == "https://photospicker.googleapis.com/v1/mediaItems":
             return FakeResp(


### PR DESCRIPTION
## Summary
- add `picker_import_item` task for handling individual picker selections
- ensure media item sessions are fetched via path parameters
- introduce dummy `PickerImportTask` model and tests

## Testing
- `pytest tests/test_picker_import_item.py::test_picker_import_item_imports -q`
- `pytest tests/test_picker_import_item.py::test_picker_import_item_dup -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e14f8b9c8323b98a95816ac6cf21