### PR TITLE
Fix wrapping for media metadata in gallery

### DIFF
--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -257,20 +257,26 @@
   .media-info {
     padding: 10px;
     background: white;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
-  
+
   .media-title {
     font-size: 0.9rem;
     margin: 0 0 5px 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.3;
   }
-  
+
   .media-meta {
     font-size: 0.8rem;
     color: #6c757d;
     margin: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.4;
   }
   
   .loading-spinner {


### PR DESCRIPTION
## Summary
- allow media info text to wrap within media cards
- enable wrapping on media titles and metadata for long account names

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d138874a2083238ef1241e3fe72e5e