### PR TITLE
Align translation quoting across photo view templates

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -8,17 +8,17 @@
 {% block content %}
 <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-4">
   <div>
-    <h1 class="h2 mb-1">{{ _('Photo View Home') }}</h1>
-    <p class="text-muted mb-0">{{ _('Create new picker sessions and keep track of imports at a glance.') }}</p>
+    <h1 class="h2 mb-1">{{ _("Photo View Home") }}</h1>
+    <p class="text-muted mb-0">{{ _("Create new picker sessions and keep track of imports at a glance.") }}</p>
   </div>
   <div class="d-flex flex-wrap align-items-center gap-2">
     {% if is_admin %}
       <span class="badge bg-warning text-dark d-flex align-items-center px-3 py-2">
-        <i class="bi bi-tools me-1"></i>{{ _('Admin tools available') }}
+        <i class="bi bi-tools me-1"></i>{{ _("Admin tools available") }}
       </span>
     {% endif %}
     <a href="{{ url_for('photo_view.settings') }}" class="btn btn-outline-secondary">
-      <i class="bi bi-gear me-1"></i>{{ _('Settings') }}
+      <i class="bi bi-gear me-1"></i>{{ _("Settings") }}
     </a>
   </div>
 </div>
@@ -27,29 +27,29 @@
   <div class="col-xl-7">
     <div class="card shadow-sm h-100">
       <div class="card-header bg-white">
-        <h2 class="h5 mb-0">{{ _('Start a new picker session') }}</h2>
+        <h2 class="h5 mb-0">{{ _("Start a new picker session") }}</h2>
       </div>
       <div class="card-body">
-        <label for="session-account" class="form-label">{{ _('Google account for the new session') }}</label>
+        <label for="session-account" class="form-label">{{ _("Google account for the new session") }}</label>
         <div class="input-group">
           {% set has_multiple_accounts = google_accounts|length > 1 %}
           <select id="session-account" class="form-select" {% if not google_accounts %}disabled{% endif %}>
             {% if not google_accounts %}
-              <option value="" selected disabled>{{ _('No Google accounts are linked yet') }}</option>
+              <option value="" selected disabled>{{ _("No Google accounts are linked yet") }}</option>
             {% else %}
-              <option value="" disabled {% if has_multiple_accounts %}selected{% endif %}>{{ _('Select an account') }}</option>
+              <option value="" disabled {% if has_multiple_accounts %}selected{% endif %}>{{ _("Select an account") }}</option>
               {% for account in google_accounts %}
                 <option value="{{ account.id }}" {% if not has_multiple_accounts and loop.first %}selected{% endif %}>{{ account.email }}</option>
               {% endfor %}
             {% endif %}
           </select>
           <button id="create-session-btn" class="btn btn-success" {% if not google_accounts %}disabled{% endif %}>
-            <i class="bi bi-plus-circle me-1"></i>{{ _('Create new session') }}
+            <i class="bi bi-plus-circle me-1"></i>{{ _("Create new session") }}
           </button>
         </div>
         {% if not google_accounts %}
           <div class="form-text text-muted mt-2">
-            {{ _('Link a Google account from the admin console before creating a new session.') }}
+            {{ _("Link a Google account from the admin console before creating a new session.") }}
           </div>
         {% endif %}
       </div>
@@ -59,12 +59,12 @@
   <div class="col-xl-5">
     <div class="card shadow-sm h-100">
       <div class="card-header bg-white d-flex justify-content-between align-items-center">
-        <h2 class="h6 mb-0">{{ _('Quick actions') }}</h2>
-        <span class="text-muted small">{{ _('Everything you need for day-to-day work') }}</span>
+        <h2 class="h6 mb-0">{{ _("Quick actions") }}</h2>
+        <span class="text-muted small">{{ _("Everything you need for day-to-day work") }}</span>
       </div>
       <div class="card-body d-flex flex-column gap-2">
         <button id="refresh-sessions" class="btn btn-outline-primary d-flex align-items-center justify-content-center">
-          <i id="refresh-icon" class="fas fa-arrows-rotate me-2"></i>{{ _('Refresh sessions') }}
+          <i id="refresh-icon" class="fas fa-arrows-rotate me-2"></i>{{ _("Refresh sessions") }}
         </button>
         <button type="button" id="local-import-btn" class="btn btn-outline-info d-flex align-items-center justify-content-center"
                 data-import-display="{{ local_import_info.import.display or '' }}"
@@ -75,13 +75,13 @@
                 data-destination-absolute="{{ local_import_info.originals.absolute or '' }}"
                 data-destination-realpath="{{ local_import_info.originals.realpath or '' }}"
                 data-destination-exists="{{ '1' if local_import_info.originals.exists else '0' }}">
-          <i class="bi bi-folder-plus me-2"></i>{{ _('Start local import') }}
+          <i class="bi bi-folder-plus me-2"></i>{{ _("Start local import") }}
         </button>
         <a href="{{ url_for('photo_view.media_list') }}" class="btn btn-primary d-flex align-items-center justify-content-center">
-          <i class="fas fa-images me-2"></i>{{ _('Open media gallery') }}
+          <i class="fas fa-images me-2"></i>{{ _("Open media gallery") }}
         </a>
         <a href="{{ url_for('photo_view.albums') }}" class="btn btn-outline-success d-flex align-items-center justify-content-center">
-          <i class="fas fa-folder me-2"></i>{{ _('Browse albums') }}
+          <i class="fas fa-folder me-2"></i>{{ _("Browse albums") }}
         </a>
       </div>
     </div>
@@ -90,55 +90,55 @@
 
 {% if local_import_info.import.display %}
   <div class="alert alert-light border small" role="status">
-    <div class="fw-semibold mb-1">{{ _('Local import paths') }}</div>
+    <div class="fw-semibold mb-1">{{ _("Local import paths") }}</div>
     <div>
-      {{ _('Local import source') }}:
+      {{ _("Local import source") }}:
       <code>{{ local_import_info.import.display }}</code>
       {% if local_import_info.import.absolute and local_import_info.import.absolute != local_import_info.import.display %}
-        <span class="ms-1">({{ _('Configured value') }}: <code>{{ local_import_info.import.absolute }}</code>)</span>
+        <span class="ms-1">({{ _("Configured value") }}: <code>{{ local_import_info.import.absolute }}</code>)</span>
       {% elif local_import_info.import.raw and local_import_info.import.raw != local_import_info.import.display %}
