### PR TITLE
Adjust media list controls layout

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -7,11 +7,11 @@
   .controls-bar {
     display: flex;
     flex-wrap: wrap;
-    gap: 15px;
-    justify-content: space-between;
+    gap: 12px;
+    justify-content: flex-start;
     align-items: center;
     margin-bottom: 20px;
-    padding: 15px;
+    padding: 12px 16px;
     background: #f8f9fa;
     border-radius: 8px;
   }
@@ -22,11 +22,13 @@
     gap: 10px;
     align-items: center;
     justify-content: flex-end;
+    margin-left: auto;
   }
 
   .tag-filter {
-    flex: 1 1 260px;
-    max-width: 420px;
+    flex: 0 1 320px;
+    max-width: 360px;
+    width: 100%;
     position: relative;
   }
 
@@ -130,6 +132,12 @@
     display: flex;
     align-items: center;
     gap: 5px;
+  }
+
+  .size-control #size-label {
+    display: inline-block;
+    min-width: 140px;
+    white-space: nowrap;
   }
 
   .size-control .form-range {


### PR DESCRIPTION
## Summary
- keep the media gallery toolbar compact by preventing the tag filter from stretching across the row and aligning the control group with an auto margin
- give the thumbnail size label a fixed width so moving the slider no longer shifts the surrounding layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0f67e7cbc8323ba87164483cbad3d