### PR TITLE
Celeryタスク拡充とPickerセッションのリファクタ

### DIFF
--- a/cli/src/celery/tasks.py
+++ b/cli/src/celery/tasks.py
@@ -1,8 +1,57 @@
+from pathlib import Path
 from .celery_app import celery
-import time
+from fpv.storage import download_to_tmp, sha256_of
+from fpv.config import PhotoNestConfig
+from core.tasks.thumbs_generate import thumbs_generate
+from core.tasks.transcode import transcode_queue_scan, transcode_worker
+
+
+def _download(url: str, tmp_dir: Path):
+    """Download *url* to *tmp_dir* using fpv.storage helpers."""
+    return download_to_tmp(url, tmp_dir)
+
+
+def _build_result(tmp_path: Path, size: int, ctype: str) -> dict:
+    """Build result dictionary including SHA-256 hash."""
+    return {
+        "path": str(tmp_path),
+        "bytes": size,
+        "sha256": sha256_of(tmp_path),
+        "content_type": ctype,
+    }
+
+
+class Downloader:
+    """Simple helper class to keep task code small."""
+
+    def __init__(self, tmp_dir: str | None = None) -> None:
+        cfg = PhotoNestConfig.from_env()
+        self.tmp_dir = Path(tmp_dir or cfg.tmp_dir)
+
+    def download(self, url: str) -> dict:
+        tmp_path, size, ctype = _download(url, self.tmp_dir)
+        return _build_result(tmp_path, size, ctype)
+
 
 @celery.task(bind=True)
-def dummy_long_task(self, x, y):
-    # 擬似的に長時間処理をする
-    time.sleep(5)
-    return {"result": x + y}
+def download_file(self, url: str, tmp_dir: str | None = None) -> dict:
+    """Celery task to download a URL to a temporary directory."""
+    return Downloader(tmp_dir).download(url)
+
+
+@celery.task(bind=True)
+def generate_thumbs(self, media_id: int, force: bool = False) -> dict:
+    """Celery task wrapper for thumbnail generation."""
+    return thumbs_generate(media_id=media_id, force=force)
+
+
+@celery.task(bind=True)
+def transcode_scan(self) -> dict:
+    """Celery task wrapper for transcode queue scanning."""
+    return transcode_queue_scan()
+
+
+@celery.task(bind=True)
+def transcode_media(self, media_playback_id: int) -> dict:
+    """Celery task wrapper for video transcoding."""
+    return transcode_worker(media_playback_id=media_playback_id)

--- a/cli/src/fpv/repo.py
+++ b/cli/src/fpv/repo.py
@@ -39,10 +39,17 @@ def get_active_accounts(engine: Engine, account_id: int | None = None):
     return rows
 
 
-def create_job(engine: Engine, *, account_id: int, target: str) -> int:
+def create_job(engine: Engine, *, account_id: int, target: str, session_id: int | None = None) -> int:
+    """Create a job_sync row and return its id.
+
+    CLI の同期処理では picker セッションに紐づかないため
+    ``session_id`` は常に 0 を入れておく。
+    ``JobSync.session_id`` は NOT NULL 制約があるため必須。
+    """
     stmt = insert(job_sync).values(
         account_id=account_id,
         target=target,
+        session_id=session_id or 0,
         status="running",
     )
     with engine.begin() as conn:

--- a/cli/src/fpv/sync.py
+++ b/cli/src/fpv/sync.py
@@ -24,6 +24,174 @@ def _parse_creation_time(s: str | None):
         return None
 
 
