### PR TITLE
Add media tag management and search features

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,6 +89,7 @@ python scripts/seed_master_data.py
 - `album:edit` - アルバム編集
 - `album:view` - アルバム閲覧
 - `media:view` - メディア閲覧
+- `media:tag-manage` - メディアのタグ管理
 - `permission:manage` - 権限管理
 - `role:manage` - ロール管理
 - `system:manage` - システム管理

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -49,7 +49,8 @@ def seed_permissions():
         {'id': 10, 'code': 'system:manage'},
         {'id': 11, 'code': 'wiki:admin'},
         {'id': 12, 'code': 'wiki:read'},
-        {'id': 13, 'code': 'wiki:write'}
+        {'id': 13, 'code': 'wiki:write'},
+        {'id': 14, 'code': 'media:tag-manage'},
     ]
     
     for perm_data in permissions_data:
@@ -68,9 +69,9 @@ def seed_role_permissions():
         # admin (role_id=1) - all permissions
         (1, 1), (1, 2), (1, 3), (1, 4), (1, 5),
         (1, 6), (1, 7), (1, 8), (1, 9), (1, 10),
-        (1, 11), (1, 12), (1, 13),
+        (1, 11), (1, 12), (1, 13), (1, 14),
         # manager (role_id=2) - limited permissions
-        (2, 1), (2, 4), (2, 5), (2, 6), (2, 7),
+        (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14),
         # member (role_id=3) - view only
         (3, 6), (3, 7)
     ]

--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -117,7 +117,103 @@
     text-align: right;
     word-break: break-word;
   }
