### PR TITLE
Track picker session progress and finalize imports

### DIFF
--- a/core/models/picker_session.py
+++ b/core/models/picker_session.py
@@ -17,10 +17,30 @@ class PickerSession(db.Model):
     polling_config_json = db.Column(db.Text, nullable=True)
     picking_config_json = db.Column(db.Text, nullable=True)
     media_items_set = db.Column(db.Boolean, nullable=True)
-    status = db.Column(db.String(20), nullable=False, default="pending")
+    status = db.Column(
+        db.Enum(
+            "pending",
+            "ready",
+            "processing",
+            "enqueued",
+            "importing",
+            "imported",
+            "canceled",
+            "expired",
+            "error",
+            "failed",
+            name="picker_session_status",
+        ),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+    )
     selected_count = db.Column(db.Integer, nullable=True)
     stats_json = db.Column(db.Text, nullable=True)
     last_polled_at = db.Column(db.DateTime, nullable=True)
+    last_progress_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=True
+    )
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )

--- a/migrations/versions/8c9e5f7f1b3a_picker_session_updates.py
+++ b/migrations/versions/8c9e5f7f1b3a_picker_session_updates.py
@@ -1,0 +1,41 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8c9e5f7f1b3a'
+down_revision = 'f1f22e95f3c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    status_enum = sa.Enum(
+        'pending', 'ready', 'processing', 'enqueued', 'importing', 'imported',
+        'canceled', 'expired', 'error', 'failed', name='picker_session_status'
+    )
+    status_enum.create(op.get_bind(), checkfirst=True)
+    with op.batch_alter_table('picker_session') as batch:
+        batch.add_column(sa.Column('last_progress_at', sa.DateTime(), nullable=True))
+        batch.alter_column(
+            'status',
+            existing_type=sa.String(length=20),
+            type_=status_enum,
+            existing_nullable=False,
+            server_default='pending',
+        )
+
+
+def downgrade():
+    status_enum = sa.Enum(
+        'pending', 'ready', 'processing', 'enqueued', 'importing', 'imported',
+        'canceled', 'expired', 'error', 'failed', name='picker_session_status'
+    )
+    with op.batch_alter_table('picker_session') as batch:
+        batch.alter_column(
+            'status',
+            existing_type=status_enum,
+            type_=sa.String(length=20),
+            existing_nullable=False,
+        )
+        batch.drop_column('last_progress_at')
+    status_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- add `last_progress_at` and enumerated statuses to picker sessions
- finalize picker sessions with counts and job sync update
- test session completion reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82704738883239867b50db2bbc615