### PR TITLE
Add configurable timeout to download task

### DIFF
--- a/tests/test_celery_context.py
+++ b/tests/test_celery_context.py
@@ -133,7 +133,7 @@ class TestCeleryAppContext:
     
     def test_download_file_task_context(self, app, celery_app, tmp_path):
         """Test that download_file task has proper Flask context."""
-        from cli.src.celery.tasks import download_file
+        from cli.src.celery.tasks import download_file, DEFAULT_DOWNLOAD_TIMEOUT
         
         # Mock the helper functions
         mock_content = b"test content"
@@ -153,7 +153,7 @@ class TestCeleryAppContext:
                     assert result['bytes'] == len(mock_content)
                     assert result['sha256'] == mock_sha
                     
-                    mock_download.assert_called_once_with("http://example.com/file")
+                    mock_download.assert_called_once_with("http://example.com/file", timeout=DEFAULT_DOWNLOAD_TIMEOUT)
                     mock_save.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- add a default download timeout constant and use it in the Celery download helper
- allow overriding the timeout from the download_file task and propagate it to requests.get
- expand tests to assert timeout usage and cover timeout error scenarios

## Testing
- pytest tests/test_celery_context.py tests/test_celery_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68d24a68eae48323af8abf1565ae6635