-        <span class="ms-1">({{ _('Configured value') }}: <code>{{ local_import_info.import.raw }}</code>)</span>
+        <span class="ms-1">({{ _("Configured value") }}: <code>{{ local_import_info.import.raw }}</code>)</span>
       {% endif %}
       {% if not local_import_info.import.exists %}
-        <span class="ms-1 text-danger">{{ _('Not found') }}</span>
+        <span class="ms-1 text-danger">{{ _("Not found") }}</span>
       {% endif %}
     </div>
     <div class="mt-1">
-      {{ _('Destination') }}:
+      {{ _("Destination") }}:
       {% if local_import_info.originals.display %}
         <code>{{ local_import_info.originals.display }}</code>
         {% if local_import_info.originals.absolute and local_import_info.originals.absolute != local_import_info.originals.display %}
-          <span class="ms-1">({{ _('Configured value') }}: <code>{{ local_import_info.originals.absolute }}</code>)</span>
+          <span class="ms-1">({{ _("Configured value") }}: <code>{{ local_import_info.originals.absolute }}</code>)</span>
         {% elif local_import_info.originals.raw and local_import_info.originals.raw != local_import_info.originals.display %}
-          <span class="ms-1">({{ _('Configured value') }}: <code>{{ local_import_info.originals.raw }}</code>)</span>
+          <span class="ms-1">({{ _("Configured value") }}: <code>{{ local_import_info.originals.raw }}</code>)</span>
         {% endif %}
         {% if not local_import_info.originals.exists %}
-          <span class="ms-1 text-danger">{{ _('Not found') }}</span>
+          <span class="ms-1 text-danger">{{ _("Not found") }}</span>
         {% endif %}
       {% else %}
-        <span class="text-warning">{{ _('No destination directory configured.') }}</span>
+        <span class="text-warning">{{ _("No destination directory configured.") }}</span>
       {% endif %}
     </div>
   </div>
 {% endif %}
 
 <div class="mt-4">
-  <h2>{{ _('All Picker Sessions') }}</h2>
+  <h2>{{ _("All Picker Sessions") }}</h2>
   <div id="session-stats" class="mb-3">
-    <span id="session-count" class="badge bg-info">{{ _('Loading...') }}</span>
+    <span id="session-count" class="badge bg-info">{{ _("Loading...") }}</span>
   </div>
   <div id="sessions-list">
     <div class="table-responsive">
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>{{ _('Session ID') }}</th>
-            <th>{{ _('Status') }}</th>
-            <th>{{ _('Target Account') }}</th>
-            <th>{{ _('File Status') }}</th>
-            <th>{{ _('Created At') }}</th>
-            <th>{{ _('Last Progress') }}</th>
-            <th>{{ _('Actions') }}</th>
+            <th>{{ _("Session ID") }}</th>
+            <th>{{ _("Status") }}</th>
+            <th>{{ _("Target Account") }}</th>
+            <th>{{ _("File Status") }}</th>
+            <th>{{ _("Created At") }}</th>
+            <th>{{ _("Last Progress") }}</th>
+            <th>{{ _("Actions") }}</th>
           </tr>
         </thead>
         <tbody id="sessions-body">
@@ -151,13 +151,13 @@
 
 <div id="loading-indicator" class="text-center" style="display: none;">
   <div class="spinner-border text-primary" role="status">
-    <span class="visually-hidden">{{ _('Loading...') }}</span>
+    <span class="visually-hidden">{{ _("Loading...") }}</span>
   </div>
-  <p class="mt-2">{{ _('Loading more sessions...') }}</p>
+  <p class="mt-2">{{ _("Loading more sessions...") }}</p>
 </div>
 
 <div id="no-more-data" class="text-center text-muted" style="display: none;">
-  <p>{{ _('All sessions loaded') }}</p>
+  <p>{{ _("All sessions loaded") }}</p>
 </div>
 
 <script>
@@ -171,22 +171,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const accountSelect = document.getElementById('session-account');
   const localImportBtn = document.getElementById('local-import-btn');
 
-  const selectAccountMessage = '{{ _('Please choose a Google account first.') }}';
-  const localImportPromptHeader = '{{ _('Start a local import from the following directories?') }}';
-  const localImportSourceLabel = '{{ _('Source') }}';
-  const localImportDestinationLabel = '{{ _('Destination') }}';
-  const localImportResolvedLabel = '{{ _('Resolved path') }}';
-  const localImportMissingLabel = '{{ _('Not found') }}';
-  const localImportRemovalNotice = '{{ _('Files will be removed from the original directory after import completes.') }}';
-  const localImportDestinationUnset = '{{ _('No destination directory configured.') }}';
-  const localImportStartingNotice = '{{ _('Starting local import...') }}';
-  const localImportSuccessNotice = '{{ _('Local import has started. Track the progress in the session list.') }}';
-  const localImportErrorNotice = '{{ _('Failed to start the local import.') }}';
-  const startingImportNotice = '{{ _('Starting import...') }}';
+  const selectAccountMessage = '{{ _("Please choose a Google account first.") }}';
+  const localImportPromptHeader = '{{ _("Start a local import from the following directories?") }}';
+  const localImportSourceLabel = '{{ _("Source") }}';
+  const localImportDestinationLabel = '{{ _("Destination") }}';
+  const localImportResolvedLabel = '{{ _("Resolved path") }}';
+  const localImportMissingLabel = '{{ _("Not found") }}';
+  const localImportRemovalNotice = '{{ _("Files will be removed from the original directory after import completes.") }}';
+  const localImportDestinationUnset = '{{ _("No destination directory configured.") }}';
+  const localImportStartingNotice = '{{ _("Starting local import...") }}';
+  const localImportSuccessNotice = '{{ _("Local import has started. Track the progress in the session list.") }}';
+  const localImportErrorNotice = '{{ _("Failed to start the local import.") }}';
+  const startingImportNotice = '{{ _("Starting import...") }}';
 
   let totalLoaded = 0;
