### PR TITLE
Delete media files on removal and ignore deleted in dedup

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -187,7 +187,8 @@ def check_duplicate_media(file_hash: str, file_size: int) -> Optional[Media]:
     """重複チェック: SHA-256 + サイズ一致"""
     return Media.query.filter_by(
         hash_sha256=file_hash,
-        bytes=file_size
+        bytes=file_size,
+        is_deleted=False,
     ).first()
 
 

--- a/core/tasks/picker_import.py
+++ b/core/tasks/picker_import.py
@@ -979,7 +979,7 @@ def picker_import_item(
             raise
 
         # Deduplication by hash
-        if Media.query.filter_by(hash_sha256=dl.sha256).first():
+        if Media.query.filter_by(hash_sha256=dl.sha256, is_deleted=False).first():
             sel.status = "dup"
             dl.path.unlink(missing_ok=True)
         else:
@@ -1383,7 +1383,7 @@ def picker_import(*, picker_session_id: int, account_id: int) -> Dict[str, objec
                 continue
 
             # Deduplication by hash
-            if Media.query.filter_by(hash_sha256=dl.sha256).first():
+            if Media.query.filter_by(hash_sha256=dl.sha256, is_deleted=False).first():
                 dup += 1
                 dl.path.unlink(missing_ok=True)
                 continue


### PR DESCRIPTION
## Summary
- delete media artifacts from originals, thumbnails and playback directories when a media item is removed
- ignore soft-deleted rows during duplicate detection in picker and local imports so re-imports create fresh media
- extend API and import tests to cover file cleanup and re-import scenarios

## Testing
- pytest tests/test_media_api.py::test_media_delete_success
- pytest -vv tests/test_picker_import_item.py::test_picker_import_item_reimports_deleted_media (skipped: Google Photos integration not available)
- pytest -vv tests/test_picker_session_service_local_import.py::TestPickerSessionServiceLocalImport::test_reimport_after_deletion_creates_new_media (skipped)


------
https://chatgpt.com/codex/tasks/task_e_68d101c68d308323ae67bf6063d28920