### PR TITLE
Respect user timezone settings in photo view and admin pages

### DIFF
--- a/core/models/google_account.py
+++ b/core/models/google_account.py
@@ -32,8 +32,8 @@ class GoogleAccount(db.Model):
             return []
         return [s.strip() for s in self.scopes.split(",") if s.strip()]
 
-    def refresh_token_expires_at(self):
-        """Return refresh token expiry timestamp in ISO format if available."""
+    def refresh_token_expires_at(self, *, as_datetime: bool = False):
+        """Return refresh token expiry timestamp."""
         if not self.oauth_token_json:
             return None
         try:
@@ -43,13 +43,31 @@ class GoogleAccount(db.Model):
 
         expiry = data.get("refresh_token_expires_at") or data.get("refresh_token_expiry")
         if expiry:
-            return expiry
+            return self._coerce_expiry(expiry, as_datetime)
 
         expires_in = data.get("refresh_token_expires_in")
         if expires_in:
             try:
                 base = self.last_synced_at or datetime.now(timezone.utc)
-                return (base + timedelta(seconds=int(expires_in))).isoformat()
+                dt = base + timedelta(seconds=int(expires_in))
+                return dt if as_datetime else dt.isoformat()
             except Exception:
                 return None
+        return None
+
+    @staticmethod
+    def _coerce_expiry(value, as_datetime):
+        if not as_datetime:
+            return value
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str):
+            normalized = value.replace("Z", "+00:00")
+            try:
+                dt = datetime.fromisoformat(normalized)
+            except ValueError:
+                return None
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
         return None

--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -122,8 +122,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDateTime(isoString) {
     if (!isoString) return '-';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDate === 'function') {
+      const formatted = helper.formatDate(isoString, { dateStyle: 'medium' });
+      return formatted || '-';
+    }
     const date = new Date(isoString);
-    return date.toLocaleDateString();
+    return Number.isNaN(date.getTime()) ? '-' : date.toLocaleDateString();
   }
 
   function getCsrfToken() {

--- a/webapp/admin/templates/admin/google_accounts.html
+++ b/webapp/admin/templates/admin/google_accounts.html
@@ -103,7 +103,13 @@
                 {% endfor %}
               </div>
             </td>
-            <td class="text-nowrap">{{ a.last_synced_at or _('Never') }}</td>
+            <td class="text-nowrap">
+              {% if a.last_synced_at %}
+                {{ a.last_synced_at|localtime('%Y-%m-%d %H:%M') }}
+              {% else %}
+                {{ _('Never') }}
+              {% endif %}
+            </td>
             <td>
               {% if a.oauth_token_json %}
                 <span class="badge text-bg-success d-inline-flex align-items-center gap-1">
@@ -115,7 +121,14 @@
                 </span>
               {% endif %}
             </td>
-            <td class="text-nowrap">{{ a.refresh_token_expires_at() or _('Unknown') }}</td>
+            {% set refresh_expiry = a.refresh_token_expires_at(as_datetime=True) %}
+            <td class="text-nowrap">
+              {% if refresh_expiry %}
+                {{ refresh_expiry|localtime('%Y-%m-%d %H:%M') }}
+              {% else %}
+                {{ _('Unknown') }}
+              {% endif %}
+            </td>
             <td class="text-end">
               <div class="dropdown action-menu" data-id="{{ a.id }}" data-scopes="{{ a.scopes }}" data-scope-profile="photo_picker">
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/webapp/auth/templates/auth/google_accounts.html
+++ b/webapp/auth/templates/auth/google_accounts.html
@@ -39,7 +39,13 @@
             {% endfor %}
           </div>
         </td>
-        <td>{{ a.last_synced_at or '-' }}</td>
+        <td>
+          {% if a.last_synced_at %}
+            {{ a.last_synced_at|localtime('%Y-%m-%d %H:%M') }}
+          {% else %}
+            -
+          {% endif %}
+        </td>
         <td>
           {% if a.oauth_token_json %}
             <span class="badge bg-success">OK</span>
@@ -47,7 +53,14 @@
             <span class="badge bg-danger">NG</span>
           {% endif %}
         </td>
-        <td>{{ a.refresh_token_expires_at() or '-' }}</td>
+        {% set refresh_expiry = a.refresh_token_expires_at(as_datetime=True) %}
+        <td>
+          {% if refresh_expiry %}
+            {{ refresh_expiry|localtime('%Y-%m-%d %H:%M') }}
+          {% else %}
+            -
+          {% endif %}
+        </td>
         <td>
           <div class="btn-group btn-group-sm" role="group"
                data-id="{{ a.id }}" data-scopes="{{ a.scopes }}" data-scope-profile="photo_picker">

--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -661,6 +661,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDate(isoString) {
     if (!isoString) return '';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDate === 'function') {
+      const formatted = helper.formatDate(isoString, { dateStyle: 'medium' });
+      if (formatted) {
+        return formatted;
+      }
+    }
     const date = new Date(isoString);
     if (Number.isNaN(date.getTime())) return '';
     return date.toLocaleDateString();
@@ -668,6 +675,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDateTime(isoString) {
     if (!isoString) return '';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      const formatted = helper.formatDateTime(isoString, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      });
+      if (formatted) {
+        return formatted;
+      }
+    }
     const date = new Date(isoString);
     if (Number.isNaN(date.getTime())) return '';
     return date.toLocaleDateString();

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -190,8 +190,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDateTime(isoString) {
     if (!isoString) return '-';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      const formatted = helper.formatDateTime(isoString);
+      return formatted || '-';
+    }
     const date = new Date(isoString);
