### PR TITLE
Fix JavaScript translations in photo view settings template

### DIFF
--- a/webapp/photo_view/templates/photo_view/settings.html
+++ b/webapp/photo_view/templates/photo_view/settings.html
@@ -4,32 +4,32 @@
 <div class="container">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-3 mb-4">
         <div>
-            <h1 class="mb-0">{{ _('Settings') }}</h1>
+            <h1 class="mb-0">{{ _("Settings") }}</h1>
             <p class="text-muted mb-0 small">
-                {{ _('Check the status of local imports and upcoming preferences.') }}
+                {{ _("Check the status of local imports and upcoming preferences.") }}
                 {% if is_admin %}
-                <span class="badge bg-warning text-dark ms-2">{{ _('Admin tools available') }}</span>
+                <span class="badge bg-warning text-dark ms-2">{{ _("Admin tools available") }}</span>
                 {% endif %}
             </p>
         </div>
         <a href="{{ url_for('photo_view.home') }}" class="btn btn-outline-secondary btn-sm">
-            <i class="bi bi-arrow-left"></i> {{ _('Back to Sessions') }}
+            <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
         </a>
     </div>
 
     <div class="card mb-4">
         <div class="card-header d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-2">
-            <h2 class="h5 mb-0">{{ _('Local Import Overview') }}</h2>
+            <h2 class="h5 mb-0">{{ _("Local Import Overview") }}</h2>
             <div class="d-flex flex-wrap gap-2">
                 <button id="refresh-status-btn" class="btn btn-outline-secondary btn-sm">
-                    <i class="bi bi-arrow-clockwise"></i> {{ _('Refresh') }}
+                    <i class="bi bi-arrow-clockwise"></i> {{ _("Refresh") }}
                 </button>
                 {% if is_admin %}
                 <button id="ensure-dirs-btn" class="btn btn-outline-secondary btn-sm d-none">
-                    <i class="bi bi-folder-plus"></i> {{ _('Create Directories') }}
+                    <i class="bi bi-folder-plus"></i> {{ _("Create Directories") }}
                 </button>
                 <button id="start-import-btn" class="btn btn-primary btn-sm" disabled>
-                    <i class="bi bi-upload"></i> {{ _('Start Import') }}
+                    <i class="bi bi-upload"></i> {{ _("Start Import") }}
                 </button>
                 {% endif %}
             </div>
@@ -37,26 +37,26 @@
         <div class="card-body">
             <div id="local-import-loading" class="text-muted d-flex align-items-center gap-2">
                 <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
-                <span>{{ _('Loading status...') }}</span>
+                <span>{{ _("Loading status...") }}</span>
             </div>
             <div id="local-import-content" class="d-none">
                 <div class="row g-3">
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3 bg-light">
-                            <div class="fw-semibold mb-2">{{ _('System Status') }}</div>
+                            <div class="fw-semibold mb-2">{{ _("System Status") }}</div>
                             <span id="system-status" class="badge bg-secondary">-</span>
                             <div class="mt-3">
-                                <div class="text-muted small">{{ _('Pending files') }}</div>
+                                <div class="text-muted small">{{ _("Pending files") }}</div>
                                 <div id="pending-files" class="fs-4 fw-semibold">0</div>
                             </div>
                             <p class="text-muted small mb-0 mt-3">
-                                {{ _('The import process becomes available when all directories are ready.') }}
+                                {{ _("The import process becomes available when all directories are ready.") }}
                             </p>
                         </div>
                     </div>
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3">
-                            <div class="fw-semibold">{{ _('Import directory') }}</div>
+                            <div class="fw-semibold">{{ _("Import directory") }}</div>
                             <div class="d-flex justify-content-between align-items-start gap-2 mt-2">
                                 <code id="import-dir" class="d-block text-break flex-grow-1">-</code>
                                 <span id="import-dir-status" class="badge bg-secondary">-</span>
