### PR TITLE
Fix media list empty state string literal

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -629,7 +629,12 @@ document.addEventListener('DOMContentLoaded', () => {
         mediaCount.textContent = `${totalLoaded} {{ _('items') }}`;
         
         if (items.length === 0 && meta.isFirstPage) {
-        mediaGrid.innerHTML = '<div class="text-center text-muted p-5"><h4>{{ _('No media found') }}</h4><p>{{ _('Try adjusting your filters or add more media to your library.') }}</p></div>';
+          mediaGrid.innerHTML = `
+            <div class="text-center text-muted p-5">
+              <h4>{{ _('No media found') }}</h4>
+              <p>{{ _('Try adjusting your filters or add more media to your library.') }}</p>
+            </div>
+          `.trim();
         }
       },
       onError: (error) => {


### PR DESCRIPTION
## Summary
- replace the broken single-quoted HTML string for the empty media result message with a template literal
- trim the generated markup so the empty state renders without leading whitespace

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d102a107e88323a5ac10445a00fdb7