-  const sessionsLoadedLabel = '{{ _('sessions loaded') }}';
-  const noSessionsLoadedLabel = '{{ _('No sessions loaded yet') }}';
+  const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
+  const noSessionsLoadedLabel = '{{ _("No sessions loaded yet") }}';
 
   function formatDateTime(isoString) {
     if (!isoString) return '-';
@@ -195,26 +195,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const selectionStatusLabels = {
-    pending: '{{ _('Pending') }}',
-    enqueued: '{{ _('Enqueued') }}',
-    running: '{{ _('Running') }}',
-    imported: '{{ _('Imported') }}',
-    failed: '{{ _('Failed') }}',
-    dup: '{{ _('Duplicate') }}',
-    skipped: '{{ _('Skipped') }}'
+    pending: '{{ _("Pending") }}',
+    enqueued: '{{ _("Enqueued") }}',
+    running: '{{ _("Running") }}',
+    imported: '{{ _("Imported") }}',
+    failed: '{{ _("Failed") }}',
+    dup: '{{ _("Duplicate") }}',
+    skipped: '{{ _("Skipped") }}'
   };
 
   const sessionStatusLabels = {
-    pending: '{{ _('Pending') }}',
-    ready: '{{ _('Ready') }}',
-    processing: '{{ _('Processing') }}',
-    enqueued: '{{ _('Enqueued') }}',
-    importing: '{{ _('Importing') }}',
-    imported: '{{ _('Imported') }}',
-    canceled: '{{ _('Canceled') }}',
-    expired: '{{ _('Expired') }}',
-    error: '{{ _('Error') }}',
-    failed: '{{ _('Failed') }}'
+    pending: '{{ _("Pending") }}',
+    ready: '{{ _("Ready") }}',
+    processing: '{{ _("Processing") }}',
+    enqueued: '{{ _("Enqueued") }}',
+    importing: '{{ _("Importing") }}',
+    imported: '{{ _("Imported") }}',
+    canceled: '{{ _("Canceled") }}',
+    expired: '{{ _("Expired") }}',
+    error: '{{ _("Error") }}',
+    failed: '{{ _("Failed") }}'
   };
 
   function formatCounts(counts) {
@@ -226,7 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatAccountLabel(session) {
     if (session.isLocalImport) {
-      return '{{ _('Local Import') }}';
+      return '{{ _("Local Import") }}';
     }
     if (session.accountEmail) {
       return session.accountEmail;
@@ -290,8 +290,8 @@ document.addEventListener('DOMContentLoaded', () => {
       <td><small>${formatDateTime(session.createdAt)}</small></td>
       <td><small>${formatDateTime(session.lastProgressAt)}</small></td>
       <td>
-        <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary">{{ _('View Details') }}</a>
-        ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success ms-1" onclick="startImport('${session.sessionId}')">{{ _('Start Import') }}</button>` : ''}
+        <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary">{{ _("View Details") }}</a>
+        ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success ms-1" onclick="startImport('${session.sessionId}')">{{ _("Start Import") }}</button>` : ''}
       </td>
     `;
     return tr;
@@ -335,8 +335,8 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
 
-        sessionsBody.innerHTML = `<tr><td colspan="7"><div class="alert alert-danger">{{ _('Failed to load sessions.') }}</div></td></tr>`;
-        sessionCount.textContent = '{{ _('Error loading sessions') }}';
+        sessionsBody.innerHTML = `<tr><td colspan="7"><div class="alert alert-danger">{{ _("Failed to load sessions.") }}</div></td></tr>`;
+        sessionCount.textContent = '{{ _("Error loading sessions") }}';
       }
     });
 

--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -254,14 +254,14 @@
       </div>
       <div class="d-flex flex-wrap gap-2 justify-content-end">
         <button class="btn btn-outline-secondary" onclick="history.back()">
-          <i class="fas fa-arrow-left"></i> {{ _('Back') }}
+          <i class="fas fa-arrow-left"></i> {{ _("Back") }}
         </button>
         <button class="btn btn-outline-primary" id="download-btn" disabled>
-          <i class="fas fa-download"></i> {{ _('Download') }}
+          <i class="fas fa-download"></i> {{ _("Download") }}
         </button>
         {% if current_user.can('media:delete') %}
         <button class="btn btn-outline-danger" id="delete-btn">
-          <i class="fas fa-trash-alt"></i> {{ _('Delete') }}
+          <i class="fas fa-trash-alt"></i> {{ _("Delete") }}
         </button>
         {% endif %}
       </div>
@@ -297,32 +297,32 @@
   <div class="media-info-panel">
     <div class="info-grid">
       <div class="info-section">
-        <h5>{{ _('Basic Information') }}</h5>
+        <h5>{{ _("Basic Information") }}</h5>
         <div id="basic-info">
           <!-- 基本情報がここに表示されます -->
         </div>
       </div>
 
       <div class="info-section">
-        <h5>{{ _('Technical Details') }}</h5>
+        <h5>{{ _("Technical Details") }}</h5>
         <div id="technical-info">
           <!-- 技術情報がここに表示されます -->
         </div>
       </div>
 
       <div class="info-section">
-        <h5>{{ _('Tags') }}</h5>
-        <div id="media-tags" class="tag-chip-container empty" data-empty-text="{{ _('No tags assigned') }}"></div>
+        <h5>{{ _("Tags") }}</h5>
+        <div id="media-tags" class="tag-chip-container empty" data-empty-text="{{ _("No tags assigned") }}"></div>
         {% if current_user.can('media:tag-manage') %}
         <div id="tag-editor" class="tag-editor">
           <div class="tag-editor-input">
-            <input type="text" id="tag-manage-input" class="form-control form-control-sm tag-search-input" placeholder="{{ _('Search tags...') }}" autocomplete="off">
+            <input type="text" id="tag-manage-input" class="form-control form-control-sm tag-search-input" placeholder="{{ _("Search tags...") }}" autocomplete="off">
             <select id="tag-attr-select" class="form-select form-select-sm">
-              <option value="person">{{ _('Person') }}</option>
-              <option value="place">{{ _('Place') }}</option>
-              <option value="thing" selected>{{ _('Thing') }}</option>
+              <option value="person">{{ _("Person") }}</option>
+              <option value="place">{{ _("Place") }}</option>
+              <option value="thing" selected>{{ _("Thing") }}</option>
             </select>
-            <button class="btn btn-sm btn-outline-primary" id="create-tag-btn">{{ _('Create and add') }}</button>
+            <button class="btn btn-sm btn-outline-primary" id="create-tag-btn">{{ _("Create and add") }}</button>
           </div>
           <div id="tag-manage-suggestions" class="tag-suggestions"></div>
         </div>
@@ -330,7 +330,7 @@
       </div>
 
       <div class="info-section" id="exif-section" style="display: none;">
-        <h5>{{ _('EXIF Data') }}</h5>
+        <h5>{{ _("EXIF Data") }}</h5>
         <div id="exif-info">
           <!-- EXIF情報がここに表示されます -->
         </div>
@@ -368,21 +368,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const canManageTags = {{ 'true' if current_user.can('media:tag-manage') else 'false' }};
   const tagAttrLabels = {
-    person: '{{ _('Person') }}',
-    place: '{{ _('Place') }}',
-    thing: '{{ _('Thing') }}'
+    person: '{{ _("Person") }}',
+    place: '{{ _("Place") }}',
+    thing: '{{ _("Thing") }}'
   };
-  const noTagsAssignedText = '{{ _('No tags assigned') }}';
-  const noTagSuggestionsText = '{{ _('No tags found') }}';
-  const tagUpdateErrorText = '{{ _('Failed to update tags.') }}';
-  const tagCreateErrorText = '{{ _('Failed to create tag.') }}';
-  const removeTagLabel = '{{ _('Remove') }}';
-  const deleteConfirmText = '{{ _('Are you sure you want to delete this media? This action cannot be undone.') }}';
-  const deleteSuccessText = '{{ _('Media was deleted successfully.') }}';
-  const deleteErrorText = '{{ _('Failed to delete media.') }}';
-  const deleteForbiddenText = '{{ _('You do not have permission to delete media.') }}';
-  const deleteMissingText = '{{ _('Media was not found or is already deleted.') }}';
-  const deleteInProgressText = '{{ _('Deleting...') }}';
+  const noTagsAssignedText = '{{ _("No tags assigned") }}';
+  const noTagSuggestionsText = '{{ _("No tags found") }}';
+  const tagUpdateErrorText = '{{ _("Failed to update tags.") }}';
+  const tagCreateErrorText = '{{ _("Failed to create tag.") }}';
+  const removeTagLabel = '{{ _("Remove") }}';
+  const deleteConfirmText = '{{ _("Are you sure you want to delete this media? This action cannot be undone.") }}';
+  const deleteSuccessText = '{{ _("Media was deleted successfully.") }}';
+  const deleteErrorText = '{{ _("Failed to delete media.") }}';
+  const deleteForbiddenText = '{{ _("You do not have permission to delete media.") }}';
+  const deleteMissingText = '{{ _("Media was not found or is already deleted.") }}';
+  const deleteInProgressText = '{{ _("Deleting...") }}';
   const redirectAfterDeleteUrl = '{{ url_for("photo_view.media_list") }}';
 
   if (mediaTagsContainer && !mediaTagsContainer.dataset.emptyText) {

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -299,15 +299,15 @@
 {% block content %}
 <div class="controls-bar">
   <div class="d-flex align-items-center">
-    <h1 class="h3 mb-0">{{ _('Media Gallery') }}</h1>
-    <span id="media-count" class="filter-badge">{{ _('Loading...') }}</span>
+    <h1 class="h3 mb-0">{{ _("Media Gallery") }}</h1>
+    <span id="media-count" class="filter-badge">{{ _("Loading...") }}</span>
   </div>
 
   <div class="tag-filter">
-    <label for="tag-filter-input" class="form-label mb-1">{{ _('Filter by tags') }}</label>
+    <label for="tag-filter-input" class="form-label mb-1">{{ _("Filter by tags") }}</label>
     <div class="tag-filter-box" id="tag-filter-box">
       <div id="selected-tag-filters" class="tag-chip-container empty"></div>
-      <input type="text" id="tag-filter-input" placeholder="{{ _('Type to search tags...') }}" autocomplete="off">
+      <input type="text" id="tag-filter-input" placeholder="{{ _("Type to search tags...") }}" autocomplete="off">
       <div id="tag-filter-suggestions" class="tag-suggestions"></div>
     </div>
   </div>
@@ -315,27 +315,27 @@
   <div class="view-controls">
     <!-- Filter -->
     <select id="type-filter" class="form-select form-select-sm" style="width: auto;">
-      <option value="all">{{ _('All Media') }}</option>
-      <option value="photo">{{ _('Photos Only') }}</option>
-      <option value="video">{{ _('Videos Only') }}</option>
+      <option value="all">{{ _("All Media") }}</option>
+      <option value="photo">{{ _("Photos Only") }}</option>
+      <option value="video">{{ _("Videos Only") }}</option>
     </select>
     
     <!-- Thumbnail size -->
     <div class="size-control">
-      <label for="size-slider" class="form-label mb-0 me-2" style="font-size: 0.9rem;">{{ _('Thumbnail size') }}</label>
+      <label for="size-slider" class="form-label mb-0 me-2" style="font-size: 0.9rem;">{{ _("Thumbnail size") }}</label>
       <input type="range" id="size-slider" class="form-range" min="1" max="3" value="2" style="width: 80px;">
-      <span id="size-label" class="text-muted small fw-semibold">{{ _('Medium thumbnails') }}</span>
+      <span id="size-label" class="text-muted small fw-semibold">{{ _("Medium thumbnails") }}</span>
     </div>
 
     <!-- Sort order -->
     <select id="sort-order" class="form-select form-select-sm" style="width: auto;">
-      <option value="desc">{{ _('Newest First') }}</option>
-      <option value="asc">{{ _('Oldest First') }}</option>
+      <option value="desc">{{ _("Newest First") }}</option>
+      <option value="asc">{{ _("Oldest First") }}</option>
     </select>
     
     <!-- Refresh -->
     <button id="refresh-btn" class="btn btn-outline-primary btn-sm">
-      <i class="fas fa-refresh"></i> {{ _('Refresh') }}
+      <i class="fas fa-refresh"></i> {{ _("Refresh") }}
     </button>
   </div>
 </div>
@@ -346,13 +346,13 @@
 
 <div id="loading-indicator" class="loading-spinner" style="display: none;">
   <div class="spinner-border text-primary" role="status">
-    <span class="visually-hidden">{{ _('Loading...') }}</span>
+    <span class="visually-hidden">{{ _("Loading...") }}</span>
   </div>
-  <p class="mt-2">{{ _('Loading more media...') }}</p>
+  <p class="mt-2">{{ _("Loading more media...") }}</p>
 </div>
 
 <div id="no-more-data" class="no-more-data" style="display: none;">
-  <p>{{ _('All media loaded') }}</p>
+  <p>{{ _("All media loaded") }}</p>
 </div>
 
 <script>
@@ -523,18 +523,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const sourceLabels = {
-    local: '{{ _('Local import') }}',
-    google_photos: '{{ _('Google Photos') }}'
+    local: '{{ _("Local import") }}',
+    google_photos: '{{ _("Google Photos") }}'
   };
-  const unknownSourceLabel = '{{ _('Unknown source') }}';
-  const videoLabel = '{{ _('Video') }}';
-  const photoLabel = '{{ _('Photo') }}';
-  const removeTagLabel = '{{ _('Remove') }}';
-  const noTagsFoundText = '{{ _('No tags found') }}';
+  const unknownSourceLabel = '{{ _("Unknown source") }}';
+  const videoLabel = '{{ _("Video") }}';
+  const photoLabel = '{{ _("Photo") }}';
+  const removeTagLabel = '{{ _("Remove") }}';
+  const noTagsFoundText = '{{ _("No tags found") }}';
   const tagAttrLabels = {
-    person: "{{ _('Person')|escapejs }}",
-    place: "{{ _('Place')|escapejs }}",
-    thing: "{{ _('Thing')|escapejs }}"
+    person: "{{ _("Person")|escapejs }}",
+    place: "{{ _("Place")|escapejs }}",
+    thing: "{{ _("Thing")|escapejs }}"
   };
 
   function createMediaCard(media) {
@@ -625,10 +625,10 @@ document.addEventListener('DOMContentLoaded', () => {
           totalLoaded++;
         });
         
-        mediaCount.textContent = `${totalLoaded} {{ _('items') }}`;
+        mediaCount.textContent = `${totalLoaded} {{ _("items") }}`;
         
         if (items.length === 0 && meta.isFirstPage) {
-        mediaGrid.innerHTML = '<div class="text-center text-muted p-5"><h4>{{ _('No media found') }}</h4><p>{{ _('Try adjusting your filters or add more media to your library.') }}</p></div>';
+        mediaGrid.innerHTML = '<div class="text-center text-muted p-5"><h4>{{ _("No media found") }}</h4><p>{{ _("Try adjusting your filters or add more media to your library.") }}</p></div>';
         }
       },
       onError: (error) => {
@@ -656,9 +656,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const sizeLabel = document.getElementById('size-label');
   const sizeClasses = ['size-small', 'size-medium', 'size-large'];
   const sizeDescriptions = {
-    1: '{{ _('Compact thumbnails') }}',
-    2: '{{ _('Medium thumbnails') }}',
-    3: '{{ _('Large previews') }}',
+    1: '{{ _("Compact thumbnails") }}',
+    2: '{{ _("Medium thumbnails") }}',
+    3: '{{ _("Large previews") }}',
   };
 
   function applyGridSize(value) {

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -8,36 +8,36 @@
 {% block content %}
 <div class="d-flex flex-column flex-lg-row gap-2 align-items-lg-center justify-content-lg-between mb-3">
   <div>
-    <h1 id="session-title" class="mb-1">{{ _('Session Details') }}</h1>
+    <h1 id="session-title" class="mb-1">{{ _("Session Details") }}</h1>
     <p id="session-subtitle" class="text-muted small mb-0 d-none"></p>
   </div>
   <a href="/photo-view" class="btn btn-outline-secondary btn-sm">
-    <i class="bi bi-arrow-left"></i> {{ _('Back to Sessions') }}
+    <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
   </a>
 </div>
 
 <div class="mb-3">
   <button id="btn-import-start" class="btn btn-primary" disabled aria-disabled="true">
-    {{ _('Start Import') }}
+    {{ _("Start Import") }}
   </button>
   <div id="session-info" class="text-muted mt-2">
-    {{ _('Loading session info...') }}
+    {{ _("Loading session info...") }}
   </div>
 </div>
 
 <div id="import-status" class="mt-3" aria-live="polite"></div>
 
 <div class="mt-4">
-  <h2>{{ _('Selected Files') }}</h2>
-  <div id="selection-counts" class="mb-2 text-muted">{{ _('Loading...') }}</div>
+  <h2>{{ _("Selected Files") }}</h2>
+  <div id="selection-counts" class="mb-2 text-muted">{{ _("Loading...") }}</div>
   <div class="table-responsive">
     <table class="table table-sm">
       <thead>
         <tr>
-          <th>{{ _('File') }}</th>
-          <th>{{ _('Status') }}</th>
-          <th>{{ _('Attempts') }}</th>
-          <th>{{ _('Error') }}</th>
+          <th>{{ _("File") }}</th>
+          <th>{{ _("Status") }}</th>
+          <th>{{ _("Attempts") }}</th>
+          <th>{{ _("Error") }}</th>
         </tr>
       </thead>
       <tbody id="selection-body">
@@ -95,26 +95,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const sessionSubtitleEl = document.getElementById('session-subtitle');
 
   const selectionStatusLabels = {
-    pending: '{{ _('Pending') }}',
-    enqueued: '{{ _('Enqueued') }}',
-    running: '{{ _('Running') }}',
-    imported: '{{ _('Imported') }}',
-    failed: '{{ _('Failed') }}',
-    dup: '{{ _('Duplicate') }}',
-    skipped: '{{ _('Skipped') }}'
+    pending: '{{ _("Pending") }}',
+    enqueued: '{{ _("Enqueued") }}',
+    running: '{{ _("Running") }}',
+    imported: '{{ _("Imported") }}',
+    failed: '{{ _("Failed") }}',
+    dup: '{{ _("Duplicate") }}',
+    skipped: '{{ _("Skipped") }}'
   };
 
   const sessionStatusLabels = {
-    pending: '{{ _('Pending') }}',
-    ready: '{{ _('Ready') }}',
-    processing: '{{ _('Processing') }}',
-    enqueued: '{{ _('Enqueued') }}',
-    importing: '{{ _('Importing') }}',
-    imported: '{{ _('Imported') }}',
-    canceled: '{{ _('Canceled') }}',
-    expired: '{{ _('Expired') }}',
-    error: '{{ _('Error') }}',
-    failed: '{{ _('Failed') }}'
+    pending: '{{ _("Pending") }}',
+    ready: '{{ _("Ready") }}',
+    processing: '{{ _("Processing") }}',
+    enqueued: '{{ _("Enqueued") }}',
+    importing: '{{ _("Importing") }}',
+    imported: '{{ _("Imported") }}',
+    canceled: '{{ _("Canceled") }}',
+    expired: '{{ _("Expired") }}',
+    error: '{{ _("Error") }}',
+    failed: '{{ _("Failed") }}'
   };
 
   function getStatusBadgeClass(status) {
@@ -299,8 +299,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (sessionTitleEl) {
       sessionTitleEl.textContent = sessionData.isLocalImport
-        ? '{{ _('Local Import Session') }}'
-        : '{{ _('Session Details') }}';
+        ? '{{ _("Local Import Session") }}'
+        : '{{ _("Session Details") }}';
     }
 
     if (sessionSubtitleEl) {
@@ -316,7 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const accountLabel = sessionData.isLocalImport
-      ? '{{ _('Local Import') }}'
+      ? '{{ _("Local Import") }}'
       : (sessionData.accountEmail || '-');
     const selectedCount = deriveSelectedCount(sessionData);
     const countsSummary = formatCounts(sessionData.counts) || '-';
@@ -326,18 +326,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusBadge = `<span class="badge bg-${getSessionBadgeClass(sessionData.status)}">${statusLabel}</span>`;
 
     const infoParts = [
-      `<div><strong>{{ _('Status') }}:</strong> ${statusBadge}</div>`,
-      `<div><strong>{{ _('Target Account') }}:</strong> ${accountLabel}</div>`,
-      `<div><strong>{{ _('Selected Files') }}:</strong> ${selectedCount}</div>`,
-      `<div><strong>{{ _('File Status') }}:</strong> ${countsSummary}</div>`,
-      `<div><strong>{{ _('Created At') }}:</strong> ${createdAt}</div>`,
-      `<div><strong>{{ _('Last Progress') }}:</strong> ${lastProgress}</div>`
+      `<div><strong>{{ _("Status") }}:</strong> ${statusBadge}</div>`,
+      `<div><strong>{{ _("Target Account") }}:</strong> ${accountLabel}</div>`,
+      `<div><strong>{{ _("Selected Files") }}:</strong> ${selectedCount}</div>`,
+      `<div><strong>{{ _("File Status") }}:</strong> ${countsSummary}</div>`,
+      `<div><strong>{{ _("Created At") }}:</strong> ${createdAt}</div>`,
+      `<div><strong>{{ _("Last Progress") }}:</strong> ${lastProgress}</div>`
     ];
 
     if (sessionData.isLocalImport) {
-      infoParts.push(`<div class="mt-2 text-muted"><i class="bi bi-info-circle"></i> {{ _('Local Import Session. Import runs automatically.') }}</div>`);
+      infoParts.push(`<div class="mt-2 text-muted"><i class="bi bi-info-circle"></i> {{ _("Local Import Session. Import runs automatically.") }}</div>`);
     } else if (sessionData.status !== 'ready') {
-      infoParts.push(`<div class="mt-2 text-warning"><i class="bi bi-exclamation-triangle"></i> {{ _('Import can only be started when the session status is ready.') }}</div>`);
+      infoParts.push(`<div class="mt-2 text-warning"><i class="bi bi-exclamation-triangle"></i> {{ _("Import can only be started when the session status is ready.") }}</div>`);
     }
 
     sessionInfoEl.innerHTML = infoParts.join('');
@@ -442,7 +442,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (isLocalImport) {
         statusEl.textContent = 'ローカルインポートセッションでは手動インポートできません。';
       } else {
-        statusEl.textContent = '{{ _('Import is not available for the current status.') }}';
+        statusEl.textContent = '{{ _("Import is not available for the current status.") }}';
       }
       return;
     }

--- a/webapp/photo_view/templates/photo_view/settings.html
+++ b/webapp/photo_view/templates/photo_view/settings.html
@@ -4,32 +4,32 @@
 <div class="container">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-3 mb-4">
         <div>
-            <h1 class="mb-0">{{ _('Settings') }}</h1>
+            <h1 class="mb-0">{{ _("Settings") }}</h1>
             <p class="text-muted mb-0 small">
-                {{ _('Check the status of local imports and upcoming preferences.') }}
+                {{ _("Check the status of local imports and upcoming preferences.") }}
                 {% if is_admin %}
-                <span class="badge bg-warning text-dark ms-2">{{ _('Admin tools available') }}</span>
+                <span class="badge bg-warning text-dark ms-2">{{ _("Admin tools available") }}</span>
                 {% endif %}
             </p>
         </div>
         <a href="{{ url_for('photo_view.home') }}" class="btn btn-outline-secondary btn-sm">
-            <i class="bi bi-arrow-left"></i> {{ _('Back to Sessions') }}
+            <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
         </a>
     </div>
 
     <div class="card mb-4">
         <div class="card-header d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-2">
-            <h2 class="h5 mb-0">{{ _('Local Import Overview') }}</h2>
+            <h2 class="h5 mb-0">{{ _("Local Import Overview") }}</h2>
             <div class="d-flex flex-wrap gap-2">
                 <button id="refresh-status-btn" class="btn btn-outline-secondary btn-sm">
-                    <i class="bi bi-arrow-clockwise"></i> {{ _('Refresh') }}
+                    <i class="bi bi-arrow-clockwise"></i> {{ _("Refresh") }}
                 </button>
                 {% if is_admin %}
                 <button id="ensure-dirs-btn" class="btn btn-outline-secondary btn-sm d-none">
-                    <i class="bi bi-folder-plus"></i> {{ _('Create Directories') }}
+                    <i class="bi bi-folder-plus"></i> {{ _("Create Directories") }}
                 </button>
                 <button id="start-import-btn" class="btn btn-primary btn-sm" disabled>
-                    <i class="bi bi-upload"></i> {{ _('Start Import') }}
+                    <i class="bi bi-upload"></i> {{ _("Start Import") }}
                 </button>
                 {% endif %}
             </div>
@@ -37,26 +37,26 @@
         <div class="card-body">
             <div id="local-import-loading" class="text-muted d-flex align-items-center gap-2">
                 <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
-                <span>{{ _('Loading status...') }}</span>
+                <span>{{ _("Loading status...") }}</span>
             </div>
             <div id="local-import-content" class="d-none">
                 <div class="row g-3">
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3 bg-light">
-                            <div class="fw-semibold mb-2">{{ _('System Status') }}</div>
+                            <div class="fw-semibold mb-2">{{ _("System Status") }}</div>
                             <span id="system-status" class="badge bg-secondary">-</span>
                             <div class="mt-3">
-                                <div class="text-muted small">{{ _('Pending files') }}</div>
+                                <div class="text-muted small">{{ _("Pending files") }}</div>
                                 <div id="pending-files" class="fs-4 fw-semibold">0</div>
                             </div>
                             <p class="text-muted small mb-0 mt-3">
-                                {{ _('The import process becomes available when all directories are ready.') }}
+                                {{ _("The import process becomes available when all directories are ready.") }}
                             </p>
                         </div>
                     </div>
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3">
-                            <div class="fw-semibold">{{ _('Import directory') }}</div>
+                            <div class="fw-semibold">{{ _("Import directory") }}</div>
                             <div class="d-flex justify-content-between align-items-start gap-2 mt-2">
                                 <code id="import-dir" class="d-block text-break flex-grow-1">-</code>
                                 <span id="import-dir-status" class="badge bg-secondary">-</span>
@@ -66,7 +66,7 @@
                     </div>
                     <div class="col-md-4">
                         <div class="border rounded h-100 p-3">
-                            <div class="fw-semibold">{{ _('Originals directory') }}</div>
+                            <div class="fw-semibold">{{ _("Originals directory") }}</div>
                             <div class="d-flex justify-content-between align-items-start gap-2 mt-2">
                                 <code id="originals-dir" class="d-block text-break flex-grow-1">-</code>
                                 <span id="originals-dir-status" class="badge bg-secondary">-</span>
@@ -81,19 +81,19 @@
                 {% if not is_admin %}
                 <p class="text-muted small mt-3 mb-0">
                     <i class="bi bi-info-circle"></i>
-                    {{ _('Only administrators can manage the import process. Please contact the administrator if you need assistance.') }}
+                    {{ _("Only administrators can manage the import process. Please contact the administrator if you need assistance.") }}
                 </p>
                 {% endif %}
             </div>
 
             {% if is_admin %}
             <div id="import-progress" class="mt-4 d-none">
-                <h3 class="h6 mb-3">{{ _('Import progress') }}</h3>
+                <h3 class="h6 mb-3">{{ _("Import progress") }}</h3>
                 <div class="progress mb-2">
                     <div id="progress-bar" class="progress-bar" role="progressbar"
                          style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                 </div>
-                <div id="progress-status" class="mb-2 text-muted small">{{ _('Waiting...') }}</div>
+                <div id="progress-status" class="mb-2 text-muted small">{{ _("Waiting...") }}</div>
                 <div id="progress-details" class="mb-2 text-muted small d-none">
                     <span id="progress-current">0</span> / <span id="progress-total">0</span>
                 </div>
@@ -106,10 +106,10 @@
 
     <div class="card mb-4">
         <div class="card-header">
-            <h2 class="h5 mb-0">{{ _('Other settings') }}</h2>
+            <h2 class="h5 mb-0">{{ _("Other settings") }}</h2>
         </div>
         <div class="card-body">
-            <p class="text-muted mb-0">{{ _('User preference settings will be added soon.') }}</p>
+            <p class="text-muted mb-0">{{ _("User preference settings will be added soon.") }}</p>
         </div>
     </div>
 </div>
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressMessage = document.getElementById('progress-message');
   const resultDiv = document.getElementById('import-result');
 
-  const isAdmin = {{ 'true' if is_admin else 'false' }};
+  const isAdmin = JSON.parse('{{ is_admin | tojson }}');
 
   let currentTaskId = null;
   let progressInterval = null;
@@ -190,11 +190,11 @@ document.addEventListener('DOMContentLoaded', () => {
   function updatePathDisplay(raw, absolute, realpath, exists, codeEl, badgeEl, extraEl) {
     if (!codeEl) return;
 
-    const display = realpath || absolute || raw || '{{ _('Not configured') }}';
+    const display = realpath || absolute || raw || '{{ _("Not configured") }}';
     codeEl.textContent = display;
 
     if (badgeEl) {
-      updateBadge(badgeEl, exists, '{{ _('Available') }}', '{{ _('Missing') }}');
+      updateBadge(badgeEl, exists, '{{ _("Available") }}', '{{ _("Missing") }}');
     }
 
     if (!extraEl) {
@@ -203,13 +203,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const extraLines = [];
     if (raw && raw !== display) {
-      extraLines.push(`{{ _('Configured value') }}: <code>${escapeHtml(raw)}</code>`);
+      extraLines.push(`{{ _("Configured value") }}: <code>${escapeHtml(raw)}</code>`);
     }
     if (absolute && absolute !== display) {
-      extraLines.push(`{{ _('Absolute path') }}: <code>${escapeHtml(absolute)}</code>`);
+      extraLines.push(`{{ _("Absolute path") }}: <code>${escapeHtml(absolute)}</code>`);
     }
     if (realpath && realpath !== display) {
-      extraLines.push(`{{ _('Resolved path') }}: <code>${escapeHtml(realpath)}</code>`);
+      extraLines.push(`{{ _("Resolved path") }}: <code>${escapeHtml(realpath)}</code>`);
     }
 
     if (extraLines.length) {
@@ -228,24 +228,24 @@ document.addEventListener('DOMContentLoaded', () => {
     pendingFilesEl.textContent = pending;
 
     if (ready) {
-      systemStatusEl.textContent = '{{ _('Ready') }}';
+      systemStatusEl.textContent = '{{ _("Ready") }}';
       systemStatusEl.className = 'badge bg-success';
       resetStatusMessage();
     } else {
-      systemStatusEl.textContent = '{{ _('Needs attention') }}';
+      systemStatusEl.textContent = '{{ _("Needs attention") }}';
       systemStatusEl.className = 'badge bg-warning text-dark';
 
       const issues = [];
       if (!config.import_dir_exists) {
-        issues.push('{{ _('Import directory is missing.') }}');
+        issues.push('{{ _("Import directory is missing.") }}');
       }
       if (!config.originals_dir_exists) {
-        issues.push('{{ _('Originals directory is missing.') }}');
+        issues.push('{{ _("Originals directory is missing.") }}');
       }
       if (!issues.length) {
-        issues.push('{{ _('Please review the configuration.') }}');
+        issues.push('{{ _("Please review the configuration.") }}');
       }
-      showStatusMessage(`<strong>{{ _('Attention') }}:</strong><br>${issues.join('<br>')}`);
+      showStatusMessage(`<strong>{{ _("Attention") }}:</strong><br>${issues.join('<br>')}`);
     }
 
     if (isAdmin && startImportBtn) {
@@ -263,7 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updateFromConfig(data) {
     if (!data || !data.config || !data.status) {
-      showStatusMessage('{{ _('Failed to load status.') }}', 'danger');
+      showStatusMessage('{{ _("Failed to load status.") }}', 'danger');
       return;
     }
 
@@ -302,7 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await response.json();
       updateFromConfig(data);
     } catch (error) {
-      showStatusMessage(`{{ _('Failed to load status.') }} ${error.message}`, 'danger');
+      showStatusMessage(`{{ _("Failed to load status.") }} ${error.message}`, 'danger');
     } finally {
       toggleLoading(false);
     }
@@ -322,7 +322,7 @@ document.addEventListener('DOMContentLoaded', () => {
     progressBar.setAttribute('aria-valuenow', '0');
     progressBar.textContent = '0%';
     progressBar.classList.remove('bg-success', 'bg-danger');
-    progressStatus.innerHTML = '<small>{{ _('Starting...') }}</small>';
+    progressStatus.innerHTML = '<small>{{ _("Starting...") }}</small>';
     if (progressDetails) {
       progressDetails.classList.add('d-none');
       progressCurrent.textContent = '0';
@@ -361,7 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBar.style.width = `${progress}%`;
         progressBar.setAttribute('aria-valuenow', String(progress));
         progressBar.textContent = `${progress}%`;
-        progressStatus.innerHTML = `<small class="text-info">${data.status || '{{ _('Processing...') }}'}</small>`;
+        progressStatus.innerHTML = `<small class="text-info">${data.status || '{{ _("Processing...") }}'}</small>`;
 
         if (data.current && data.total && progressDetails) {
           progressCurrent.textContent = data.current;
@@ -377,24 +377,28 @@ document.addEventListener('DOMContentLoaded', () => {
         progressBar.setAttribute('aria-valuenow', '100');
         progressBar.textContent = '100%';
         progressBar.classList.add('bg-success');
-        progressStatus.innerHTML = '<small class="text-success">{{ _('Completed') }}</small>';
+        progressStatus.innerHTML = '<small class="text-success">{{ _("Completed") }}</small>';
 
         const result = data.result || {};
         const summary = `
           <div>
-            <strong>{{ _('Processed') }}</strong>: ${result.processed || 0},
-            <strong>{{ _('Succeeded') }}</strong>: ${result.success || 0},
-            <strong>{{ _('Skipped') }}</strong>: ${result.skipped || 0},
-            <strong>{{ _('Failed') }}</strong>: ${result.failed || 0}
+            <strong>{{ _("Processed") }}</strong>: ${result.processed || 0},
+            <strong>{{ _("Succeeded") }}</strong>: ${result.success || 0},
+            <strong>{{ _("Skipped") }}</strong>: ${result.skipped || 0},
+            <strong>{{ _("Failed") }}</strong>: ${result.failed || 0}
           </div>`;
-        showResult(`<div><i class="bi bi-check-circle text-success"></i> {{ _('Import completed.') }}</div>${summary}`, 'success');
+        const successContent = `
+          <div>
+            <i class="bi bi-check-circle text-success"></i> {{ _("Import completed.") }}
+          </div>${summary}`;
+        showResult(successContent, 'success');
         hideProgressSection();
         loadStatus();
       } else if (data.state === 'FAILURE' || data.state === 'ERROR') {
         clearProgressTimer();
         progressBar.classList.add('bg-danger');
-        progressStatus.innerHTML = '<small class="text-danger">{{ _('Error occurred') }}</small>';
-        const errorMessage = data.error || data.status || '{{ _('An unexpected error occurred.') }}';
+        progressStatus.innerHTML = '<small class="text-danger">{{ _("Error occurred") }}</small>';
+        const errorMessage = data.error || data.status || '{{ _("An unexpected error occurred.") }}';
         showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${errorMessage}</div>`, 'danger');
         hideProgressSection();
         loadStatus();
@@ -408,24 +412,24 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!ensureDirsBtn) return;
     const originalHtml = ensureDirsBtn.innerHTML;
     ensureDirsBtn.disabled = true;
-    ensureDirsBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _('Working...') }}';
+    ensureDirsBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _("Working...") }}';
 
     try {
       const response = await fetch('/api/sync/local-import/directories', { method: 'POST' });
       const data = await response.json();
       if (response.ok && data.success) {
         if (typeof showSuccessToast === 'function') {
-          showSuccessToast(data.message || '{{ _('Directories created successfully.') }}');
+          showSuccessToast(data.message || '{{ _("Directories created successfully.") }}');
         }
       } else {
-        const message = data.error || data.message || '{{ _('Failed to create directories.') }}';
+        const message = data.error || data.message || '{{ _("Failed to create directories.") }}';
         showStatusMessage(message, 'danger');
         if (typeof showErrorToast === 'function') {
           showErrorToast(message);
         }
       }
     } catch (error) {
-      const message = `{{ _('Failed to create directories.') }} ${error.message}`;
+      const message = `{{ _("Failed to create directories.") }} ${error.message}`;
       showStatusMessage(message, 'danger');
     } finally {
       ensureDirsBtn.innerHTML = originalHtml;
@@ -439,7 +443,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const originalHtml = startImportBtn.innerHTML;
     startImportBtn.disabled = true;
-    startImportBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _('Starting...') }}';
+    startImportBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _("Starting...") }}';
     hideResult();
     showProgressSection();
 
