### PR TITLE
Adjust tag filter layout to stay on one line

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -30,13 +30,18 @@
     max-width: 360px;
     width: 100%;
     position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
   }
 
   .tag-filter label {
     font-size: 0.85rem;
     color: #6c757d;
-    margin-bottom: 4px;
-    display: block;
+    margin-bottom: 0;
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
   }
 
   .tag-filter-box {
@@ -46,6 +51,7 @@
     border-radius: 6px;
     padding: 6px;
     min-height: 38px;
+    flex: 1;
   }
 
   .tag-filter-box:focus-within {


### PR DESCRIPTION
## Summary
- update the media list tag filter layout to use a horizontal flex row
- keep the label aligned with the tag selector so the UI no longer wraps onto two lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0fa1f75448323834880ba5aa4ae30