@@ -66,7 +66,7 @@
                     </div>
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3">
-                            <div class="fw-semibold">{{ _('Originals directory') }}</div>
+                            <div class="fw-semibold">{{ _("Originals directory") }}</div>
                             <div class="d-flex justify-content-between align-items-start gap-2 mt-2">
                                 <code id="originals-dir" class="d-block text-break flex-grow-1">-</code>
                                 <span id="originals-dir-status" class="badge bg-secondary">-</span>
@@ -81,19 +81,19 @@
                 {% if not is_admin %}
                 <p class="text-muted small mt-3 mb-0">
                     <i class="bi bi-info-circle"></i>
-                    {{ _('Only administrators can manage the import process. Please contact the administrator if you need assistance.') }}
+                    {{ _("Only administrators can manage the import process. Please contact the administrator if you need assistance.") }}
                 </p>
                 {% endif %}
             </div>
 
             {% if is_admin %}
             <div id="import-progress" class="mt-4 d-none">
-                <h3 class="h6 mb-3">{{ _('Import progress') }}</h3>
+                <h3 class="h6 mb-3">{{ _("Import progress") }}</h3>
                 <div class="progress mb-2">
                     <div id="progress-bar" class="progress-bar" role="progressbar"
                          style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                 </div>
-                <div id="progress-status" class="mb-2 text-muted small">{{ _('Waiting...') }}</div>
+                <div id="progress-status" class="mb-2 text-muted small">{{ _("Waiting...") }}</div>
                 <div id="progress-details" class="mb-2 text-muted small d-none">
                     <span id="progress-current">0</span> / <span id="progress-total">0</span>
                 </div>
@@ -106,10 +106,10 @@
 
     <div class="card mb-4">
         <div class="card-header">
-            <h2 class="h5 mb-0">{{ _('Other settings') }}</h2>
+            <h2 class="h5 mb-0">{{ _("Other settings") }}</h2>
         </div>
         <div class="card-body">
-            <p class="text-muted mb-0">{{ _('User preference settings will be added soon.') }}</p>
+            <p class="text-muted mb-0">{{ _("User preference settings will be added soon.") }}</p>
         </div>
     </div>
 </div>
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressMessage = document.getElementById('progress-message');
   const resultDiv = document.getElementById('import-result');
 
-  const isAdmin = {{ 'true' if is_admin else 'false' }};
+  const isAdmin = JSON.parse('{{ is_admin | tojson }}');
 
   let currentTaskId = null;
   let progressInterval = null;