@@ -447,7 +451,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const response = await fetch('/api/sync/local-import', { method: 'POST' });
       const data = await response.json();
       if (!response.ok || !data.success) {
-        const message = data.error || '{{ _('Failed to start import.') }}';
+        const message = data.error || '{{ _("Failed to start import.") }}';
         showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${message}</div>`, 'danger');
         hideProgressSection();
         if (typeof showErrorToast === 'function') {
@@ -458,7 +462,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       currentTaskId = data.task_id;
       if (typeof showSuccessToast === 'function') {
-        showSuccessToast('{{ _('Import started.') }}');
+        showSuccessToast('{{ _("Import started.") }}');
       }
       clearProgressTimer();
       progressInterval = setInterval(() => {
@@ -468,7 +472,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }, 1000);
       loadStatus();
     } catch (error) {
-      const message = `{{ _('Failed to start import.') }} ${error.message}`;
+      const message = `{{ _("Failed to start import.") }} ${error.message}`;
       showResult(`<div><i class="bi bi-exclamation-triangle text-danger"></i> ${message}</div>`, 'danger');
       hideProgressSection();
     } finally {


### PR DESCRIPTION
## Summary
- switch the remaining photo view templates to use double-quoted translation helper calls so embedded JavaScript strings stay valid
- update inline script dictionaries and constants in each template to rely on the safer quoting pattern introduced in settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10397c880832389e6c2dfe6bfe7ff