### PR TITLE
Require authentication for signed download URLs

### DIFF
--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1776,6 +1776,7 @@ def api_media_playback_url(media_id):
 
 
 @bp.route("/dl/<path:token>", methods=["GET", "HEAD"])
+@login_or_jwt_required
 def api_download(token):
     payload, err = _verify_token(token)
     if err:


### PR DESCRIPTION
## Summary
- require authentication for the signed /api/dl download endpoint
- extend media API tests to cover the authentication requirement and keep token checks passing

## Testing
- pytest tests/test_media_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d16c2d0d848323b6fa9ffb19a3865b