### PR TITLE
Ensure Celery logs to appdb.log and refine session detail links

### DIFF
--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -1,39 +1,81 @@
 """Logging configuration for core tasks."""
 
+from __future__ import annotations
+
 import logging
+import os
+from logging.handlers import WatchedFileHandler
+from pathlib import Path
 from typing import Optional
 
 from flask import current_app, has_app_context
 
 
+_APPDB_HANDLER_ATTR = "_is_appdb_log_handler"
+_APPDB_LOG_ENV = "APP_DB_LOG_PATH"
+_APPDB_DEFAULT_FILENAME = "appdb.log"
+
+
+def _resolve_appdb_log_path() -> Path:
+    """Return filesystem path for the appdb log file."""
+
+    env_path = os.environ.get(_APPDB_LOG_ENV)
+    if env_path:
+        path = Path(env_path)
+    else:
+        path = Path(_APPDB_DEFAULT_FILENAME)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path
+
+
+def _create_appdb_file_handler() -> logging.Handler:
+    """Create a file handler for appdb.log with sane defaults."""
+
+    log_path = _resolve_appdb_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    handler = WatchedFileHandler(log_path)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s'))
+    setattr(handler, _APPDB_HANDLER_ATTR, True)
+    return handler
+
+
+def ensure_appdb_file_logging(logger: logging.Logger) -> None:
+    """Attach the appdb.log file handler to *logger* if missing."""
+
+    for handler in logger.handlers:
+        if getattr(handler, _APPDB_HANDLER_ATTR, False):
+            break
+    else:
+        file_handler = _create_appdb_file_handler()
+        logger.addHandler(file_handler)
+
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
+
+
 def setup_task_logging(logger_name: Optional[str] = None) -> logging.Logger:
-    """Setup logging for core tasks to use DBLogHandler.
-    
-    Args:
-        logger_name: Name of the logger. If None, uses root logger.
-        
-    Returns:
-        Configured logger instance.
-    """
+    """Setup logging for core tasks to use DBLogHandler and appdb.log."""
+
     from core.db_log_handler import DBLogHandler
-    
+
     # Get logger
     if logger_name:
         logger = logging.getLogger(logger_name)
     else:
         logger = logging.getLogger()
-    
+
     # Check if DBLogHandler is already added
     if not any(isinstance(h, DBLogHandler) for h in logger.handlers):
         app_obj = current_app._get_current_object() if has_app_context() else None
         db_handler = DBLogHandler(app=app_obj)
         db_handler.setLevel(logging.INFO)
         logger.addHandler(db_handler)
-        
-        # Set logger level if not already set
-        if logger.level == logging.NOTSET:
-            logger.setLevel(logging.INFO)
-    
+
+    ensure_appdb_file_logging(logger)
+
     return logger
 
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,77 @@
+"""Tests for logging configuration helpers."""
+
+import logging
+
+import pytest
+
+from core.logging_config import ensure_appdb_file_logging, setup_task_logging
+
+
+@pytest.fixture
+def cleanup_logger():
+    loggers = []
+
+    def _register(name: str) -> logging.Logger:
+        logger = logging.getLogger(name)
+        loggers.append(logger)
+        return logger
+
+    yield _register
+
+    for logger in loggers:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        logger.handlers.clear()
+        logger.propagate = True
+        logger.setLevel(logging.NOTSET)
+
+
+def _flush_handlers(logger: logging.Logger) -> None:
+    for handler in logger.handlers:
+        flush = getattr(handler, "flush", None)
+        if callable(flush):
+            flush()
+
+
+def test_ensure_appdb_file_logging_writes_progress(tmp_path, monkeypatch, cleanup_logger):
+    log_path = tmp_path / "appdb.log"
+    monkeypatch.setenv("APP_DB_LOG_PATH", str(log_path))
+
+    logger = cleanup_logger("test.ensure_appdb")
+    logger.propagate = False
+
+    ensure_appdb_file_logging(logger)
+
+    logger.info("progress message", extra={"event": "test.progress"})
+    _flush_handlers(logger)
+
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8")
+    assert "progress message" in content
+    assert any(getattr(h, "_is_appdb_log_handler", False) for h in logger.handlers)
+
+
+def test_setup_task_logging_includes_appdb_handler(tmp_path, monkeypatch, cleanup_logger):
+    log_path = tmp_path / "custom_appdb.log"
+    db_path = tmp_path / "log.db"
+    monkeypatch.setenv("APP_DB_LOG_PATH", str(log_path))
+    monkeypatch.setenv("DATABASE_URI", f"sqlite:///{db_path}")
+
+    logger_name = "core.tasks.test_logger"
+    logger = cleanup_logger(logger_name)
+    logger.propagate = False
+
+    configured = setup_task_logging(logger_name)
+    assert configured is logger
+
+    logger.info("task finished", extra={"event": "test.task"})
+    _flush_handlers(logger)
+
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8")
+    assert "task finished" in content
+    assert any(getattr(h, "_is_appdb_log_handler", False) for h in logger.handlers)

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -225,7 +225,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const tr = document.createElement('tr');
     const displayName = selection.filename || selection.googleMediaId || 'N/A';
     const safeDisplayName = escapeHtml(displayName);
-    const fileCellContent = selection.mediaId
+    const canDisplayLink = selection.mediaId && ['imported', 'dup'].includes(selection.status);
+    const fileCellContent = canDisplayLink
       ? `<a href="/photo-view/media/${selection.mediaId}" class="text-decoration-none">${safeDisplayName}</a>`
       : safeDisplayName;
     tr.innerHTML = `


### PR DESCRIPTION
## Summary
- add an appdb.log file handler to Celery and task loggers so progress and errors are written to disk
- expose a helper in `core.logging_config` to attach the file handler and cover it with unit tests
- only render session detail links for imported or duplicate items to avoid broken links when errors occur

## Testing
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d16818cb2483239f031312821b3f75