### PR TITLE
Add crypto service layer tests

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,38 @@
+import base64
+import os
+
+import pytest
+
+from core import crypto
+
+
+def _gen_key() -> str:
+    return base64.urlsafe_b64encode(os.urandom(32)).decode()
+
+
+def test_validate_oauth_key_valid():
+    key = _gen_key()
+    ok, msg = crypto.validate_oauth_key(key)
+    assert ok is True
+    assert msg == "base64(32bytes)"
+
+
+def test_validate_oauth_key_invalid_length():
+    bad_key = base64.urlsafe_b64encode(b'123').decode()
+    ok, msg = crypto.validate_oauth_key(bad_key)
+    assert ok is False
+    assert "invalid base64 length" in msg
+
+
+def test_encrypt_decrypt_round_trip(monkeypatch):
+    key = _gen_key()
+    monkeypatch.setenv("OAUTH_TOKEN_KEY", key)
+    token = crypto.encrypt("secret")
+    assert crypto.decrypt(token) == "secret"
+
+
+def test_encrypt_decrypt_legacy_format(monkeypatch):
+    key = _gen_key()
+    monkeypatch.setenv("OAUTH_TOKEN_KEY", key)
+    token = crypto.encrypt("data", envelope=False)
+    assert crypto.decrypt(token) == "data"


### PR DESCRIPTION
## Summary
- add unit tests for crypto key validation and AES-GCM encrypt/decrypt paths

## Testing
- `SECRET_KEY=dev DATABASE_URI=sqlite:///app.db flask --app main routes`
- `SECRET_KEY=dev pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afef5a2f74832383e0049879d4966c