### PR TITLE
Fix JS templating quoting in media views

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -363,23 +363,23 @@ document.addEventListener('DOMContentLoaded', () => {
   let tagEditorTimeout = null;
 
   const canManageTags = {{ current_user.can('media:tag-manage') | tojson }};
-  const tagAttrLabels = {
-    person: '{{ _("Person") }}',
-    place: '{{ _("Place") }}',
-    thing: '{{ _("Thing") }}'
-  };
-  const noTagsAssignedText = '{{ _("No tags assigned") }}';
-  const noTagSuggestionsText = '{{ _("No tags found") }}';
-  const tagUpdateErrorText = '{{ _("Failed to update tags.") }}';
-  const tagCreateErrorText = '{{ _("Failed to create tag.") }}';
-  const removeTagLabel = '{{ _("Remove") }}';
-  const deleteConfirmText = '{{ _("Are you sure you want to delete this media? This action cannot be undone.") }}';
-  const deleteSuccessText = '{{ _("Media was deleted successfully.") }}';
-  const deleteErrorText = '{{ _("Failed to delete media.") }}';
-  const deleteForbiddenText = '{{ _("You do not have permission to delete media.") }}';
-  const deleteMissingText = '{{ _("Media was not found or is already deleted.") }}';
-  const deleteInProgressText = '{{ _("Deleting...") }}';
-  const redirectAfterDeleteUrl = '{{ url_for("photo_view.media_list") }}';
+  const tagAttrLabels = {{ {
+    'person': _("Person"),
+    'place': _("Place"),
+    'thing': _("Thing"),
+  } | tojson }};
+  const noTagsAssignedText = {{ _("No tags assigned") | tojson }};
+  const noTagSuggestionsText = {{ _("No tags found") | tojson }};
+  const tagUpdateErrorText = {{ _("Failed to update tags.") | tojson }};
+  const tagCreateErrorText = {{ _("Failed to create tag.") | tojson }};
+  const removeTagLabel = {{ _("Remove") | tojson }};
+  const deleteConfirmText = {{ _("Are you sure you want to delete this media? This action cannot be undone.") | tojson }};
+  const deleteSuccessText = {{ _("Media was deleted successfully.") | tojson }};
+  const deleteErrorText = {{ _("Failed to delete media.") | tojson }};
+  const deleteForbiddenText = {{ _("You do not have permission to delete media.") | tojson }};
+  const deleteMissingText = {{ _("Media was not found or is already deleted.") | tojson }};
+  const deleteInProgressText = {{ _("Deleting...") | tojson }};
+  const redirectAfterDeleteUrl = {{ url_for("photo_view.media_list") | tojson }};
 
   if (mediaTagsContainer && !mediaTagsContainer.dataset.emptyText) {
     mediaTagsContainer.dataset.emptyText = noTagsAssignedText;

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -522,20 +522,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 200);
   }
 
-  const sourceLabels = {
-    local: '{{ _("Local import") }}',
-    google_photos: '{{ _("Google Photos") }}'
-  };
-  const unknownSourceLabel = '{{ _("Unknown source") }}';
-  const videoLabel = '{{ _("Video") }}';
-  const photoLabel = '{{ _("Photo") }}';
-  const removeTagLabel = '{{ _("Remove") }}';
-  const noTagsFoundText = '{{ _("No tags found") }}';
-  const tagAttrLabels = {
-    person: "{{ _("Person")|escapejs }}",
-    place: "{{ _("Place")|escapejs }}",
-    thing: "{{ _("Thing")|escapejs }}"
-  };
+  const sourceLabels = {{ {
+    'local': _("Local import"),
+    'google_photos': _("Google Photos"),
+  } | tojson }};
+  const unknownSourceLabel = {{ _("Unknown source") | tojson }};
+  const videoLabel = {{ _("Video") | tojson }};
+  const photoLabel = {{ _("Photo") | tojson }};
+  const removeTagLabel = {{ _("Remove") | tojson }};
+  const noTagsFoundText = {{ _("No tags found") | tojson }};
+  const itemsLabel = {{ _("items") | tojson }};
+  const failedToLoadMediaText = {{ _("Failed to load media. Please try again.") | tojson }};
+  const tagAttrLabels = {{ {
+    'person': _("Person"),
+    'place': _("Place"),
+    'thing': _("Thing"),
+  } | tojson }};
 
   function createMediaCard(media) {
     const card = document.createElement('div');
@@ -625,7 +627,7 @@ document.addEventListener('DOMContentLoaded', () => {
           totalLoaded++;
         });
         
-        mediaCount.textContent = `${totalLoaded} {{ _("items") }}`;
+        mediaCount.textContent = `${totalLoaded} ${itemsLabel}`;
         
         if (items.length === 0 && meta.isFirstPage) {
           mediaGrid.innerHTML = `
@@ -640,7 +642,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('Media loading error:', error);
         const errorDiv = document.createElement('div');
         errorDiv.className = 'alert alert-danger';
-        errorDiv.textContent = '{{ _("Failed to load media. Please try again.") }}';
+        errorDiv.textContent = failedToLoadMediaText;
         mediaGrid.appendChild(errorDiv);
       }
     });
@@ -660,11 +662,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const sizeSlider = document.getElementById('size-slider');
   const sizeLabel = document.getElementById('size-label');
   const sizeClasses = ['size-small', 'size-medium', 'size-large'];
-  const sizeDescriptions = {
-    1: '{{ _("Compact") }}',
-    2: '{{ _("Medium") }}',
-    3: '{{ _("Large") }}',
-  };
+  const sizeDescriptions = {{ {
+    1: _("Compact"),
+    2: _("Medium"),
+    3: _("Large"),
+  } | tojson }};
 
   function applyGridSize(value) {
     const index = Math.min(Math.max(parseInt(value, 10) || 2, 1), 3) - 1;


### PR DESCRIPTION
## Summary
- serialize translated strings with `tojson` for the media detail view's JS constants
- update the media list view scripts to use JSON-safe translations for labels and messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d11651be988323a78d8b5577cfe841