### PR TITLE
Restore JS-friendly templating in media views

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -364,22 +364,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const canManageTags = {{ current_user.can('media:tag-manage') | tojson }};
   const tagAttrLabels = {
-    person: '{{ _("Person") }}',
-    place: '{{ _("Place") }}',
-    thing: '{{ _("Thing") }}'
+    person: '{{ _("Person")|escapejs }}',
+    place: '{{ _("Place")|escapejs }}',
+    thing: '{{ _("Thing")|escapejs }}'
   };
-  const noTagsAssignedText = '{{ _("No tags assigned") }}';
-  const noTagSuggestionsText = '{{ _("No tags found") }}';
-  const tagUpdateErrorText = '{{ _("Failed to update tags.") }}';
-  const tagCreateErrorText = '{{ _("Failed to create tag.") }}';
-  const removeTagLabel = '{{ _("Remove") }}';
-  const deleteConfirmText = '{{ _("Are you sure you want to delete this media? This action cannot be undone.") }}';
-  const deleteSuccessText = '{{ _("Media was deleted successfully.") }}';
-  const deleteErrorText = '{{ _("Failed to delete media.") }}';
-  const deleteForbiddenText = '{{ _("You do not have permission to delete media.") }}';
-  const deleteMissingText = '{{ _("Media was not found or is already deleted.") }}';
-  const deleteInProgressText = '{{ _("Deleting...") }}';
-  const redirectAfterDeleteUrl = '{{ url_for("photo_view.media_list") }}';
+  const noTagsAssignedText = '{{ _("No tags assigned")|escapejs }}';
+  const noTagSuggestionsText = '{{ _("No tags found")|escapejs }}';
+  const tagUpdateErrorText = '{{ _("Failed to update tags.")|escapejs }}';
+  const tagCreateErrorText = '{{ _("Failed to create tag.")|escapejs }}';
+  const removeTagLabel = '{{ _("Remove")|escapejs }}';
+  const deleteConfirmText = '{{ _("Are you sure you want to delete this media? This action cannot be undone.")|escapejs }}';
+  const deleteSuccessText = '{{ _("Media was deleted successfully.")|escapejs }}';
+  const deleteErrorText = '{{ _("Failed to delete media.")|escapejs }}';
+  const deleteForbiddenText = '{{ _("You do not have permission to delete media.")|escapejs }}';
+  const deleteMissingText = '{{ _("Media was not found or is already deleted.")|escapejs }}';
+  const deleteInProgressText = '{{ _("Deleting...")|escapejs }}';
+  const redirectAfterDeleteUrl = '{{ url_for("photo_view.media_list")|escapejs }}';
 
   if (mediaTagsContainer && !mediaTagsContainer.dataset.emptyText) {
     mediaTagsContainer.dataset.emptyText = noTagsAssignedText;

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -523,18 +523,20 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const sourceLabels = {
-    local: '{{ _("Local import") }}',
-    google_photos: '{{ _("Google Photos") }}'
+    local: '{{ _("Local import")|escapejs }}',
+    google_photos: '{{ _("Google Photos")|escapejs }}'
   };
-  const unknownSourceLabel = '{{ _("Unknown source") }}';
-  const videoLabel = '{{ _("Video") }}';
-  const photoLabel = '{{ _("Photo") }}';
-  const removeTagLabel = '{{ _("Remove") }}';
-  const noTagsFoundText = '{{ _("No tags found") }}';
+  const unknownSourceLabel = '{{ _("Unknown source")|escapejs }}';
+  const videoLabel = '{{ _("Video")|escapejs }}';
+  const photoLabel = '{{ _("Photo")|escapejs }}';
+  const removeTagLabel = '{{ _("Remove")|escapejs }}';
+  const noTagsFoundText = '{{ _("No tags found")|escapejs }}';
+  const itemsLabel = '{{ _("items")|escapejs }}';
+  const failedToLoadMediaText = '{{ _("Failed to load media. Please try again.")|escapejs }}';
   const tagAttrLabels = {
-    person: "{{ _("Person")|escapejs }}",
-    place: "{{ _("Place")|escapejs }}",
-    thing: "{{ _("Thing")|escapejs }}"
+    person: '{{ _("Person")|escapejs }}',
+    place: '{{ _("Place")|escapejs }}',
+    thing: '{{ _("Thing")|escapejs }}'
   };
 
   function createMediaCard(media) {
@@ -625,7 +627,7 @@ document.addEventListener('DOMContentLoaded', () => {
           totalLoaded++;
         });
         
-        mediaCount.textContent = `${totalLoaded} {{ _("items") }}`;
+        mediaCount.textContent = `${totalLoaded} ${itemsLabel}`;
         
         if (items.length === 0 && meta.isFirstPage) {
           mediaGrid.innerHTML = `
@@ -640,7 +642,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('Media loading error:', error);
         const errorDiv = document.createElement('div');
         errorDiv.className = 'alert alert-danger';
-        errorDiv.textContent = '{{ _("Failed to load media. Please try again.") }}';
+        errorDiv.textContent = failedToLoadMediaText;
         mediaGrid.appendChild(errorDiv);
       }
     });
@@ -661,9 +663,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const sizeLabel = document.getElementById('size-label');
   const sizeClasses = ['size-small', 'size-medium', 'size-large'];
   const sizeDescriptions = {
-    1: '{{ _("Compact") }}',
-    2: '{{ _("Medium") }}',
-    3: '{{ _("Large") }}',
+    1: '{{ _("Compact")|escapejs }}',
+    2: '{{ _("Medium")|escapejs }}',
+    3: '{{ _("Large")|escapejs }}'
   };
 
   function applyGridSize(value) {


### PR DESCRIPTION
## Summary
- wrap translated labels in quoted strings that use `escapejs` so the scripts remain parseable before rendering
- ensure media detail/list templates keep sanitized text constants without breaking IDE JavaScript linting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d11651be988323a78d8b5577cfe841