### PR TITLE
Link photo import session selections to media detail pages

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -250,7 +250,8 @@ def import_single_file(file_path: str, import_dir: str, originals_dir: str) -> D
         "success": False,
         "file_path": file_path,
         "reason": "",
-        "media_id": None
+        "media_id": None,
+        "media_google_id": None,
     }
     
     _log_info(
@@ -301,6 +302,8 @@ def import_single_file(file_path: str, import_dir: str, originals_dir: str) -> D
         existing_media = check_duplicate_media(file_hash, file_size)
         if existing_media:
             result["reason"] = f"重複ファイル (既存ID: {existing_media.id})"
+            result["media_id"] = existing_media.id
+            result["media_google_id"] = existing_media.google_media_id
             _log_info(
                 "local_import.file.duplicate",
                 "重複ファイルを検出したためスキップ",
@@ -441,6 +444,7 @@ def import_single_file(file_path: str, import_dir: str, originals_dir: str) -> D
 
         result["success"] = True
         result["media_id"] = media.id
+        result["media_google_id"] = media.google_media_id
         result["reason"] = "取り込み成功"
 
         _log_info(
@@ -760,6 +764,10 @@ def local_import_task(task_instance=None, session_id=None) -> Dict:
             # Selectionの状態を処理結果に応じて更新
             if selection:
                 try:
+                    media_google_id = file_result.get("media_google_id")
+                    if media_google_id:
+                        selection.google_media_id = media_google_id
+
                     if file_result["success"]:
                         selection.status = "imported"
                         selection.finished_at = datetime.now(timezone.utc)

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -145,7 +145,9 @@ class TestSessionDetailAPI:
         
         # 選択の詳細確認
         selection = data['selections'][0]
-        assert selection['googleMediaId'] is None
+        assert selection['googleMediaId'] is not None
+        assert selection['googleMediaId'].startswith('local_')
+        assert selection['mediaId'] is not None
         assert selection['filename'] == 'test_file.jpg'
         assert selection['status'] == 'imported'
         assert selection['attempts'] >= 0
@@ -277,7 +279,8 @@ class TestLocalImportIntegration:
         selection = selections_data['selections'][0]
         assert selection['filename'] == 'test_file.jpg'
         assert selection['status'] == 'imported'
-        assert selection['googleMediaId'] is None
+        assert selection['googleMediaId'] is not None
+        assert selection['mediaId'] is not None
         
         # 5. 状態確認（取り込み済みなのでファイル数は0）
         response = client.get('/api/sync/local-import/status')

--- a/tests/test_picker_session_service_local_import.py
+++ b/tests/test_picker_session_service_local_import.py
@@ -142,7 +142,8 @@ class TestPickerSessionServiceLocalImport:
             
             # 各選択の詳細確認
             for selection in details['selections']:
-                assert selection['googleMediaId'] is None
+                assert selection['googleMediaId'] is not None
+                assert selection['mediaId'] is not None
                 assert selection['filename'] in ['test_image.jpg', 'test_video.mp4']
                 assert selection['status'] == 'imported'
                 assert selection['attempts'] >= 0
@@ -301,7 +302,8 @@ class TestPickerSessionServiceMixedSessions:
             
             # ローカルインポートの特徴確認
             for selection in local_details['selections']:
-                assert selection['googleMediaId'] is None
+                assert selection['googleMediaId'] is not None
+                assert selection['mediaId'] is not None
                 assert selection['filename'] is not None
             
             # 通常のPickerSessionを作成（選択なし）

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -53,6 +53,18 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  function escapeHtml(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   function resolveSessionId() {
     const params = new URLSearchParams(window.location.search);
     const fromQuery = params.get('session_id');
@@ -204,8 +216,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function createSelectionRow(selection) {
     const tr = document.createElement('tr');
+    const displayName = selection.filename || selection.googleMediaId || 'N/A';
+    const safeDisplayName = escapeHtml(displayName);
+    const fileCellContent = selection.mediaId
+      ? `<a href="/photo-view/media/${selection.mediaId}" class="text-decoration-none">${safeDisplayName}</a>`
+      : safeDisplayName;
     tr.innerHTML = `
-      <td>${selection.filename || selection.googleMediaId || 'N/A'}</td>
+      <td>${fileCellContent}</td>
       <td>
         <span class="badge bg-${getStatusBadgeClass(selection.status)}">
           ${selectionStatusLabels[selection.status] || selection.status}


### PR DESCRIPTION
## Summary
- record the associated media identifiers for local import selections and expose them in the selection API payload
- surface the media identifier in the session detail table and render file names as links to the media detail page
- adjust local import tests to reflect the new metadata and escape file labels in the UI

## Testing
- pytest tests/test_local_import_ui.py tests/test_picker_session_service_local_import.py


------
https://chatgpt.com/codex/tasks/task_e_68d0fcce538883238c6118251b2cb036