### PR TITLE
refactor: simplify picker import task signature

### DIFF
--- a/cli/src/celery/tasks.py
+++ b/cli/src/celery/tasks.py
@@ -6,7 +6,7 @@ import hashlib
 import time
 import requests
 
-from core.tasks.picker_import import picker_import_watchdog
+from core.tasks.picker_import import picker_import_watchdog, picker_import_item
 
 
 def _save_content(path: Path, content: bytes) -> None:
@@ -42,6 +42,10 @@ def download_file(self, url: str, dest_dir: str) -> dict:
     return {"path": str(dest_path), "bytes": len(content), "sha256": sha}
 
 
+@celery.task(bind=True, name="picker_import.item")
+def picker_import_item_task(self, selection_id: int, session_id: int) -> dict:
+    """Run picker import for a single selection."""
+    return picker_import_item(selection_id=selection_id, session_id=session_id)
 
 
 @celery.task(name="picker_import.watchdog")
@@ -49,4 +53,9 @@ def picker_import_watchdog_task():
     return picker_import_watchdog()
 
 
-__all__ = ["dummy_long_task", "download_file", "picker_import_watchdog_task"]
+__all__ = [
+    "dummy_long_task",
+    "download_file",
+    "picker_import_item_task",
+    "picker_import_watchdog_task",
+]

--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -243,15 +243,15 @@ def test_picker_import_queue_scan(monkeypatch, app):
     import importlib
     mod = importlib.import_module("core.tasks.picker_import")
 
-    def fake_enqueue(selection_id):
-        called.append(selection_id)
+    def fake_enqueue(selection_id, session_id):
+        called.append((selection_id, session_id))
 
     monkeypatch.setattr(mod, "enqueue_picker_import_item", fake_enqueue)
 
     with app.app_context():
         res = picker_import_queue_scan()
         assert res["queued"] == 1
-        assert called == [pmi_id]
+        assert called == [(pmi_id, ps_id)]
 
 
 def test_picker_import_item_heartbeat(monkeypatch, app, tmp_path):

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -613,13 +613,13 @@ def test_media_items_enqueue_and_skip_duplicate(monkeypatch, client, app):
     enqueued = []
     import webapp.api.picker_session as ps_module
 
-    def fake_enqueue(pmi_id):
+    def fake_enqueue(pmi_id, sess_id):
         with app.app_context():
             from core.models.photo_models import PickerSelection
             pmi = PickerSelection.query.get(pmi_id)
             assert pmi.status == "enqueued"
             assert pmi.enqueued_at is not None
-        enqueued.append(pmi_id)
+        enqueued.append((pmi_id, sess_id))
 
     monkeypatch.setattr(ps_module, "enqueue_picker_import_item", fake_enqueue)
 
@@ -819,12 +819,12 @@ def test_media_items_skip_duplicate_in_response(monkeypatch, client, app):
     enqueued = []
     import webapp.api.picker_session as ps_module
 
-    def fake_enqueue(pmi_id):
+    def fake_enqueue(pmi_id, sess_id):
         with app.app_context():
             from core.models.photo_models import PickerSelection
             pmi = PickerSelection.query.get(pmi_id)
             assert pmi.status == "enqueued"
-        enqueued.append(pmi_id)
+        enqueued.append((pmi_id, sess_id))
 
     monkeypatch.setattr(ps_module, "enqueue_picker_import_item", fake_enqueue)
 

--- a/tests/test_picker_watchdog.py
+++ b/tests/test_picker_watchdog.py
@@ -140,7 +140,9 @@ def test_watchdog_republishes_stalled_enqueued(monkeypatch, app, caplog):
     mod = importlib.import_module("core.tasks.picker_import")
 
     called: list[int] = []
-    monkeypatch.setattr(mod, "enqueue_picker_import_item", lambda sid: called.append(sid))
+    monkeypatch.setattr(
+        mod, "enqueue_picker_import_item", lambda sid, sess: called.append(sid)
+    )
 
     from webapp.extensions import db
     from core.models.photo_models import PickerSelection

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -480,7 +480,7 @@ def api_picker_session_media_items():
             pmi.enqueued_at = now
         db.session.commit()
         for pmi in new_pmis:
-            enqueue_picker_import_item(pmi.id)
+            enqueue_picker_import_item(pmi.id, ps.id)
 
         return jsonify({"saved": saved, "duplicates": dup, "nextCursor": None})
     except Exception as e:


### PR DESCRIPTION
## Summary
- enqueue picker import jobs using `selection_id` and `session_id` only
- resolve OAuth tokens inside worker via DB lookup
- add Celery task wrapper for single-item imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa6b4e30c83238b2c1895b1056657