-    return date.toLocaleString();
+    return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
   }
 
   const selectionStatusLabels = {

--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -818,8 +818,15 @@ document.addEventListener('DOMContentLoaded', () => {
   // ユーティリティ関数
   function formatDateTime(isoString) {
     if (!isoString) return 'Not available';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      const formatted = helper.formatDateTime(isoString);
+      if (formatted) {
+        return formatted;
+      }
+    }
     const date = new Date(isoString);
-    return date.toLocaleString();
+    return Number.isNaN(date.getTime()) ? 'Not available' : date.toLocaleString();
   }
 
   function formatFileSize(bytes) {

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -381,7 +381,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDateTime(isoString) {
     if (!isoString) return '';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      const formatted = helper.formatDateTime(isoString);
+      if (formatted) {
+        return formatted;
+      }
+    }
     const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
     const locale = navigator.language || 'en-US';
     return `${date.toLocaleDateString(locale)} ${date.toLocaleTimeString(locale, {
       hour: '2-digit',

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -153,9 +153,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function formatDateTime(isoString) {
     if (!isoString) return '-';
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      const formatted = helper.formatDateTime(isoString);
+      if (formatted) {
+        return formatted;
+      }
+    }
     try {
       const date = new Date(isoString);
-      return date.toLocaleString();
+      return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
     } catch (e) {
       return isoString;
     }

--- a/webapp/static/js/timezone.js
+++ b/webapp/static/js/timezone.js
@@ -1,0 +1,116 @@
+(function () {
+  const docEl = document.documentElement;
+  const timezoneMeta = document.querySelector('meta[name="user-timezone"]');
+  const timezoneName = (timezoneMeta?.getAttribute('content') || docEl?.dataset?.timezone || 'UTC').trim() || 'UTC';
+  const locale = docEl?.lang || undefined;
+
+  function parseDate(value) {
+    if (!value) {
+      return null;
+    }
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === 'number') {
+      const fromNumber = new Date(value);
+      return Number.isNaN(fromNumber.getTime()) ? null : fromNumber;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const normalized = trimmed.endsWith('Z') || /[+-]\d\d:?\d\d$/.test(trimmed)
+        ? trimmed
+        : `${trimmed}Z`;
+      const fromString = new Date(normalized);
+      if (!Number.isNaN(fromString.getTime())) {
+        return fromString;
+      }
+      const fallback = new Date(trimmed);
+      return Number.isNaN(fallback.getTime()) ? null : fallback;
+    }
+    try {
+      const fromValue = new Date(value);
+      return Number.isNaN(fromValue.getTime()) ? null : fromValue;
+    } catch (error) {
+      console.warn('appTime.parseDate failed', error);
+      return null;
+    }
+  }
+
+  function buildOptions(options) {
+    const finalOptions = { ...(options || {}) };
+    if (!finalOptions.timeZone) {
+      finalOptions.timeZone = timezoneName;
+    }
+    return finalOptions;
+  }
+
+  function formatWithFormatter(date, formatterBuilder, fallback) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return fallback;
+    }
+    try {
+      return formatterBuilder().format(date);
+    } catch (error) {
+      console.warn('appTime formatter failed', error);
+      try {
+        return date.toLocaleString();
+      } catch (innerError) {
+        console.warn('Fallback formatting failed', innerError);
+        return fallback;
+      }
+    }
+  }
+
+  function formatDateTime(value, options) {
+    const date = parseDate(value);
+    if (!date) {
+      return '';
+    }
+    const finalOptions = buildOptions(options);
+    if (!('dateStyle' in finalOptions) && !('timeStyle' in finalOptions) &&
+        !('year' in finalOptions) && !('month' in finalOptions) && !('day' in finalOptions) &&
+        !('hour' in finalOptions)) {
+      finalOptions.dateStyle = 'medium';
+      finalOptions.timeStyle = 'short';
+    }
+    return formatWithFormatter(date, () => new Intl.DateTimeFormat(locale, finalOptions), '');
+  }
+
+  function formatDate(value, options) {
+    const date = parseDate(value);
+    if (!date) {
+      return '';
+    }
+    const finalOptions = buildOptions(options);
+    if (!('dateStyle' in finalOptions) &&
+        !('year' in finalOptions) && !('month' in finalOptions) && !('day' in finalOptions)) {
+      finalOptions.dateStyle = 'medium';
+    }
+    return formatWithFormatter(date, () => new Intl.DateTimeFormat(locale, finalOptions), '');
+  }
+
+  function formatTime(value, options) {
+    const date = parseDate(value);
+    if (!date) {
+      return '';
+    }
+    const finalOptions = buildOptions(options);
+    if (!('timeStyle' in finalOptions) &&
+        !('hour' in finalOptions) && !('minute' in finalOptions) && !('second' in finalOptions)) {
+      finalOptions.timeStyle = 'short';
+    }
+    return formatWithFormatter(date, () => new Intl.DateTimeFormat(locale, finalOptions), '');
+  }
+
+  window.appTime = {
+    timezone: timezoneName,
+    locale: locale || undefined,
+    parseDate,
+    formatDateTime,
+    formatDate,
+    formatTime,
+  };
+})();

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="user-timezone" content="{{ current_timezone_name }}">
   <title>{% block title %}FlaskApp{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
@@ -132,6 +133,7 @@
 </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.0/dist/mermaid.min.js"></script>
+  <script src="{{ url_for('static', filename='js/timezone.js') }}"></script>
   <script src="{{ url_for('static', filename='js/api-client.js') }}"></script>
   <script src="{{ url_for('static', filename='main.js') }}"></script>
   {% block extra_scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- add a shared timezone-aware formatter and expose the selected timezone to front-end scripts
- update photo view and admin interfaces to render timestamps with the user’s preferred timezone
- enhance Google account expiry handling so templates can localise refresh token deadlines

## Testing
- pytest tests/test_auth_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68d1517474c48323bab68ce4ca25d5cd