### PR TITLE
Implement queue and heartbeat for picker selections

### DIFF
--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -1,6 +1,11 @@
 """Celery-like task modules."""
 
-from .picker_import import picker_import, enqueue_picker_import_item, picker_import_item
+from .picker_import import (
+    picker_import,
+    enqueue_picker_import_item,
+    picker_import_item,
+    picker_import_queue_scan,
+)
 from .thumbs_generate import thumbs_generate
 from .transcode import transcode_queue_scan, transcode_worker
 
@@ -11,4 +16,5 @@ __all__ = [
     "transcode_queue_scan",
     "transcode_worker",
     "picker_import_item",
+    "picker_import_queue_scan",
 ]


### PR DESCRIPTION
## Summary
- add `picker_import_queue_scan` to publish enqueued selections
- atomically claim selections with lock/heartbeat in `picker_import_item`
- exercise queue scan and heartbeat in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a829beddcc8323be14a5a182cdaecc