### PR TITLE
Fix login form icon alignment

### DIFF
--- a/webapp/auth/templates/auth/edit.html
+++ b/webapp/auth/templates/auth/edit.html
@@ -15,24 +15,28 @@
           <i class="fas fa-envelope"></i>
           {{ _('Email Address') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-envelope"></i>
+        <div class="input-wrapper">
+          <input type="email" class="form-control" id="email" name="email"
+                 value="{{ current_user.email }}"
+                 placeholder="{{ _('Enter your email') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-envelope"></i>
+          </div>
         </div>
-        <input type="email" class="form-control" id="email" name="email" 
-               value="{{ current_user.email }}" 
-               placeholder="{{ _('Enter your email') }}" required>
       </div>
-      
+
       <div class="form-group">
         <label for="password" class="form-label">
           <i class="fas fa-lock"></i>
           {{ _('New Password') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-lock"></i>
+        <div class="input-wrapper">
+          <input type="password" class="form-control" id="password" name="password"
+                 placeholder="{{ _('Leave blank to keep current password') }}">
+          <div class="input-icon">
+            <i class="fas fa-lock"></i>
+          </div>
         </div>
-        <input type="password" class="form-control" id="password" name="password" 
-               placeholder="{{ _('Leave blank to keep current password') }}">
       </div>
       
       <button type="submit" class="btn btn-login">

--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -15,23 +15,27 @@
           <i class="fas fa-envelope"></i>
           {{ _('Email Address') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-envelope"></i>
+        <div class="input-wrapper">
+          <input type="email" class="form-control" id="email" name="email"
+                 placeholder="{{ _('Enter your email') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-envelope"></i>
+          </div>
         </div>
-        <input type="email" class="form-control" id="email" name="email" 
-               placeholder="{{ _('Enter your email') }}" required>
       </div>
-      
+
       <div class="form-group">
         <label for="password" class="form-label">
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-lock"></i>
+        <div class="input-wrapper">
+          <input type="password" class="form-control" id="password" name="password"
+                 placeholder="{{ _('Enter your password') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-lock"></i>
+          </div>
         </div>
-        <input type="password" class="form-control" id="password" name="password" 
-               placeholder="{{ _('Enter your password') }}" required>
       </div>
       
       <div class="form-group auth-code-field">
@@ -44,11 +48,11 @@
           {{ _('Enter the 6-digit code from your authenticator app (optional if not set up)') }}
         </div>
         <div class="input-wrapper">
+          <input type="text" class="form-control" id="token" name="token"
+                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}">
           <div class="input-icon">
             <i class="fas fa-shield-alt"></i>
           </div>
-          <input type="text" class="form-control" id="token" name="token" 
-                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}">
         </div>
       </div>
       
@@ -78,12 +82,6 @@ footer {
 /* Adjust container height since footer is hidden */
 .login-container {
   min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Enhanced input focus effects */
-.form-control:focus + .input-icon,
-.form-control:valid + .input-icon {
-  color: #667eea;
 }
 
 /* Loading state for button */

--- a/webapp/auth/templates/auth/register.html
+++ b/webapp/auth/templates/auth/register.html
@@ -15,23 +15,27 @@
           <i class="fas fa-envelope"></i>
           {{ _('Email Address') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-envelope"></i>
+        <div class="input-wrapper">
+          <input type="email" class="form-control" id="email" name="email"
+                 placeholder="{{ _('Enter your email') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-envelope"></i>
+          </div>
         </div>
-        <input type="email" class="form-control" id="email" name="email" 
-               placeholder="{{ _('Enter your email') }}" required>
       </div>
-      
+
       <div class="form-group">
         <label for="password" class="form-label">
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-lock"></i>
+        <div class="input-wrapper">
+          <input type="password" class="form-control" id="password" name="password"
+                 placeholder="{{ _('Create a strong password') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-lock"></i>
+          </div>
         </div>
-        <input type="password" class="form-control" id="password" name="password" 
-               placeholder="{{ _('Create a strong password') }}" required>
       </div>
       
       <div class="auth-code-info">
@@ -69,12 +73,6 @@ footer {
 /* Adjust container height since footer is hidden */
 .login-container {
   min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Enhanced input focus effects */
-.form-control:focus + .input-icon,
-.form-control:valid + .input-icon {
-  color: #667eea;
 }
 
 /* Loading state for button */

--- a/webapp/auth/templates/auth/register_no_totp.html
+++ b/webapp/auth/templates/auth/register_no_totp.html
@@ -15,23 +15,27 @@
           <i class="fas fa-envelope"></i>
           {{ _('Email Address') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-envelope"></i>
+        <div class="input-wrapper">
+          <input type="email" class="form-control" id="email" name="email"
+                 placeholder="{{ _('Enter your email') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-envelope"></i>
+          </div>
         </div>
-        <input type="email" class="form-control" id="email" name="email" 
-               placeholder="{{ _('Enter your email') }}" required>
       </div>
-      
+
       <div class="form-group">
         <label for="password" class="form-label">
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-icon">
-          <i class="fas fa-lock"></i>
+        <div class="input-wrapper">
+          <input type="password" class="form-control" id="password" name="password"
+                 placeholder="{{ _('Create a strong password') }}" required>
+          <div class="input-icon">
+            <i class="fas fa-lock"></i>
+          </div>
         </div>
-        <input type="password" class="form-control" id="password" name="password" 
-               placeholder="{{ _('Create a strong password') }}" required>
       </div>
       
       <div class="auth-code-info" style="background: linear-gradient(135deg, #fff3cd 0%, #fefefe 100%); border-color: #ffc107; color: #856404;">
@@ -69,12 +73,6 @@ footer {
 /* Adjust container height since footer is hidden */
 .login-container {
   min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Enhanced input focus effects */
-.form-control:focus + .input-icon,
-.form-control:valid + .input-icon {
-  color: #667eea;
 }
 
 /* Loading state for button */

--- a/webapp/auth/templates/auth/register_totp.html
+++ b/webapp/auth/templates/auth/register_totp.html
@@ -46,11 +46,11 @@
           {{ _('Authentication Code') }}
         </label>
         <div class="input-wrapper">
+          <input type="text" class="form-control" id="token" name="token"
+                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}" required>
           <div class="input-icon">
             <i class="fas fa-shield-alt"></i>
           </div>
-          <input type="text" class="form-control" id="token" name="token" 
-                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}" required>
         </div>
       </div>
       
@@ -244,12 +244,6 @@ footer {
 .btn-cancel-link:hover {
   color: #c53030;
   text-decoration: underline;
-}
-
-/* Enhanced input focus effects */
-.form-control:focus + .input-icon,
-.form-control:valid + .input-icon {
-  color: #667eea;
 }
 
 /* Loading state for button */

--- a/webapp/auth/templates/auth/setup_totp.html
+++ b/webapp/auth/templates/auth/setup_totp.html
@@ -46,11 +46,11 @@
           {{ _('Authentication Code') }}
         </label>
         <div class="input-wrapper">
+          <input type="text" class="form-control" id="token" name="token"
+                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}" required>
           <div class="input-icon">
             <i class="fas fa-shield-alt"></i>
           </div>
-          <input type="text" class="form-control" id="token" name="token" 
-                 placeholder="{{ _('000000') }}" maxlength="6" pattern="[0-9]{6}" required>
         </div>
       </div>
       
@@ -246,12 +246,6 @@ footer {
 .btn-cancel-link:hover {
   color: #c53030;
   text-decoration: underline;
-}
-
-/* Enhanced input focus effects */
-.form-control:focus + .input-icon,
-.form-control:valid + .input-icon {
-  color: #667eea;
 }
 
 /* Loading state for button */

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -72,6 +72,8 @@ body {
   font-size: 1rem;
   transition: all 0.3s ease;
   background-color: #fff;
+  padding: 12px 16px;
+  box-sizing: border-box;
 }
 
 .form-control:focus {
@@ -80,15 +82,34 @@ body {
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
-.input-icon {
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper .form-control {
+  padding-left: 48px;
+}
+
+.input-wrapper .input-icon {
   position: absolute;
   left: 16px;
   top: 50%;
   transform: translateY(-50%);
   color: #a0aec0;
   font-size: 1.1rem;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
   z-index: 2;
-  margin-top: 14px;
+}
+
+.input-wrapper .form-control:focus + .input-icon,
+.input-wrapper .form-control:valid + .input-icon {
+  color: #667eea;
+}
+
+.input-wrapper:focus-within .input-icon {
+  color: #667eea;
 }
 
 .btn-login {
@@ -210,22 +231,14 @@ body {
 }
 
 /* Authentication code field specific icon positioning */
-.input-wrapper {
-  position: relative;
-}
-
 .auth-code-field .input-icon {
   top: 50%;
-  bottom: auto;
-  margin-top: 0;
   transform: translateY(-50%);
 }
 
 /* Fallback for browsers that don't support :has() */
-.form-group:has(.auth-code-info) .input-icon {
+.form-group:has(.auth-code-info) .input-wrapper .input-icon {
   top: 50%;
-  bottom: auto;
-  margin-top: 0;
   transform: translateY(-50%);
 }
 


### PR DESCRIPTION
## Summary
- wrap login, registration, and profile form inputs with a shared wrapper so icons align with their fields
- update shared stylesheet to pad inputs and anchor icons within the new wrapper structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1153f46bc8323962bb9f943e682ac