+def _process_item(
+    eng,
+    cfg: PhotoNestConfig,
+    aid: int,
+    item: Dict[str, Any],
+    trace: str,
+    job_id: int,
+    stats: Dict[str, Any],
+) -> None:
+    try:
+        mid = item.get("id")
+        mime = (item.get("mimeType") or "")
+        filename = item.get("filename") or f"{mid}"
+        meta_md = item.get("mediaMetadata") or {}
+        base_url = item.get("baseUrl")
+        if not base_url:
+            return
+
+        ext = (
+            ext_from_filename(filename)
+            or ext_from_mime(mime)
+            or ("mp4" if is_video_mime(mime) else "jpg")
+        )
+        dl_url = google.build_download_url(base_url, mime)
+        tmp_path, bytes_, ctype = download_to_tmp(dl_url, Path(cfg.tmp_dir))
+        h = sha256_of(tmp_path)
+        if media_exists_by_hash(eng, h):
+            log("sync.item.dup", trace=trace, account_id=aid, media_id=mid)
+            stats["dup"] += 1
+            update_job_stats(eng, job_id, dup=1)
+            tmp_path.unlink(missing_ok=True)
+            return
+
+        shot_at = _parse_creation_time(meta_md.get("creationTime"))
+        rel = decide_relpath(shot_at, "gphotos", h, ext)
+        abs_dst = Path(cfg.nas_orig_dir) / rel
+        atomic_move(tmp_path, abs_dst)
+
+        width = int(meta_md.get("width")) if meta_md.get("width") else None
+        height = int(meta_md.get("height")) if meta_md.get("height") else None
+        is_video = is_video_mime(mime) or ("video" in meta_md)
+
+        m_id = insert_media(
+            eng,
+            google_media_id=mid,
+            account_id=aid,
+            rel_path=rel,
+            sha256=h,
+            bytes_=bytes_,
+            mime=mime,
+            width=width,
+            height=height,
+            duration_ms=None,
+            shot_at_utc=shot_at,
+            is_video=is_video,
+        )
+
+        if "photo" in meta_md or meta_md:
+            upsert_exif(eng, m_id, meta_md)
+
+        if is_video:
+            rel_path = Path(rel)
+            parts = list(rel_path.parts)
+            if parts and parts[0] == "originals":
+                parts[0] = "playback"
+            play_rel = str(Path(*parts))
+            if not play_rel.endswith(".mp4"):
+                play_rel = play_rel.rsplit(".", 1)[0] + ".mp4"
+            upsert_media_playback_queue(eng, m_id, play_rel)
+
+        stats["new"] += 1
+        update_job_stats(eng, job_id, new=1)
+    except Exception as ie:
+        stats["failed"] += 1
+        update_job_stats(eng, job_id, failed=1)
+        log("sync.item.error", trace=trace, account_id=aid, error=str(ie))
+
+
+def _sync_account(
+    eng,
+    cfg: PhotoNestConfig,
+    acc: Dict[str, Any],
+    trace: str,
+    dry_run: bool,
+    page_size: int,
+    max_pages: int,
+) -> int:
+    aid, email, enc = int(acc["id"]), acc["email"], acc["oauth_token_json"]
+    log("sync.account.begin", trace=trace, account_id=aid, email=email, dry_run=dry_run)
+
+    job_id = create_job(eng, account_id=aid, target="google_photos")
+    stats: Dict[str, Any] = {"listed": 0, "new": 0, "dup": 0, "failed": 0}
+    status = "success"
+    failed = 0
+
+    try:
+        if dry_run:
+            for i in range(1, 4):
+                log("sync.dryrun.item", trace=trace, account_id=aid, idx=i)
+            stats["listed"] = 3
+        else:
+            token, meta = google.refresh_access_token(
+                enc,
+                cfg.oauth_key,
+                cfg.google_client_id,
+                cfg.google_client_secret,
+            )
+            log(
+                "sync.token.ok",
+                trace=trace,
+                account_id=aid,
+                expires_in=meta.get("expires_in", 0),
+            )
+
+            page: Optional[str] = None
+            pages_done = 0
+            while True:
+                if pages_done >= max_pages:
+                    break
+                try:
+                    resp = google.list_media_items_once(token, page_size=page_size, page_token=page)
+                except google.GoogleAPIError as ge:
+                    status = "failed"
+                    stats["failed"] += 1
+                    failed += 1
+                    log(
+                        "sync.list.error",
+                        trace=trace,
+                        account_id=aid,
+                        status=ge.status,
+                        message=str(ge),
+                    )
+                    break
+
+                items = resp.get("mediaItems") or []
+                next_token = resp.get("nextPageToken")
+                stats["listed"] += len(items)
+                update_job_stats(eng, job_id, listed=len(items))
+                save_pagination_cursor(eng, job_id, next_token)
+
+                if not items:
+                    break
+
+                for it in items:
+                    _process_item(eng, cfg, aid, it, trace, job_id, stats)
+
+                pages_done += 1
+                if not next_token:
+                    break
+                page = next_token
+
+    except google.ReauthRequired as e:
+        status = "failed"
+        failed += 1
+        stats["failed"] += 1
+        log("sync.account.reauth_required", trace=trace, account_id=aid, error=str(e))
+    except Exception as e:
+        status = "failed"
+        failed += 1
+        stats["failed"] += 1
+        log("sync.account.error", trace=trace, account_id=aid, error=str(e))
+    finally:
+        finalize_job(eng, job_id=job_id, account_id=aid, status=status, stats=stats)
+        log("sync.account.end", trace=trace, account_id=aid, status=status, stats=stats)
+
+    return failed
+
+
 def run_sync(
     all_accounts: bool = True,
     account_id: Optional[int] = None,
@@ -56,152 +224,8 @@ def run_sync(
         return 0
 
     overall_failed = 0
-
     for acc in accounts:
-        aid, email, enc = int(acc["id"]), acc["email"], acc["oauth_token_json"]
-        log("sync.account.begin", trace=trace, account_id=aid, email=email, dry_run=dry_run)
-
-        job_id = create_job(eng, account_id=aid, target="google_photos")
-        stats: Dict[str, Any] = {"listed": 0, "new": 0, "dup": 0, "failed": 0}
-        status = "success"
-
-        try:
-            if dry_run:
-                for i in range(1, 4):
-                    log("sync.dryrun.item", trace=trace, account_id=aid, idx=i)
-                stats["listed"] = 3
-            else:
-                token, meta = google.refresh_access_token(
-                    enc,
-                    cfg.oauth_key,
-                    cfg.google_client_id,
-                    cfg.google_client_secret,
-                )
-                log(
-                    "sync.token.ok",
-                    trace=trace,
-                    account_id=aid,
-                    expires_in=meta.get("expires_in", 0),
-                )
-
-                page: Optional[str] = None
-                pages_done = 0
-                while True:
-                    if pages_done >= max_pages:
-                        break
-                    try:
-                        resp = google.list_media_items_once(token, page_size=page_size, page_token=page)
-                    except google.GoogleAPIError as ge:
-                        status = "failed"
-                        stats["failed"] += 1
-                        overall_failed += 1
-                        log(
-                            "sync.list.error",
-                            trace=trace,
-                            account_id=aid,
-                            status=ge.status,
-                            message=str(ge),
-                        )
-                        break
-
-                    items = resp.get("mediaItems") or []
-                    next_token = resp.get("nextPageToken")
-                    stats["listed"] += len(items)
-                    update_job_stats(eng, job_id, listed=len(items))
-                    save_pagination_cursor(eng, job_id, next_token)
-
-                    if not items:
-                        break
-
-                    for it in items:
-                        try:
-                            mid = it.get("id")
-                            mime = (it.get("mimeType") or "")
-                            filename = it.get("filename") or f"{mid}"
-                            meta_md = it.get("mediaMetadata") or {}
-                            base_url = it.get("baseUrl")
-                            if not base_url:
-                                continue
-
-                            ext = (
-                                ext_from_filename(filename)
-                                or ext_from_mime(mime)
-                                or ("mp4" if is_video_mime(mime) else "jpg")
-                            )
-                            dl_url = google.build_download_url(base_url, mime)
-                            tmp_path, bytes_, ctype = download_to_tmp(dl_url, Path(cfg.tmp_dir))
-                            h = sha256_of(tmp_path)
-                            if media_exists_by_hash(eng, h):
-                                log("sync.item.dup", trace=trace, account_id=aid, media_id=mid)
-                                stats["dup"] += 1
-                                update_job_stats(eng, job_id, dup=1)
-                                tmp_path.unlink(missing_ok=True)
-                                continue
-
-                            shot_at = _parse_creation_time(meta_md.get("creationTime"))
-                            rel = decide_relpath(shot_at, "gphotos", h, ext)
-                            abs_dst = Path(cfg.nas_orig_dir) / rel
-                            atomic_move(tmp_path, abs_dst)
-
-                            width = int(meta_md.get("width")) if meta_md.get("width") else None
-                            height = int(meta_md.get("height")) if meta_md.get("height") else None
-                            is_video = is_video_mime(mime) or ("video" in meta_md)
-
-                            m_id = insert_media(
-                                eng,
-                                google_media_id=mid,
-                                account_id=aid,
-                                rel_path=rel,
-                                sha256=h,
-                                bytes_=bytes_,
-                                mime=mime,
-                                width=width,
-                                height=height,
-                                duration_ms=None,
-                                shot_at_utc=shot_at,
-                                is_video=is_video,
-                            )
-
-                            if "photo" in meta_md or meta_md:
-                                upsert_exif(eng, m_id, meta_md)
-
-                            if is_video:
-                                rel_path = Path(rel)
-                                parts = list(rel_path.parts)
-                                if parts and parts[0] == "originals":
-                                    parts[0] = "playback"
-                                play_rel = str(Path(*parts))
-                                if not play_rel.endswith(".mp4"):
-                                    play_rel = play_rel.rsplit(".", 1)[0] + ".mp4"
-                                upsert_media_playback_queue(eng, m_id, play_rel)
-
-                            stats["new"] += 1
-                            update_job_stats(eng, job_id, new=1)
-
-                        except Exception as ie:
-                            stats["failed"] += 1
-                            update_job_stats(eng, job_id, failed=1)
-                            log("sync.item.error", trace=trace, account_id=aid, error=str(ie))
-
-                    pages_done += 1
-                    if not next_token:
-                        break
-                    page = next_token
-
-        except google.ReauthRequired as e:
-            status = "failed"
-            overall_failed += 1
-            stats["failed"] += 1
-            log("sync.account.reauth_required", trace=trace, account_id=aid, error=str(e))
-        except Exception as e:
-            status = "failed"
-            overall_failed += 1
-            stats["failed"] += 1
-            log("sync.account.error", trace=trace, account_id=aid, error=str(e))
-        finally:
-            finalize_job(eng, job_id=job_id, account_id=aid, status=status, stats=stats)
-
-        log("sync.account.end", trace=trace, account_id=aid, status=status, stats=stats)
+        overall_failed += _sync_account(eng, cfg, acc, trace, dry_run, page_size, max_pages)
 
     log("sync.done", trace=trace, result=("partial" if overall_failed else "success"))
     return 1 if overall_failed else 0


### PR DESCRIPTION
## 概要
- Pickerセッションのインポート時ステータスを`importing`に戻し既存ロジックと整合
- `create_job`で`session_id`を明示的に設定しSQLiteでのNOT NULL制約違反を解消

## テスト
- `pytest -q -p no:warnings`

------
https://chatgpt.com/codex/tasks/task_e_68a80469d2108323a25fa95a69fe152b