### PR TITLE
Fix refresh token revocation during logout

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timezone
+from typing import Optional
+
 from flask_login import UserMixin
+
 from core.db import db
 from webapp.extensions import login_manager
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -52,7 +55,11 @@ class User(db.Model, UserMixin):
         return check_password_hash(self.password_hash, raw)
 
     # リフレッシュトークンの管理ヘルパ
-    def set_refresh_token(self, token: str) -> None:
+    def set_refresh_token(self, token: Optional[str]) -> None:
+        if not token:
+            self.refresh_token_hash = None
+            return
+
         self.refresh_token_hash = generate_password_hash(token)
 
     def check_refresh_token(self, token: str) -> bool:

--- a/core/tasks/session_recovery.py
+++ b/core/tasks/session_recovery.py
@@ -1,4 +1,11 @@
-"""Session recovery tasks for cleaning up stale processing sessions."""
+"""Session recovery tasks for cleaning up stale processing sessions.
+
+`cleanup_stale_sessions` は Celery Beat から 5 分間隔で起動される定期タスクです。
+そのため、ログアウト直後などユーザー操作とほぼ同じタイミングで
+`session_recovery.cleanup_stale_sessions` というログが出力されることがありますが、
+これはスケジュール実行によるものであり、ログアウト処理が直接トリガーしている
+わけではありません。
+"""
 
 import json
 from datetime import datetime, timedelta

--- a/tests/test_token_service_revocation.py
+++ b/tests/test_token_service_revocation.py
@@ -1,0 +1,24 @@
+import pytest
+
+from core.models.user import User
+from webapp.extensions import db
+from webapp.services.token_service import TokenService
+
+
+@pytest.mark.usefixtures("app_context")
+def test_revoke_refresh_token_clears_hash():
+    user = User(email="logout-test@example.com")
+    user.set_password("secret")
+    db.session.add(user)
+    db.session.commit()
+
+    _, refresh_token = TokenService.generate_token_pair(user)
+
+    assert user.refresh_token_hash is not None
+    assert user.check_refresh_token(refresh_token)
+
+    TokenService.revoke_refresh_token(user)
+    db.session.refresh(user)
+
+    assert user.refresh_token_hash is None
+    assert not user.check_refresh_token(refresh_token)


### PR DESCRIPTION
## Summary
- allow `User.set_refresh_token` to clear the stored hash when no token is provided
- add a regression test that verifies refresh tokens are cleared when revoked
- document that `session_recovery.cleanup_stale_sessions` runs on a 5-minute beat schedule independent of logout

## Testing
- pytest tests/test_token_service_revocation.py

------
https://chatgpt.com/codex/tasks/task_e_68d108fda2e48323abe72978bed57396