@@ -190,11 +190,11 @@ document.addEventListener('DOMContentLoaded', () => {
   function updatePathDisplay(raw, absolute, realpath, exists, codeEl, badgeEl, extraEl) {
     if (!codeEl) return;
 
-    const display = realpath || absolute || raw || '{{ _('Not configured') }}';
+    const display = realpath || absolute || raw || '{{ _("Not configured") }}';
     codeEl.textContent = display;
 
     if (badgeEl) {
-      updateBadge(badgeEl, exists, '{{ _('Available') }}', '{{ _('Missing') }}');
+      updateBadge(badgeEl, exists, '{{ _("Available") }}', '{{ _("Missing") }}');
     }
 
     if (!extraEl) {
@@ -203,13 +203,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const extraLines = [];
     if (raw && raw !== display) {
-      extraLines.push(`{{ _('Configured value') }}: <code>${escapeHtml(raw)}</code>`);
+      extraLines.push(`{{ _("Configured value") }}: <code>${escapeHtml(raw)}</code>`);
     }
     if (absolute && absolute !== display) {
-      extraLines.push(`{{ _('Absolute path') }}: <code>${escapeHtml(absolute)}</code>`);
+      extraLines.push(`{{ _("Absolute path") }}: <code>${escapeHtml(absolute)}</code>`);
     }
     if (realpath && realpath !== display) {
-      extraLines.push(`{{ _('Resolved path') }}: <code>${escapeHtml(realpath)}</code>`);
+      extraLines.push(`{{ _("Resolved path") }}: <code>${escapeHtml(realpath)}</code>`);
     }
 
     if (extraLines.length) {
@@ -228,24 +228,24 @@ document.addEventListener('DOMContentLoaded', () => {
     pendingFilesEl.textContent = pending;
 
     if (ready) {
-      systemStatusEl.textContent = '{{ _('Ready') }}';
+      systemStatusEl.textContent = '{{ _("Ready") }}';
       systemStatusEl.className = 'badge bg-success';
       resetStatusMessage();
     } else {
-      systemStatusEl.textContent = '{{ _('Needs attention') }}';
+      systemStatusEl.textContent = '{{ _("Needs attention") }}';
       systemStatusEl.className = 'badge bg-warning text-dark';
 
       const issues = [];
       if (!config.import_dir_exists) {
-        issues.push('{{ _('Import directory is missing.') }}');
+        issues.push('{{ _("Import directory is missing.") }}');
       }
       if (!config.originals_dir_exists) {
-        issues.push('{{ _('Originals directory is missing.') }}');
+        issues.push('{{ _("Originals directory is missing.") }}');
       }
       if (!issues.length) {
-        issues.push('{{ _('Please review the configuration.') }}');
+        issues.push('{{ _("Please review the configuration.") }}');
       }
-      showStatusMessage(`<strong>{{ _('Attention') }}:</strong><br>${issues.join('<br>')}`);
+      showStatusMessage(`<strong>{{ _("Attention") }}:</strong><br>${issues.join('<br>')}`);
     }
 
     if (isAdmin && startImportBtn) {
@@ -263,7 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updateFromConfig(data) {
     if (!data || !data.config || !data.status) {
-      showStatusMessage('{{ _('Failed to load status.') }}', 'danger');
+      showStatusMessage('{{ _("Failed to load status.") }}', 'danger');
       return;
     }
 
@@ -302,7 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await response.json();
       updateFromConfig(data);
     } catch (error) {
-      showStatusMessage(`{{ _('Failed to load status.') }} ${error.message}`, 'danger');
+      showStatusMessage(`{{ _("Failed to load status.") }} ${error.message}`, 'danger');
     } finally {
       toggleLoading(false);
     }
@@ -322,7 +322,7 @@ document.addEventListener('DOMContentLoaded', () => {
     progressBar.setAttribute('aria-valuenow', '0');
     progressBar.textContent = '0%';
     progressBar.classList.remove('bg-success', 'bg-danger');
-    progressStatus.innerHTML = '<small>{{ _('Starting...') }}</small>';
+    progressStatus.innerHTML = '<small>{{ _("Starting...") }}</small>';
     if (progressDetails) {
       progressDetails.classList.add('d-none');
       progressCurrent.textContent = '0';
@@ -361,7 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBar.style.width = `${progress}%`;
         progressBar.setAttribute('aria-valuenow', String(progress));
         progressBar.textContent = `${progress}%`;
-        progressStatus.innerHTML = `<small class="text-info">${data.status || '{{ _('Processing...') }}'}</small>`;
+        progressStatus.innerHTML = `<small class="text-info">${data.status || '{{ _("Processing...") }}'}</small>`;
 
         if (data.current && data.total && progressDetails) {
           progressCurrent.textContent = data.current;
@@ -377,24 +377,28 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBar.setAttribute('aria-valuenow', '100');
         progressBar.textContent = '100%';
         progressBar.classList.add('bg-success');
-        progressStatus.innerHTML = '<small class="text-success">{{ _('Completed') }}</small>';
+        progressStatus.innerHTML = '<small class="text-success">{{ _("Completed") }}</small>';
 
         const result = data.result || {};
         const summary = `
           <div>
-            <strong>{{ _('Processed') }}</strong>: ${result.processed || 0},
-            <strong>{{ _('Succeeded') }}</strong>: ${result.success || 0},
-            <strong>{{ _('Skipped') }}</strong>: ${result.skipped || 0},
-            <strong>{{ _('Failed') }}</strong>: ${result.failed || 0}
+            <strong>{{ _("Processed") }}</strong>: ${result.processed || 0},
+            <strong>{{ _("Succeeded") }}</strong>: ${result.success || 0},
+            <strong>{{ _("Skipped") }}</strong>: ${result.skipped || 0},
+            <strong>{{ _("Failed") }}</strong>: ${result.failed || 0}
           </div>`;
-        showResult(`<div><i class="bi bi-check-circle text-success"></i> {{ _('Import completed.') }}</div>${summary}`, 'success');
+        const successContent = `
+          <div>
+            <i class="bi bi-check-circle text-success"></i> {{ _("Import completed.") }}
+          </div>${summary}`;
+        showResult(successContent, 'success');
         hideProgressSection();
         loadStatus();
       } else if (data.state === 'FAILURE' || data.state === 'ERROR') {
         clearProgressTimer();
         progressBar.classList.add('bg-danger');
-        progressStatus.innerHTML = '<small class="text-danger">{{ _('Error occurred') }}</small>';
-        const errorMessage = data.error || data.status || '{{ _('An unexpected error occurred.') }}';
+        progressStatus.innerHTML = '<small class="text-danger">{{ _("Error occurred") }}</small>';
+        const errorMessage = data.error || data.status || '{{ _("An unexpected error occurred.") }}';
         showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${errorMessage}</div>`, 'danger');
         hideProgressSection();
         loadStatus();
@@ -408,24 +412,24 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!ensureDirsBtn) return;
     const originalHtml = ensureDirsBtn.innerHTML;
     ensureDirsBtn.disabled = true;
-    ensureDirsBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _('Working...') }}';
+    ensureDirsBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _("Working...") }}';
 
     try {
       const response = await fetch('/api/sync/local-import/directories', { method: 'POST' });
       const data = await response.json();
       if (response.ok && data.success) {
         if (typeof showSuccessToast === 'function') {
-          showSuccessToast(data.message || '{{ _('Directories created successfully.') }}');
+          showSuccessToast(data.message || '{{ _("Directories created successfully.") }}');
         }
       } else {
-        const message = data.error || data.message || '{{ _('Failed to create directories.') }}';
+        const message = data.error || data.message || '{{ _("Failed to create directories.") }}';
         showStatusMessage(message, 'danger');
         if (typeof showErrorToast === 'function') {
           showErrorToast(message);
         }
       }
     } catch (error) {
-      const message = `{{ _('Failed to create directories.') }} ${error.message}`;
+      const message = `{{ _("Failed to create directories.") }} ${error.message}`;
       showStatusMessage(message, 'danger');
     } finally {
       ensureDirsBtn.innerHTML = originalHtml;
@@ -439,7 +443,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const originalHtml = startImportBtn.innerHTML;
     startImportBtn.disabled = true;
-    startImportBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _('Starting...') }}';
+    startImportBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _("Starting...") }}';
     hideResult();
     showProgressSection();
 
@@ -447,7 +451,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch('/api/sync/local-import', { method: 'POST' });
       const data = await response.json();
       if (!response.ok || !data.success) {
-        const message = data.error || '{{ _('Failed to start import.') }}';
+        const message = data.error || '{{ _("Failed to start import.") }}';
         showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${message}</div>`, 'danger');
         hideProgressSection();
         if (typeof showErrorToast === 'function') {
@@ -458,7 +462,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       currentTaskId = data.task_id;
       if (typeof showSuccessToast === 'function') {
-        showSuccessToast('{{ _('Import started.') }}');
+        showSuccessToast('{{ _("Import started.") }}');
       }
       clearProgressTimer();
       progressInterval = setInterval(() => {
@@ -468,7 +472,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }, 1000);
       loadStatus();
     } catch (error) {
-      const message = `{{ _('Failed to start import.') }} ${error.message}`;
+      const message = `{{ _("Failed to start import.") }} ${error.message}`;
       showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${message}</div>`, 'danger');
       hideProgressSection();
     } finally {


### PR DESCRIPTION
## Summary
- replace translation helper calls in the settings template with double-quoted strings so the embedded JavaScript parses correctly
- compute the admin flag via JSON.parse and refactor the success toast composition to avoid malformed string literals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10397c880832389e6c2dfe6bfe7ff