### PR TITLE
feat: add audit logging and picker session summary endpoint

### DIFF
--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -5,6 +5,7 @@ from .picker_import import (
     enqueue_picker_import_item,
     picker_import_item,
     picker_import_queue_scan,
+    picker_import_scavenger,
 )
 from .thumbs_generate import thumbs_generate
 from .transcode import transcode_queue_scan, transcode_worker
@@ -17,4 +18,5 @@ __all__ = [
     "transcode_worker",
     "picker_import_item",
     "picker_import_queue_scan",
+    "picker_import_scavenger",
 ]


### PR DESCRIPTION
## Summary
- log JSON audits for picker item claim, heartbeat, completion and scavenger actions
- add scavenger to requeue stale selections and finalize failed ones
- provide `/api/picker/session/{id}` returning counts and job sync summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a832a653588323834eaa86b621f48f