### PR TITLE
Prevent refresh token use for inactive users

### DIFF
--- a/tests/test_api_refresh_token.py
+++ b/tests/test_api_refresh_token.py
@@ -61,3 +61,19 @@ def test_refresh_invalid_token(client, app):
     res = client.post("/api/refresh", json={"refresh_token": "invalid"})
     assert res.status_code == 401
 
+
+def test_refresh_inactive_user(client, app):
+    _, refresh = login(client, app)
+
+    from webapp.extensions import db
+    from core.models.user import User
+
+    with app.app_context():
+        user = User.query.filter_by(email=app.test_user_email).first()
+        assert user is not None
+        user.is_active = False
+        db.session.commit()
+
+    res = client.post("/api/refresh", json={"refresh_token": refresh})
+    assert res.status_code == 401
+

--- a/webapp/services/token_service.py
+++ b/webapp/services/token_service.py
@@ -139,10 +139,18 @@ class TokenService:
             return None
         
         user = User.query.get(user_id)
-        if not user or not user.check_refresh_token(refresh_token):
+        if not user:
+            current_app.logger.debug("Refresh token verification failed: user not found")
+            return None
+
+        if not user.is_active:
+            current_app.logger.debug("Refresh token verification failed: user inactive")
+            return None
+
+        if not user.check_refresh_token(refresh_token):
             current_app.logger.debug("Refresh token verification failed")
             return None
-            
+
         return user
     
     @classmethod


### PR DESCRIPTION
## Summary
- block refresh token verification when the associated user record is missing or inactive
- add an API test that ensures inactive users cannot obtain new tokens via /api/refresh

## Testing
- pytest tests/test_api_refresh_token.py

------
https://chatgpt.com/codex/tasks/task_e_68d24c0a9fe08323956f24014891af45