### PR TITLE
Add picker import status viewer

### DIFF
--- a/tests/test_picker_session_selections.py
+++ b/tests/test_picker_session_selections.py
@@ -1,0 +1,78 @@
+import os
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def app(tmp_path):
+    db_path = tmp_path / "test.db"
+    tmp_dir = tmp_path / "tmp"
+    orig_dir = tmp_path / "orig"
+    tmp_dir.mkdir()
+    orig_dir.mkdir()
+    env = {
+        "SECRET_KEY": "test",
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "FPV_TMP_DIR": str(tmp_dir),
+        "FPV_NAS_ORIG_DIR": str(orig_dir),
+    }
+    prev = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+    app = create_app()
+    app.config.update(TESTING=True)
+    from webapp.extensions import db
+    from core.models.google_account import GoogleAccount
+    from core.models.user import User
+    with app.app_context():
+        db.create_all()
+        acc = GoogleAccount(email="acc@example.com", scopes="", oauth_token_json="{}")
+        user = User(email="u@example.com", password_hash="x")
+        db.session.add_all([acc, user])
+        db.session.commit()
+    yield app
+    del sys.modules["webapp.config"]
+    del sys.modules["webapp"]
+    for k, v in prev.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _create_selection(app):
+    from webapp.extensions import db
+    from core.models.photo_models import MediaItem, PickerSelection
+    from core.models.picker_session import PickerSession
+    with app.app_context():
+        ps = PickerSession(account_id=1, status="pending")
+        db.session.add(ps)
+        mi = MediaItem(id="m1", mime_type="image/jpeg", filename="a.jpg", type="PHOTO")
+        db.session.add(mi)
+        db.session.flush()
+        sel = PickerSelection(session_id=ps.id, google_media_id="m1", status="pending")
+        db.session.add(sel)
+        db.session.commit()
+        return ps.id
+
+
+def test_picker_session_selections_endpoint(app):
+    ps_id = _create_selection(app)
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = "1"
+        sess["_fresh"] = True
+    resp = client.get(f"/api/picker/session/{ps_id}/selections")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["counts"]["pending"] == 1
+    assert data["selections"][0]["filename"] == "a.jpg"

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -133,6 +133,17 @@ def api_picker_session_summary(picker_session_id):
     return jsonify({"countsByStatus": counts, "jobSync": job_summary})
 
 
+@bp.get("/picker/session/<int:picker_session_id>/selections")
+@login_required
+def api_picker_session_selections(picker_session_id: int):
+    """Return detailed picker selection list for a session."""
+    ps = PickerSession.query.get(picker_session_id)
+    if not ps:
+        return jsonify({"error": "not_found"}), 404
+    payload = PickerSessionService.selection_details(ps)
+    return jsonify(payload)
+
+
 @bp.get("/picker/session/<string:session_id>")
 @login_required
 def api_picker_session_status(session_id):

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -13,6 +13,22 @@
 
 <div id="import-status" class="mt-3" aria-live="polite"></div>
 
+<div class="mt-4">
+  <h2>{{ _('Selected Files') }}</h2>
+  <div id="selection-counts" class="mb-2"></div>
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th>{{ _('File') }}</th>
+        <th>{{ _('Status') }}</th>
+        <th>{{ _('Attempts') }}</th>
+        <th>{{ _('Error') }}</th>
+      </tr>
+    </thead>
+    <tbody id="selection-body"></tbody>
+  </table>
+</div>
+
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   // クエリパラメータからsession_idを取得
@@ -28,6 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   const importBtn = document.getElementById('btn-import-start');
   const statusEl = document.getElementById('import-status');
+  const selectionBody = document.getElementById('selection-body');
+  const countsEl = document.getElementById('selection-counts');
 
   // pickerSessionId が無い場合はボタンを無効化
   if (!pickerSessionId) {
@@ -87,6 +105,29 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  async function refreshSelections() {
+    try {
+      const resp = await fetch(`/api/picker/session/${encodeURIComponent(pickerSessionId)}/selections`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      selectionBody.innerHTML = '';
+      data.selections.forEach(sel => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${sel.filename || sel.googleMediaId}</td>` +
+                        `<td>${sel.status}</td>` +
+                        `<td>${sel.attempts}</td>` +
+                        `<td>${sel.error || ''}</td>`;
+        selectionBody.appendChild(tr);
+      });
+      countsEl.textContent = Object.entries(data.counts).map(([k,v]) => `${k}: ${v}`).join(', ');
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  setInterval(refreshSelections, 3000);
+  refreshSelections();
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expose detailed picker selection info via `/api/picker/session/<id>/selections`
- show selected file list with live status updates in photo view UI
- test picker selection status API

## Testing
- `pytest tests/test_picker_session_selections.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b021ea5cd4832394571568afdf0b71