### PR TITLE
Adjust album slideshow overlay layout

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -367,25 +367,34 @@ body {
 }
 
 /* Album slideshow shared styles */
+
 .album-slideshow-overlay {
   position: fixed;
   inset: 0;
   background: rgba(15, 23, 42, 0.88);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 8px;
+  width: 100vw;
+  height: 100vh;
   z-index: 1080;
   backdrop-filter: blur(6px);
+  box-sizing: border-box;
 }
 
 .album-slideshow-overlay .album-slideshow-dialog {
   position: relative;
-  width: min(1100px, 100%);
-  max-height: 100%;
   display: flex;
   flex-direction: column;
   color: #f8fafc;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  min-height: 0;
+  box-sizing: border-box;
 }
 
 .album-slideshow-stage {
@@ -396,12 +405,15 @@ body {
   background: rgba(15, 23, 42, 0.6);
   border-radius: 18px;
   overflow: hidden;
-  min-height: 420px;
+  flex: 1 1 0;
+  min-height: 0;
 }
 
 .album-slideshow-stage img {
+  width: 100%;
+  height: 100%;
   max-width: 100%;
-  max-height: 70vh;
+  max-height: 100%;
   object-fit: contain;
   background: rgba(15, 23, 42, 0.3);
 }
@@ -506,7 +518,7 @@ body {
 
 @media (max-width: 768px) {
   .album-slideshow-stage {
-    min-height: 320px;
+    min-height: 0;
   }
 
   .album-slideshow-nav {


### PR DESCRIPTION
## Summary
- expand the album slideshow overlay dialog to stretch across the full viewport with minimal padding
- allow the slideshow stage to flexibly fill available space while keeping images contained at full height
- ensure mobile layouts no longer enforce a fixed stage height so the viewport can be fully utilized

## Testing
- browser_container.run_playwright_script (desktop/mobile overlay coverage check)


------
https://chatgpt.com/codex/tasks/task_e_68d1cdab9e1c8323a0b510428c81f0cf