### PR TITLE
Allow reimport of deleted media in picker session

### DIFF
--- a/webapp/api/picker_session_service.py
+++ b/webapp/api/picker_session_service.py
@@ -539,7 +539,11 @@ class PickerSessionService:
             return None
         
         # 既存のメディアまたは他のセッションでの選択をチェック
-        existing_media = Media.query.filter_by(google_media_id=item_id, account_id=ps.account_id).first()
+        existing_media = (
+            Media.query.filter_by(
+                google_media_id=item_id, account_id=ps.account_id, is_deleted=False
+            ).first()
+        )
         existing_selection = PickerSelection.query.filter_by(session_id=ps.id, google_media_id=item_id).first()
         
         # 現在のセッションで既に存在する場合は何もしない


### PR DESCRIPTION
## Summary
- ignore soft-deleted media items when checking for existing picker imports so that re-imports create new records
- add a regression test covering picker session re-import behaviour when the original media was soft-deleted

## Testing
- pytest tests/test_media_api.py::test_picker_session_service_allows_reimport_of_deleted_media

------
https://chatgpt.com/codex/tasks/task_e_68d10dae836883238d416de88cb24a38