### PR TITLE
Rename PickedMediaItem to PickerSelection with import metadata fields

### DIFF
--- a/migrations/versions/f1f22e95f3c7_picker_selection.py
+++ b/migrations/versions/f1f22e95f3c7_picker_selection.py
@@ -1,0 +1,40 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f1f22e95f3c7'
+down_revision = '02a871f6064b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table('picked_media_item', 'picker_selection')
+    with op.batch_alter_table('picker_selection') as batch:
+        batch.drop_constraint('uq_picked_media_item_session_media', type_='unique')
+        batch.alter_column('picker_session_id', new_column_name='session_id')
+        batch.alter_column('media_item_id', new_column_name='google_media_id')
+        batch.add_column(sa.Column('error_msg', sa.Text(), nullable=True))
+        batch.add_column(sa.Column('base_url', sa.Text(), nullable=True))
+        batch.add_column(sa.Column('locked_by', sa.String(length=255), nullable=True))
+        batch.add_column(sa.Column('lock_heartbeat_at', sa.DateTime(), nullable=True))
+        batch.add_column(sa.Column('last_transition_at', sa.DateTime(), nullable=True))
+        batch.create_unique_constraint('uq_picker_selection_session_media', ['session_id', 'google_media_id'])
+    op.create_index('idx_picker_selection_session_status', 'picker_selection', ['session_id', 'status'])
+    op.create_index('idx_picker_selection_status_lock', 'picker_selection', ['status', 'lock_heartbeat_at'])
+
+
+def downgrade():
+    op.drop_index('idx_picker_selection_status_lock', table_name='picker_selection')
+    op.drop_index('idx_picker_selection_session_status', table_name='picker_selection')
+    with op.batch_alter_table('picker_selection') as batch:
+        batch.drop_constraint('uq_picker_selection_session_media', type_='unique')
+        batch.drop_column('last_transition_at')
+        batch.drop_column('lock_heartbeat_at')
+        batch.drop_column('locked_by')
+        batch.drop_column('base_url')
+        batch.drop_column('error_msg')
+        batch.alter_column('google_media_id', new_column_name='media_item_id')
+        batch.alter_column('session_id', new_column_name='picker_session_id')
+        batch.create_unique_constraint('uq_picked_media_item_session_media', ['picker_session_id', 'media_item_id'])
+    op.rename_table('picker_selection', 'picked_media_item')

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -419,7 +419,7 @@ def test_media_items_endpoint(monkeypatch, client, app):
     assert data["duplicates"] == 0
     assert data["nextCursor"] is None
 
-    from core.models.photo_models import MediaItem, PickedMediaItem
+    from core.models.photo_models import MediaItem, PickerSelection
     from core.models.picker_session import PickerSession
     with app.app_context():
         mi1 = MediaItem.query.get("m1")
@@ -427,11 +427,11 @@ def test_media_items_endpoint(monkeypatch, client, app):
         assert mi1 is not None and mi2 is not None
         assert mi1.filename == "a.jpg"
         ps = PickerSession.query.filter_by(session_id=session_name).first()
-        pmi1 = PickedMediaItem.query.filter_by(
-            picker_session_id=ps.id, media_item_id="m1"
+        pmi1 = PickerSelection.query.filter_by(
+            session_id=ps.id, google_media_id="m1"
         ).first()
-        pmi2 = PickedMediaItem.query.filter_by(
-            picker_session_id=ps.id, media_item_id="m2"
+        pmi2 = PickerSelection.query.filter_by(
+            session_id=ps.id, google_media_id="m2"
         ).first()
         from datetime import datetime
         assert pmi1 is not None and pmi2 is not None
@@ -617,8 +617,8 @@ def test_media_items_enqueue_and_skip_duplicate(monkeypatch, client, app):
 
     def fake_enqueue(pmi_id):
         with app.app_context():
-            from core.models.photo_models import PickedMediaItem
-            pmi = PickedMediaItem.query.get(pmi_id)
+            from core.models.photo_models import PickerSelection
+            pmi = PickerSelection.query.get(pmi_id)
             assert pmi.status == "enqueued"
             assert pmi.enqueued_at is not None
         enqueued.append(pmi_id)
@@ -634,11 +634,11 @@ def test_media_items_enqueue_and_skip_duplicate(monkeypatch, client, app):
     assert data["saved"] == 1
     assert data["duplicates"] == 1
 
-    from core.models.photo_models import PickedMediaItem
+    from core.models.photo_models import PickerSelection
     with app.app_context():
         ps = PickerSession.query.filter_by(session_id=session_name).first()
-        pmi = PickedMediaItem.query.filter_by(
-            picker_session_id=ps.id, media_item_id="m1"
+        pmi = PickerSelection.query.filter_by(
+            session_id=ps.id, google_media_id="m1"
         ).first()
         assert pmi is not None
         assert pmi.status == "enqueued"
@@ -725,8 +725,8 @@ def test_media_items_skip_duplicate_in_response(monkeypatch, client, app):
 
     def fake_enqueue(pmi_id):
         with app.app_context():
-            from core.models.photo_models import PickedMediaItem
-            pmi = PickedMediaItem.query.get(pmi_id)
+            from core.models.photo_models import PickerSelection
+            pmi = PickerSelection.query.get(pmi_id)
             assert pmi.status == "enqueued"
         enqueued.append(pmi_id)
 
@@ -741,9 +741,9 @@ def test_media_items_skip_duplicate_in_response(monkeypatch, client, app):
     assert data["saved"] == 1
     assert data["duplicates"] == 1
 
-    from core.models.photo_models import PickedMediaItem
+    from core.models.photo_models import PickerSelection
     with app.app_context():
         ps = PickerSession.query.filter_by(session_id=session_name).first()
-        assert PickedMediaItem.query.filter_by(picker_session_id=ps.id).count() == 1
+        assert PickerSelection.query.filter_by(session_id=ps.id).count() == 1
 
     assert len(enqueued) == 1


### PR DESCRIPTION
## Summary
- rename PickedMediaItem model to PickerSelection
- track import metadata like error messages, base URLs and locks
- adjust picker import workflow and API, add migration and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8233046a48323a809ada38d4c4a9c