### PR TITLE
Align admin action button sizing

### DIFF
--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -100,6 +100,11 @@ document.addEventListener('DOMContentLoaded', () => {
     usersLoaded: '{{ _("users loaded") }}',
     deactivate: '{{ _("deactivate") }}',
     activate: '{{ _("activate") }}',
+    deactivateLabel: '{{ _("Deactivate") }}',
+    activateLabel: '{{ _("Activate") }}',
+    editRoles: '{{ _("Edit Roles") }}',
+    resetTotp: '{{ _("Reset TOTP") }}',
+    deleteUser: '{{ _("Delete User") }}',
     areYouSureYouWantTo: '{{ _("Are you sure you want to") }}',
     thisUser: '{{ _("this user?") }}'
   };
@@ -141,20 +146,24 @@ document.addEventListener('DOMContentLoaded', () => {
       </td>
       <td><small>${formatDateTime(user.created_at)}</small></td>
       <td>
-        <div class="btn-group btn-group-sm" role="group">
-          <button class="btn ${user.is_active ? 'btn-warning' : 'btn-success'} btn-sm" 
-                  onclick="toggleUserActive(${user.id}, ${user.is_active})" 
+        <div class="admin-action-buttons">
+          <button class="btn ${user.is_active ? 'btn-warning' : 'btn-success'} btn-sm admin-action-button"
+                  onclick="toggleUserActive(${user.id}, ${user.is_active})"
                   title="${user.is_active ? '{{ _("Deactivate User") }}' : '{{ _("Activate User") }}'}">
             <i class="fas ${user.is_active ? 'fa-user-slash' : 'fa-user-check'}"></i>
+            <span>${user.is_active ? translations.deactivateLabel : translations.activateLabel}</span>
           </button>
-          <button class="btn btn-outline-primary btn-sm" onclick="editUserRoles(${user.id})">
-            {{ _('Edit Roles') }}
+          <button class="btn btn-outline-primary btn-sm admin-action-button" onclick="editUserRoles(${user.id})">
+            <i class="fas fa-user-cog"></i>
+            <span>${translations.editRoles}</span>
           </button>
-          <button class="btn btn-warning btn-sm" onclick="resetUserTotp(${user.id})" title="{{ _('Reset TOTP') }}">
+          <button class="btn btn-warning btn-sm admin-action-button" onclick="resetUserTotp(${user.id})" title="{{ _('Reset TOTP') }}">
             <i class="fas fa-key"></i>
+            <span>${translations.resetTotp}</span>
           </button>
-          <button class="btn btn-danger btn-sm" onclick="deleteUser(${user.id})" title="{{ _('Delete User') }}">
+          <button class="btn btn-danger btn-sm admin-action-button" onclick="deleteUser(${user.id})" title="{{ _('Delete User') }}">
             <i class="fas fa-trash"></i>
+            <span>${translations.deleteUser}</span>
           </button>
         </div>
       </td>

--- a/webapp/admin/templates/admin/permissions.html
+++ b/webapp/admin/templates/admin/permissions.html
@@ -58,13 +58,20 @@
       <td>{{ perm.id }}</td>
       <td>{{ perm.code }}</td>
       <td>
-        <a href="{{ url_for('admin.permission_edit', perm_id=perm.id) }}" class="btn btn-primary btn-sm">{{ _('Edit') }}</a>
-        <form method="post" action="{{ url_for('admin.permission_delete', perm_id=perm.id) }}" class="d-inline delete-form">
-          <button type="submit" class="btn btn-danger btn-sm" 
-                  data-confirm-message="{{ _('Are you sure you want to delete this permission?') }}">
-            {{ _('Delete') }}
-          </button>
-        </form>
+        <div class="admin-action-buttons">
+          <a href="{{ url_for('admin.permission_edit', perm_id=perm.id) }}" class="btn btn-primary btn-sm admin-action-button">
+            <i class="fas fa-edit"></i>
+            <span>{{ _('Edit') }}</span>
+          </a>
+          <form method="post" action="{{ url_for('admin.permission_delete', perm_id=perm.id) }}"
+                class="admin-action-form delete-form">
+            <button type="submit" class="btn btn-danger btn-sm admin-action-button"
+                    data-confirm-message="{{ _('Are you sure you want to delete this permission?') }}">
+              <i class="fas fa-trash"></i>
+              <span>{{ _('Delete') }}</span>
+            </button>
+          </form>
+        </div>
       </td>
     </tr>
     {% endfor %}

--- a/webapp/admin/templates/admin/roles.html
+++ b/webapp/admin/templates/admin/roles.html
@@ -58,10 +58,19 @@
         {% endfor %}
       </td>
       <td>
-        <a href="{{ url_for('admin.role_edit', role_id=role.id) }}" class="btn btn-primary btn-sm">{{ _('Edit') }}</a>
-        <form method="post" action="{{ url_for('admin.role_delete', role_id=role.id) }}" class="d-inline" onsubmit="return confirm('{{ _('Are you sure you want to delete this role?') }}');">
-          <button type="submit" class="btn btn-danger btn-sm">{{ _('Delete') }}</button>
-        </form>
+        <div class="admin-action-buttons">
+          <a href="{{ url_for('admin.role_edit', role_id=role.id) }}" class="btn btn-primary btn-sm admin-action-button">
+            <i class="fas fa-edit"></i>
+            <span>{{ _('Edit') }}</span>
+          </a>
+          <form method="post" action="{{ url_for('admin.role_delete', role_id=role.id) }}" class="admin-action-form"
+                onsubmit="return confirm('{{ _('Are you sure you want to delete this role?') }}');">
+            <button type="submit" class="btn btn-danger btn-sm admin-action-button">
+              <i class="fas fa-trash"></i>
+              <span>{{ _('Delete') }}</span>
+            </button>
+          </form>
+        </div>
       </td>
     </tr>
     {% endfor %}

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -322,3 +322,35 @@ body {
 .admin-filter-actions .btn {
   padding: 0.4rem 0.75rem;
 }
+
+/* Admin action buttons */
+.admin-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-action-form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.admin-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-width: 7rem;
+  white-space: nowrap;
+}
+
+.admin-action-button.btn-sm {
+  padding: 0.35rem 0.6rem;
+}
+
+@media (max-width: 576px) {
+  .admin-action-button {
+    flex: 1 1 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- unify the action buttons on the role and permission management tables with consistent sizing and icons
- refresh the user management action buttons to use shared labels and the new layout
- add shared admin action button styles to enforce alignment and responsive behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0f752fdd483239b94c3b69e5041bb