-  
+
+  .tag-chip-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  #media-tags {
+    min-height: 32px;
+  }
+
+  #media-tags.empty::before {
+    content: attr(data-empty-text);
+    color: #adb5bd;
+    font-size: 0.85rem;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    background: #e7f1ff;
+    color: #0d6efd;
+    border-radius: 999px;
+    font-size: 0.85rem;
+  }
+
+  .tag-chip .tag-attr {
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+
+  .tag-chip-remove {
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+  }
+
+  .tag-chip-remove:hover {
+    color: #084298;
+  }
+
+  .tag-editor {
+    margin-top: 12px;
+    position: relative;
+  }
+
+  .tag-editor-input {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  #tag-manage-input {
+    flex: 1 1 240px;
+    min-width: 200px;
+  }
+
+  #tag-attr-select {
+    width: auto;
+  }
+
+  .tag-suggestions {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    max-height: 220px;
+    overflow-y: auto;
+    display: none;
+    z-index: 20;
+  }
+
+  .tag-suggestions.visible {
+    display: block;
+  }
+
+  .tag-suggestion-item {
+    padding: 8px 12px;
+    cursor: pointer;
+  }
+
+  .tag-suggestion-item:hover {
+    background: #f1f3f5;
+  }
+
   .loading-overlay {
     position: absolute;
     top: 0;
@@ -187,14 +283,33 @@
           <!-- 基本情報がここに表示されます -->
         </div>
       </div>
-      
+
       <div class="info-section">
         <h5>{{ _('Technical Details') }}</h5>
         <div id="technical-info">
           <!-- 技術情報がここに表示されます -->
         </div>
       </div>
-      
+
+      <div class="info-section">
+        <h5>{{ _('Tags') }}</h5>
+        <div id="media-tags" class="tag-chip-container empty" data-empty-text="{{ _('No tags assigned') }}"></div>
+        {% if current_user.can('media:tag-manage') %}
+        <div id="tag-editor" class="tag-editor">
+          <div class="tag-editor-input">
+            <input type="text" id="tag-manage-input" class="form-control form-control-sm" placeholder="{{ _('Search tags...') }}" autocomplete="off">
+            <select id="tag-attr-select" class="form-select form-select-sm">
+              <option value="person">{{ _('Person') }}</option>
+              <option value="place">{{ _('Place') }}</option>
+              <option value="thing" selected>{{ _('Thing') }}</option>
+            </select>
+            <button class="btn btn-sm btn-outline-primary" id="create-tag-btn">{{ _('Create and add') }}</button>
+          </div>
+          <div id="tag-manage-suggestions" class="tag-suggestions"></div>
+        </div>
+        {% endif %}
+      </div>
+
       <div class="info-section" id="exif-section" style="display: none;">
         <h5>{{ _('EXIF Data') }}</h5>
         <div id="exif-info">
@@ -219,9 +334,33 @@ document.addEventListener('DOMContentLoaded', () => {
   const technicalInfo = document.getElementById('technical-info');
   const exifInfo = document.getElementById('exif-info');
   const exifSection = document.getElementById('exif-section');
-  
+  const mediaTagsContainer = document.getElementById('media-tags');
+  const tagEditorWrapper = document.getElementById('tag-editor');
+  const tagManageInput = document.getElementById('tag-manage-input');
+  const tagAttrSelect = document.getElementById('tag-attr-select');
+  const tagManageSuggestions = document.getElementById('tag-manage-suggestions');
+  const createTagBtn = document.getElementById('create-tag-btn');
+
   let currentMedia = null;
   let isZoomed = false;
+  let currentTags = [];
+  let tagEditorTimeout = null;
+
+  const canManageTags = {{ 'true' if current_user.can('media:tag-manage') else 'false' }};
+  const tagAttrLabels = {
+    person: '{{ _('Person') }}',
+    place: '{{ _('Place') }}',
+    thing: '{{ _('Thing') }}'
+  };
+  const noTagsAssignedText = '{{ _('No tags assigned') }}';
+  const noTagSuggestionsText = '{{ _('No tags found') }}';
+  const tagUpdateErrorText = '{{ _('Failed to update tags.') }}';
+  const tagCreateErrorText = '{{ _('Failed to create tag.') }}';
+  const removeTagLabel = '{{ _('Remove') }}';
+
+  if (mediaTagsContainer && !mediaTagsContainer.dataset.emptyText) {
+    mediaTagsContainer.dataset.emptyText = noTagsAssignedText;
+  }
 
   // メディア詳細を読み込み
   async function loadMediaDetail() {
@@ -236,7 +375,9 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('Media data loaded:', currentMedia);
       displayMedia(currentMedia);
       displayMediaInfo(currentMedia);
-      
+      currentTags = Array.isArray(currentMedia.tags) ? currentMedia.tags : [];
+      renderMediaTags();
+
     } catch (error) {
       console.error('Error loading media:', error);
       loadingOverlay.style.display = 'none';
@@ -356,14 +497,235 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
     `;
   }
-  
+
+  function renderMediaTags() {
+    if (!mediaTagsContainer) {
+      return;
+    }
+
+    mediaTagsContainer.innerHTML = '';
+    if (!currentTags || currentTags.length === 0) {
+      mediaTagsContainer.classList.add('empty');
+      return;
+    }
+
+    mediaTagsContainer.classList.remove('empty');
+    currentTags.forEach((tag) => {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = tag.name;
+      chip.appendChild(nameSpan);
+
+      if (tag.attr && tagAttrLabels[tag.attr]) {
+        const attrSpan = document.createElement('span');
+        attrSpan.className = 'tag-attr';
+        attrSpan.textContent = tagAttrLabels[tag.attr];
+        chip.appendChild(attrSpan);
+      }
+
+      if (canManageTags) {
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'tag-chip-remove';
+        removeBtn.innerHTML = '&times;';
+        removeBtn.setAttribute('aria-label', `${removeTagLabel} ${tag.name}`);
+        removeBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          removeTagFromMedia(tag.id);
+        });
+        chip.appendChild(removeBtn);
+      }
+
+      mediaTagsContainer.appendChild(chip);
+    });
+  }
+
+  function hideTagManageSuggestions() {
+    if (!tagManageSuggestions) {
+      return;
+    }
+    tagManageSuggestions.classList.remove('visible');
+    tagManageSuggestions.innerHTML = '';
+  }
+
+  function showTagManageSuggestions(items) {
+    if (!tagManageSuggestions) {
+      return;
+    }
+
+    tagManageSuggestions.innerHTML = '';
+    if (!items || items.length === 0) {
+      const emptyItem = document.createElement('div');
+      emptyItem.className = 'tag-suggestion-item text-muted';
+      emptyItem.textContent = noTagSuggestionsText;
+      tagManageSuggestions.appendChild(emptyItem);
+      tagManageSuggestions.classList.add('visible');
+      return;
+    }
+
+    items.forEach((tag) => {
+      const item = document.createElement('div');
+      item.className = 'tag-suggestion-item';
+      const attrLabel = tag.attr && tagAttrLabels[tag.attr] ? ` · ${tagAttrLabels[tag.attr]}` : '';
+      item.textContent = `${tag.name}${attrLabel}`;
+      item.addEventListener('click', () => {
+        addTagToMedia(tag);
+      });
+      tagManageSuggestions.appendChild(item);
+    });
+
+    tagManageSuggestions.classList.add('visible');
+  }
+
+  async function fetchTagOptions(query) {
+    try {
+      const response = await window.apiClient.get(`/api/tags?q=${encodeURIComponent(query)}&limit=10`);
+      if (!response.ok) {
+        throw new Error(`Failed to load tags: ${response.status}`);
+      }
+      const data = await response.json();
+      return data.items || [];
+    } catch (error) {
+      console.error('Failed to load tag suggestions', error);
+      return [];
+    }
+  }
+
+  async function saveMediaTags(tagIds) {
+    try {
+      const response = await window.apiClient.put(`/api/media/${mediaId}/tags`, { tag_ids: tagIds });
+      if (!response.ok) {
+        throw new Error(`Failed to update tags: ${response.status}`);
+      }
+      const data = await response.json();
+      currentTags = data.tags || [];
+      renderMediaTags();
+      return true;
+    } catch (error) {
+      console.error('Failed to update media tags', error);
+      if (typeof showErrorToast === 'function') {
+        showErrorToast(tagUpdateErrorText);
+      }
+      return false;
+    }
+  }
+
+  async function addTagToMedia(tag) {
+    if (!canManageTags) {
+      return;
+    }
+    if (currentTags.some((t) => t.id === tag.id)) {
+      tagManageInput.value = '';
+      hideTagManageSuggestions();
+      return;
+    }
+
+    const tagIds = currentTags.map((t) => t.id).concat(tag.id);
+    const success = await saveMediaTags(tagIds);
+    if (success) {
+      tagManageInput.value = '';
+      hideTagManageSuggestions();
+    }
+  }
+
+  function removeTagFromMedia(tagId) {
+    if (!canManageTags) {
+      return;
+    }
+    const tagIds = currentTags.filter((tag) => tag.id !== tagId).map((tag) => tag.id);
+    saveMediaTags(tagIds);
+  }
+
+  function scheduleTagEditorSuggestions(value) {
+    clearTimeout(tagEditorTimeout);
+    if (!value) {
+      hideTagManageSuggestions();
+      return;
+    }
+
+    tagEditorTimeout = setTimeout(async () => {
+      const suggestions = await fetchTagOptions(value);
+      const available = suggestions.filter(
+        (suggestion) => !currentTags.some((tag) => tag.id === suggestion.id)
+      );
+      showTagManageSuggestions(available);
+    }, 200);
+  }
+
+  async function createTagAndAdd() {
+    if (!canManageTags) {
+      return;
+    }
+    const name = tagManageInput ? tagManageInput.value.trim() : '';
+    if (!name) {
+      return;
+    }
+    const attr = tagAttrSelect ? tagAttrSelect.value : 'thing';
+
+    try {
+      const response = await window.apiClient.post('/api/tags', { name, attr });
+      if (!response.ok) {
+        throw new Error(`Failed to create tag: ${response.status}`);
+      }
+      const data = await response.json();
+      if (data && data.tag) {
+        await addTagToMedia(data.tag);
+      }
+    } catch (error) {
+      console.error('Failed to create tag', error);
+      if (typeof showErrorToast === 'function') {
+        showErrorToast(tagCreateErrorText);
+      }
+    }
+  }
+
   // フルスクリーン
   fullscreenBtn.addEventListener('click', () => {
     if (mediaDisplay.requestFullscreen) {
       mediaDisplay.requestFullscreen();
     }
   });
-  
+
+  if (canManageTags && tagManageInput) {
+    tagManageInput.addEventListener('input', (event) => {
+      scheduleTagEditorSuggestions(event.target.value.trim());
+    });
+
+    tagManageInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (tagManageSuggestions) {
+          const firstSuggestion = tagManageSuggestions.querySelector('.tag-suggestion-item');
+          if (firstSuggestion && !firstSuggestion.classList.contains('text-muted')) {
+            firstSuggestion.click();
+            return;
+          }
+        }
+        createTagAndAdd();
+      } else if (event.key === 'Escape') {
+        hideTagManageSuggestions();
+        tagManageInput.value = '';
+      }
+    });
+  }
+
+  if (canManageTags && createTagBtn) {
+    createTagBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      createTagAndAdd();
+    });
+  }
+
+  if (tagEditorWrapper) {
+    document.addEventListener('click', (event) => {
+      if (!tagEditorWrapper.contains(event.target)) {
+        hideTagManageSuggestions();
+      }
+    });
+  }
+
   // ダウンロード
   downloadBtn.addEventListener('click', async () => {
     try {

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -23,6 +23,110 @@
     align-items: center;
     justify-content: flex-end;
   }
+
+  .tag-filter {
+    flex: 1 1 260px;
+    max-width: 420px;
+    position: relative;
+  }
+
+  .tag-filter label {
+    font-size: 0.85rem;
+    color: #6c757d;
+    margin-bottom: 4px;
+    display: block;
+  }
+
+  .tag-filter-box {
+    position: relative;
+    background: white;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    padding: 6px;
+    min-height: 38px;
+  }
+
+  .tag-filter-box:focus-within {
+    border-color: #86b7fe;
+    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.1);
+  }
+
+  .tag-chip-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .tag-chip-container.empty::before {
+    content: '{{ _('Type to search tags...') }}';
+    color: #adb5bd;
+    font-size: 0.85rem;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    background: #e7f1ff;
+    color: #0d6efd;
+    border-radius: 999px;
+    font-size: 0.8rem;
+  }
+
+  .tag-chip-remove {
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+  }
+
+  .tag-chip-remove:hover {
+    color: #084298;
+  }
+
+  #tag-filter-input {
+    border: none;
+    outline: none;
+    width: 200px;
+    max-width: 100%;
+    font-size: 0.9rem;
+    padding: 6px 2px 0 2px;
+    background: transparent;
+  }
+
+  .tag-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #ced4da;
+    border-radius: 0 0 6px 6px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    z-index: 10;
+    max-height: 220px;
+    overflow-y: auto;
+    display: none;
+  }
+
+  .tag-suggestions.visible {
+    display: block;
+  }
+
+  .tag-suggestion-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.9rem;
+  }
+
+  .tag-suggestion-item:hover {
+    background: #f1f3f5;
+  }
   
   .size-control {
     display: flex;
@@ -155,7 +259,16 @@
     <h1 class="h3 mb-0">{{ _('Media Gallery') }}</h1>
     <span id="media-count" class="filter-badge">{{ _('Loading...') }}</span>
   </div>
-  
+
+  <div class="tag-filter">
+    <label for="tag-filter-input" class="form-label mb-1">{{ _('Filter by tags') }}</label>
+    <div class="tag-filter-box" id="tag-filter-box">
+      <div id="selected-tag-filters" class="tag-chip-container empty"></div>
+      <input type="text" id="tag-filter-input" placeholder="{{ _('Type to search tags...') }}" autocomplete="off">
+      <div id="tag-filter-suggestions" class="tag-suggestions"></div>
+    </div>
+  </div>
+
   <div class="view-controls">
     <!-- Filter -->
     <select id="type-filter" class="form-select form-select-sm" style="width: auto;">
@@ -207,9 +320,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const sortOrder = document.getElementById('sort-order');
   const refreshBtn = document.getElementById('refresh-btn');
   const mediaCount = document.getElementById('media-count');
-  
+  const tagFilterInput = document.getElementById('tag-filter-input');
+  const tagFilterSuggestions = document.getElementById('tag-filter-suggestions');
+  const selectedTagFiltersContainer = document.getElementById('selected-tag-filters');
+  const tagFilterBox = document.getElementById('tag-filter-box');
+
   let infiniteScroll;
   let totalLoaded = 0;
+  let selectedTagFilters = [];
+  let tagSuggestionTimeout = null;
 
   function formatDateTime(isoString) {
     if (!isoString) return '';
@@ -233,6 +352,133 @@ document.addEventListener('DOMContentLoaded', () => {
     return `${size.toFixed(1)} ${units[unitIndex]}`;
   }
 
+  function renderSelectedTagFilters() {
+    if (!selectedTagFiltersContainer) {
+      return;
+    }
+
+    selectedTagFiltersContainer.innerHTML = '';
+    if (selectedTagFilters.length === 0) {
+      selectedTagFiltersContainer.classList.add('empty');
+      return;
+    }
+
+    selectedTagFiltersContainer.classList.remove('empty');
+    selectedTagFilters.forEach((tag) => {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = tag.name;
+      chip.appendChild(nameSpan);
+
+      if (tag.attr && tagAttrLabels[tag.attr]) {
+        const attrSpan = document.createElement('span');
+        attrSpan.style.fontSize = '0.75rem';
+        attrSpan.style.opacity = '0.7';
+        attrSpan.textContent = ` (${tagAttrLabels[tag.attr]})`;
+        chip.appendChild(attrSpan);
+      }
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'tag-chip-remove';
+      removeBtn.innerHTML = '&times;';
+      removeBtn.setAttribute('aria-label', `${removeTagLabel} ${tag.name}`);
+      removeBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        removeTagFilter(tag.id);
+      });
+      chip.appendChild(removeBtn);
+
+      selectedTagFiltersContainer.appendChild(chip);
+    });
+  }
+
+  function hideTagSuggestions() {
+    if (!tagFilterSuggestions) {
+      return;
+    }
+    tagFilterSuggestions.classList.remove('visible');
+    tagFilterSuggestions.innerHTML = '';
+  }
+
+  function showTagSuggestions(items) {
+    if (!tagFilterSuggestions) {
+      return;
+    }
+
+    tagFilterSuggestions.innerHTML = '';
+    if (!items || items.length === 0) {
+      const emptyItem = document.createElement('div');
+      emptyItem.className = 'tag-suggestion-item text-muted';
+      emptyItem.textContent = noTagsFoundText;
+      tagFilterSuggestions.appendChild(emptyItem);
+      tagFilterSuggestions.classList.add('visible');
+      return;
+    }
+
+    items.forEach((tag) => {
+      const item = document.createElement('div');
+      item.className = 'tag-suggestion-item';
+      const attrLabel = tag.attr && tagAttrLabels[tag.attr] ? ` · ${tagAttrLabels[tag.attr]}` : '';
+      item.textContent = `${tag.name}${attrLabel}`;
+      item.addEventListener('click', () => {
+        addTagFilter(tag);
+        tagFilterInput.value = '';
+        hideTagSuggestions();
+      });
+      tagFilterSuggestions.appendChild(item);
+    });
+
+    tagFilterSuggestions.classList.add('visible');
+  }
+
+  async function fetchTagSuggestions(query) {
+    try {
+      const response = await window.apiClient.get(`/api/tags?q=${encodeURIComponent(query)}&limit=10`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch tag suggestions: ${response.status}`);
+      }
+      const data = await response.json();
+      return data.items || [];
+    } catch (error) {
+      console.error('Failed to fetch tag suggestions', error);
+      return [];
+    }
+  }
+
+  function addTagFilter(tag) {
+    if (selectedTagFilters.some((t) => t.id === tag.id)) {
+      return;
+    }
+    selectedTagFilters.push(tag);
+    renderSelectedTagFilters();
+    restartMediaQuery();
+  }
+
+  function removeTagFilter(tagId) {
+    selectedTagFilters = selectedTagFilters.filter((tag) => tag.id !== tagId);
+    renderSelectedTagFilters();
+    restartMediaQuery();
+  }
+
+  function scheduleTagSuggestionFetch(value) {
+    clearTimeout(tagSuggestionTimeout);
+    if (!value) {
+      hideTagSuggestions();
+      return;
+    }
+
+    tagSuggestionTimeout = setTimeout(async () => {
+      const suggestions = await fetchTagSuggestions(value);
+      const available = suggestions.filter(
+        (suggestion) => !selectedTagFilters.some((tag) => tag.id === suggestion.id)
+      );
+      showTagSuggestions(available);
+    }, 200);
+  }
+
   const sourceLabels = {
     local: '{{ _('Local import') }}',
     google_photos: '{{ _('Google Photos') }}'
@@ -240,6 +486,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const unknownSourceLabel = '{{ _('Unknown source') }}';
   const videoLabel = '{{ _('Video') }}';
   const photoLabel = '{{ _('Photo') }}';
+  const removeTagLabel = '{{ _('Remove') }}';
+  const noTagsFoundText = '{{ _('No tags found') }}';
+  const tagAttrLabels = {
+    person: '{{ _('Person') }}',
+    place: '{{ _('Place') }}',
+    thing: '{{ _('Thing') }}'
+  };
 
   function createMediaCard(media) {
     const card = document.createElement('div');
@@ -292,15 +545,25 @@ document.addEventListener('DOMContentLoaded', () => {
     return card;
   }
 
+  function restartMediaQuery() {
+    if (infiniteScroll) {
+      infiniteScroll.destroy();
+    }
+    initializeInfiniteScroll();
+  }
+
   function initializeInfiniteScroll() {
     // Read the current filter settings
     const typeFilter = document.getElementById('type-filter').value;
     const sortOrder = document.getElementById('sort-order').value;
-    
+
     // Build the request parameters
     const parameters = { order: sortOrder };
     if (typeFilter !== 'all') {
       parameters.type = typeFilter;
+    }
+    if (selectedTagFilters.length > 0) {
+      parameters.tags = selectedTagFilters.map((tag) => tag.id).join(',');
     }
     
     const paginationClient = new PaginationClient({
@@ -374,29 +637,55 @@ document.addEventListener('DOMContentLoaded', () => {
   // Filter change
   const typeFilter = document.getElementById('type-filter');
   typeFilter.addEventListener('change', () => {
-    if (infiniteScroll) {
-      infiniteScroll.destroy();
-    }
-    initializeInfiniteScroll();
+    restartMediaQuery();
   });
 
   // Sort order change handler
   sortOrder.addEventListener('change', () => {
-    if (infiniteScroll) {
-      infiniteScroll.destroy();
-    }
-    initializeInfiniteScroll();
+    restartMediaQuery();
   });
 
   // Refresh button handler
   refreshBtn.addEventListener('click', () => {
-    if (infiniteScroll) {
-      infiniteScroll.destroy();
+    restartMediaQuery();
+  });
+
+  if (tagFilterInput) {
+    tagFilterInput.addEventListener('input', (event) => {
+      scheduleTagSuggestionFetch(event.target.value.trim());
+    });
+
+    tagFilterInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (tagFilterSuggestions) {
+          const firstSuggestion = tagFilterSuggestions.querySelector('.tag-suggestion-item');
+          if (firstSuggestion) {
+            firstSuggestion.click();
+          }
+        }
+      } else if (event.key === 'Escape') {
+        hideTagSuggestions();
+        tagFilterInput.value = '';
+      }
+    });
+
+    tagFilterInput.addEventListener('focus', () => {
+      const value = tagFilterInput.value.trim();
+      if (value) {
+        scheduleTagSuggestionFetch(value);
+      }
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    if (tagFilterBox && !tagFilterBox.contains(event.target)) {
+      hideTagSuggestions();
     }
-    initializeInfiniteScroll();
   });
 
   // Initialise infinite scrolling
+  renderSelectedTagFilters();
   initializeInfiniteScroll();
 });
 </script>


### PR DESCRIPTION
## Summary
- extend the media API to serialize tags, filter by tags, and add endpoints for tag CRUD plus media assignment guarded by a new `media:tag-manage` permission
- implement incremental tag search and management UI on the media gallery and media detail pages
- seed the new permission and cover the tag workflows with API tests

## Testing
- `pytest tests/test_media_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0ed46354c8323b4b6a115adc930dd