### PR TITLE
Ensure logout revokes tokens and fixes media detail script

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -362,7 +362,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentTags = [];
   let tagEditorTimeout = null;
 
-  const canManageTags = {{ 'true' if current_user.can('media:tag-manage') else 'false' }};
+  const canManageTags = {{ current_user.can('media:tag-manage') | tojson }};
   const tagAttrLabels = {
     person: '{{ _("Person") }}',
     place: '{{ _("Place") }}',


### PR DESCRIPTION
## Summary
- revoke the user refresh token and clear the JWT cookie during the web logout flow while emitting a logout audit log entry
- remove lingering picker session data after logout to avoid reuse of protected state
- fix the media detail template to emit a proper JavaScript boolean for tag management permissions

## Testing
- pytest tests/test_api_logout.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d111bfd708832384f9c69e7c3833fe