### PR TITLE
Fix translation placeholder formatting on albums page

### DIFF
--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -620,7 +620,7 @@ document.addEventListener('DOMContentLoaded', () => {
     previousLabel: "{{ _('Previous')|escapejs }}",
     closeLabel: "{{ _('Close')|escapejs }}",
     shotAtLabel: "{{ _('Shot at')|escapejs }}",
-    positionLabel: "{{ _('%(current)s / %(total)s')|escapejs }}",
+    positionLabel: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
     slideshowLoadError: "{{ _('Unable to load album for slideshow.')|escapejs }}",
     slideshowNoMedia: "{{ _('This album has no media yet.')|escapejs }}",
     startSlideshow: "{{ _('Start Slideshow')|escapejs }}",


### PR DESCRIPTION
## Summary
- prevent the albums page JavaScript strings from raising translation placeholder errors by providing explicit placeholder values

## Testing
- python - <<'PY'
from webapp import create_app
app = create_app()
app.config['TESTING'] = True
with app.test_client() as client:
    resp = client.get('/photo-view/albums')
    assert resp.status_code == 200
PY

------
https://chatgpt.com/codex/tasks/task_e_68d171b01d0c832397dd234d712aeb0c