### PR TITLE
Add logging for media items endpoint

### DIFF
--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -170,8 +170,30 @@ def api_picker_session_media_items():
     if not session_id or not isinstance(session_id, str):
         return jsonify({"error": "invalid_session"}), 400
     cursor = data.get("cursor")
+    current_app.logger.info(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "session_id": session_id,
+                "cursor": cursor,
+            }
+        ),
+        extra={"event": "picker.mediaItems.begin"},
+    )
     try:
         payload, status = PickerSessionService.media_items(session_id, cursor)
+        current_app.logger.info(
+            json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "session_id": session_id,
+                    "saved": payload.get("saved"),
+                    "duplicates": payload.get("duplicates"),
+                    "status": status,
+                }
+            ),
+            extra={"event": "picker.mediaItems.success"},
+        )
         return jsonify(payload), status
     except Exception as e:
         current_app.logger.error(


### PR DESCRIPTION
## Summary
- add begin/end logs for the media items fetch API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affe692634832390a562d5f02d49c1