### PR TITLE
Fix picker imports marked as local

### DIFF
--- a/core/tasks/picker_import.py
+++ b/core/tasks/picker_import.py
@@ -1098,6 +1098,7 @@ def picker_import_item(
 
             try:
                 media = Media(
+                    source_type="google_photos",
                     google_media_id=mi.id,
                     account_id=ps.account_id,
                     local_rel_path=str(out_rel),
@@ -1406,6 +1407,7 @@ def picker_import(*, picker_session_id: int, account_id: int) -> Dict[str, objec
             os.replace(dl.path, final_path)
 
             media = Media(
+                source_type="google_photos",
                 google_media_id=media_id,
                 account_id=account_id,
                 local_rel_path=str(out_rel),

--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -118,6 +118,7 @@ def test_picker_import_item_imports(monkeypatch, app, tmp_path):
         assert pmi.locked_by is None
         assert pmi.lock_heartbeat_at is None
         assert Media.query.count() == 1
+        assert media.source_type == "google_photos"
         assert called_thumbs == [media.id]
         assert called_play == []
 


### PR DESCRIPTION
## Summary
- ensure Google Photos picker imports persist media with a `google_photos` source type
- add regression test asserting picker imports are saved as Google Photos media

## Testing
- `pytest tests/test_picker_import_item.py::test_picker_import_item_imports`


------
https://chatgpt.com/codex/tasks/task_e_68d0fc6039b8832381fff92d1de23cc3