### PR TITLE
docs: add usage guide and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PhotoNest
 ## FlaskApp
 
+詳細な使用方法は [USAGE.md](USAGE.md) を参照してください。
+
 ### セットアップ
 
 ```bash
@@ -123,29 +125,4 @@ Configure via environment variables. Copy `.env.example` to `.env` (loaded autom
 cp .env.example .env
 # edit values
 ```
-
-Show and validate:
-
-```bash
-fpv config show                # display with masking
-fpv config check               # basic validation
-fpv config check --strict-path # also verify path existence
-```
-
-`FPV_OAUTH_KEY` references the existing `OAUTH_TOKEN_KEY` (set `FPV_OAUTH_KEY=${OAUTH_TOKEN_KEY}` in `.env`). Alternatively, specify `FPV_OAUTH_TOKEN_KEY_FILE` to load the key from a file (e.g. `FPV_OAUTH_TOKEN_KEY_FILE=${OAUTH_TOKEN_KEY_FILE}`). `OAUTH_TOKEN_KEY` should specify a 32-byte key in the form `base64:xxxxxxxxxx`.
-
-## Sync 実行（ダウンロード→保存）
-
-```bash
-# まずは1ページだけ、実ダウンロード
-fpv sync --no-dry-run --page-size 50 --max-pages 1
-
-# ページ数を増やしていく場合
-fpv sync --no-dry-run --page-size 100 --max-pages 5
-```
-
-- 既存重複は `hash_sha256` でスキップされます。
-- 保存先は `originals/YYYY/MM/DD/` 以下、ファイル名は `YYYYMMDD_HHMMSS_gphotos_<hash8>.<ext>`。
-- 動画は `media_playback` に `queued` で登録されます（変換は `fpv transcode` 側で処理）。
-- 途中状態は `job_sync.stats_json.cursor.nextPageToken` に保持され、再実行で続きから再開します。
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,73 @@
+# PhotoNest 使い方手順書
+
+## 1. 概要
+PhotoNest は Flask をベースにしたウェブアプリケーションで、Google フォト同期やサムネイル生成などの処理をバックグラウンドジョブ（Celery）で行う構成です。
+
+## 2. 必要環境
+- Python 3.10 以上
+- Redis（Celery の broker / backend 用）
+- `requirements.txt` に記載されたライブラリ
+
+## 3. セットアップ
+```bash
+pip install -r requirements.txt
+cp .env.example .env  # 必要に応じて編集
+python main.py        # 開発サーバーを起動
+```
+
+古い pip を使っている場合は先にアップデートします。
+```bash
+python -m pip install --upgrade pip
+```
+
+## 4. 開発サーバーの起動
+アプリケーションファクトリから Flask アプリを生成し、デバッグモードで起動します。
+```bash
+python main.py
+```
+
+## 5. 翻訳ファイルのコンパイル
+多言語対応のメッセージファイルを更新したら、次のコマンドでコンパイルします。
+```bash
+pybabel compile -d webapp/translations -f
+```
+
+## 6. 環境変数と設定
+`.env` をコピーして必要な値を設定します。
+```bash
+cp .env.example .env
+# 値を編集
+```
+主な設定項目（抜粋）:
+- `SECRET_KEY`: アプリケーションの秘密鍵
+- `DATABASE_URI`: SQLAlchemy の接続文字列
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`: Google OAuth
+- `OAUTH_TOKEN_KEY` または `OAUTH_TOKEN_KEY_FILE`: OAuth トークン暗号化用鍵
+
+## 7. データベースマイグレーション
+1. モデル変更後にマイグレーションファイルを作成  
+   ```bash
+   flask db migrate -m "変更内容のコメント"
+   ```
+2. マイグレーションを適用  
+   ```bash
+   flask db upgrade
+   ```
+
+## 8. Celery バックグラウンドジョブ
+定義済みタスクを実行するにはワーカーとスケジューラを起動します。
+```bash
+# ワーカー
+celery -A cli.src.celery.tasks worker --loglevel=info
+# スケジューラ (beat)
+celery -A cli.src.celery.tasks beat --loglevel=info
+```
+
+## 9. Google OAuth トークン暗号化
+`google_account.oauth_token_json` は AES-256-GCM で暗号化されます。`OAUTH_TOKEN_KEY`（Base64 形式 32 バイト）または鍵ファイルを `.env` で指定してください。
+
+## 10. テストの実行
+`pytest` を使用してユニットテストを実行できます。
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- add usage instructions in `USAGE.md`
- remove references to obsolete `fpv` CLI from README and link to new guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa8d5001c8323b80fb36ff30ae8d0