### PR TITLE
Add JobSync status enum and numeric session import API

### DIFF
--- a/core/models/job_sync.py
+++ b/core/models/job_sync.py
@@ -4,6 +4,7 @@ from core.db import db
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
 
+
 class JobSync(db.Model):
     """Synchronization job record."""
 
@@ -12,11 +13,28 @@ class JobSync(db.Model):
     id = db.Column(BigInt, primary_key=True, autoincrement=True)
     target = db.Column(db.String(50), nullable=False)
     account_id = db.Column(BigInt, nullable=False)
-    session_id = db.Column(BigInt, nullable=False)
-    started_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    session_id = db.Column(
+        BigInt, db.ForeignKey("picker_session.id"), nullable=False
+    )
+    started_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
     finished_at = db.Column(db.DateTime, nullable=True)
-    status = db.Column(db.String(20), nullable=False, default="queued")
-    stats_json = db.Column(db.Text, nullable=False, default="{}")
+    status = db.Column(
+        db.Enum(
+            "queued",
+            "running",
+            "success",
+            "partial",
+            "failed",
+            "canceled",
+            name="job_sync_status",
+        ),
+        nullable=False,
+        default="queued",
+        server_default="queued",
+    )
+    stats_json = db.Column(db.Text, nullable=False, default="{}", server_default="{}")
 
 
 __all__ = ["JobSync"]

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -215,9 +215,8 @@ def test_import_enqueue_ok(monkeypatch, client, app):
     monkeypatch.setattr("requests.post", fake_post)
     res = client.post("/api/picker/session", json={"account_id": 1})
     ps_id = res.get_json()["pickerSessionId"]
-    session_name = res.get_json()["sessionId"]
 
-    res = client.post(f"/api/picker/session/{session_name}/import")
+    res = client.post(f"/api/picker/session/{ps_id}/import")
     assert res.status_code == 202
     data = res.get_json()
     assert data["enqueued"] is True
@@ -249,10 +248,9 @@ def test_import_idempotent(monkeypatch, client, app):
     monkeypatch.setattr("requests.post", fake_post)
     res = client.post("/api/picker/session", json={"account_id": 1})
     ps_id = res.get_json()["pickerSessionId"]
-    session_name = res.get_json()["sessionId"]
-    res = client.post(f"/api/picker/session/{session_name}/import")
+    res = client.post(f"/api/picker/session/{ps_id}/import")
     assert res.status_code == 202
-    res = client.post(f"/api/picker/session/{session_name}/import")
+    res = client.post(f"/api/picker/session/{ps_id}/import")
     assert res.status_code == 409
 
 

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -474,9 +474,9 @@ def api_picker_session_media_items():
         _release_media_items_lock(session_id, lock)
 
 
-@bp.post("/picker/session/<path:picker_session_id>/import")
+@bp.post("/picker/session/<int:picker_session_id>/import")
 @login_required
-def api_picker_session_import(picker_session_id):
+def api_picker_session_import(picker_session_id: int):
     """Enqueue import task for picker session.
 
     The frontend does not pass ``account_id`` in the request body, so the
@@ -488,7 +488,7 @@ def api_picker_session_import(picker_session_id):
     data = request.get_json(silent=True) or {}
     account_id_in = data.get("account_id")
 
-    ps = PickerSession.query.filter_by(session_id=picker_session_id).first()
+    ps = PickerSession.query.get(picker_session_id)
     if not ps or (account_id_in and ps.account_id != account_id_in):
         return jsonify({"error": "not_found"}), 404
 


### PR DESCRIPTION
## Summary
- use enum for JobSync.status and link session_id to picker_session
- add /api/picker/session/<id>/import endpoint that creates a queued JobSync row
- adjust tests for new import route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8289d880083238130a265442114d6