### PR TITLE
Allow 512px thumbnails

### DIFF
--- a/core/tasks/thumbs_generate.py
+++ b/core/tasks/thumbs_generate.py
@@ -19,7 +19,7 @@ from PIL import Image, ImageOps
 from core.models.photo_models import Media, MediaPlayback
 
 # Target thumbnail sizes (long side)
-SIZES = [256, 1024, 2048]
+SIZES = [256, 512, 1024, 2048]
 
 
 @dataclass

--- a/tests/test_import_with_thumbnails.py
+++ b/tests/test_import_with_thumbnails.py
@@ -112,7 +112,7 @@ def create_test_import():
                     
                     # Check that thumbnails were generated
                     thumbs_dir = Path(os.environ["FPV_NAS_THUMBS_DIR"])
-                    sizes = [256, 1024, 2048]
+                    sizes = [256, 512, 1024, 2048]
                     
                     rel_path = "2025/08/28/20250828_100000_picker_testhash.jpg"
                     

--- a/tests/test_thumbnail_import.py
+++ b/tests/test_thumbnail_import.py
@@ -50,7 +50,7 @@ def test_thumbnail_generation():
             
             # Check that thumbnails were created
             thumbs_dir = Path(os.environ["FPV_NAS_THUMBS_DIR"])
-            sizes = [256, 1024, 2048]
+            sizes = [256, 512, 1024, 2048]
             
             for size in sizes:
                 thumb_path = thumbs_dir / str(size) / "2025/08/28/test_import.jpg"
@@ -62,12 +62,12 @@ def test_thumbnail_generation():
         finally:
             # Cleanup
             test_file.unlink(missing_ok=True)
-            for size in [256, 1024, 2048]:
+            for size in [256, 512, 1024, 2048]:
                 thumb_path = thumbs_dir / str(size) / "2025/08/28/test_import.jpg"
                 thumb_path.unlink(missing_ok=True)
-            
+
             # Remove empty directories
-            for size in [256, 1024, 2048]:
+            for size in [256, 512, 1024, 2048]:
                 try:
                     (thumbs_dir / str(size) / "2025/08/28").rmdir()
                     (thumbs_dir / str(size) / "2025/08").rmdir()

--- a/tests/test_thumbs_generate.py
+++ b/tests/test_thumbs_generate.py
@@ -107,7 +107,12 @@ def test_image_generation(app):
     media_id = _make_media(app, rel_path="2025/08/18/img.jpg", is_video=False, width=4032, height=3024)
     with app.app_context():
         res = thumbs_generate(media_id=media_id)
-    assert res == {"ok": True, "generated": [256, 1024, 2048], "skipped": [], "notes": None}
+    assert res == {
+        "ok": True,
+        "generated": [256, 512, 1024, 2048],
+        "skipped": [],
+        "notes": None,
+    }
 
     out = Path(os.environ["FPV_NAS_THUMBS_DIR"])
     im256 = Image.open(out / "256/2025/08/18/img.jpg")
@@ -129,7 +134,7 @@ def test_image_skip_existing(app):
 
     with app.app_context():
         res = thumbs_generate(media_id=media_id)
-    assert res["generated"] == [256, 2048]
+    assert res["generated"] == [256, 512, 2048]
     assert res["skipped"] == [1024]
 
 
@@ -157,7 +162,7 @@ def test_video_with_playback(app):
 
     with app.app_context():
         res = thumbs_generate(media_id=media_id)
-    assert res["generated"] == [256, 1024, 2048]
+    assert res["generated"] == [256, 512, 1024, 2048]
     out = Path(os.environ["FPV_NAS_THUMBS_DIR"])
     assert (out / "256/2025/08/18/video.jpg").exists()
 
@@ -169,6 +174,6 @@ def test_video_playback_not_ready(app):
     assert res == {
         "ok": True,
         "generated": [],
-        "skipped": [256, 1024, 2048],
+        "skipped": [256, 512, 1024, 2048],
         "notes": "playback not ready",
     }

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1534,7 +1534,7 @@ def _verify_token(token: str):
 def api_media_thumbnail(media_id):
     """Return thumbnail image for a media item."""
     size = request.args.get("size", type=int, default=256)
-    if size not in (256, 1024, 2048):
+    if size not in (256, 512, 1024, 2048):
         return jsonify({"error": "invalid_size"}), 400
 
     media = Media.query.get(media_id)
@@ -1570,7 +1570,7 @@ def api_media_thumbnail(media_id):
 def api_media_thumb_url(media_id):
     data = request.get_json(silent=True) or {}
     size = data.get("size")
-    if size not in (256, 1024, 2048):
+    if size not in (256, 512, 1024, 2048):
         return jsonify({"error": "invalid_size"}), 400
 
     media = Media.query.get(media_id)


### PR DESCRIPTION
## Summary
- allow requesting 512px thumbnails via the media API
- generate 512px thumbnails alongside existing sizes and update tests accordingly

## Testing
- pytest tests/test_thumbs_generate.py
- pytest tests/test_media_api.py::test_thumb_url_ok tests/test_media_api.py::test_thumb_url_not_found

------
https://chatgpt.com/codex/tasks/task_e_68d15fe5b90483238468d1403371cffd