### PR TITLE
Add retry attempt note to session details page

### DIFF
--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -29,6 +29,9 @@
 
 <div class="mt-4">
   <h2>{{ _("Selected Files") }}</h2>
+  <p class="text-muted small mb-2">
+    <i class="bi bi-info-circle"></i> 失敗したファイルは最大3回まで再試行されます。
+  </p>
   <div id="selection-counts" class="mb-2 text-muted">{{ _("Loading...") }}</div>
   <div class="table-responsive">
     <table class="table table-sm">


### PR DESCRIPTION
## Summary
- add an info message to the Session Details page to clarify failed files are retried up to three times

## Testing
- pytest tests/test_local_import_ui.py::TestSessionDetailUI::test_session_detail_page_renders

------
https://chatgpt.com/codex/tasks/task_e_68d16ab4ca04832383285c55d9933c91