### PR TITLE
Use UTC timestamps in session recovery task

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,6 @@ SKIP_RULES = [
     ("tests/test_celery_", "CeleryワーカーやRedisが必要なためスキップ"),
     ("tests/test_picker_", "Google Photos連携やCeleryワーカーが必要なためスキップ"),
     ("tests/test_local_import", "ローカルインポート用のNASディレクトリ・バックグラウンドサービスが必要なためスキップ"),
-    ("tests/test_session_recovery", "Celeryタスク監視用の外部サービスが必要なためスキップ"),
     ("tests/test_thumbnail_import.py", "オリジナル写真格納先へのアクセスが必要なためスキップ"),
     ("tests/test_video_transcoding.py", "動画トランスコード用のFFmpeg等外部依存が必要なためスキップ"),
     ("tests/test_backup_cleanup_tasks.py", "バックアップCeleryタスク用のジョブ環境が必要なためスキップ"),

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from core.tasks.session_recovery import (
     cleanup_stale_sessions, 
     force_cleanup_all_processing_sessions,
@@ -17,7 +17,7 @@ class TestSessionRecovery:
 
     def test_cleanup_stale_sessions_no_stale_sessions(self, app_context):
         """古いセッションがない場合のテスト"""
-        with patch('core.tasks.session_recovery.celery') as mock_celery:
+        with patch('cli.src.celery.celery_app.celery') as mock_celery:
             # Celeryの active tasks をモック
             mock_inspect = MagicMock()
             mock_inspect.active.return_value = {}
@@ -31,12 +31,12 @@ class TestSessionRecovery:
 
     def test_cleanup_respects_session_type_timeouts(self, app_context):
         """セッションタイプに応じたタイムアウト時間のテスト"""
-        with patch('core.tasks.session_recovery.celery') as mock_celery:
+        with patch('cli.src.celery.celery_app.celery') as mock_celery:
             mock_inspect = MagicMock()
             mock_inspect.active.return_value = {}
             mock_celery.control.inspect.return_value = mock_inspect
             
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             
             # ローカルインポート: 1.5時間前（2時間タイムアウトなのでまだOK）
             local_session = PickerSession(
@@ -70,10 +70,13 @@ class TestSessionRecovery:
             updated_picker = PickerSession.query.filter_by(session_id="picker-test").first()
             assert updated_picker.status == "error"
             assert "picker_import" in updated_picker.error_message
+            assert "Z" in updated_picker.error_message
+
+            assert result["details"][0]["last_updated"].endswith("Z")
 
     def test_cleanup_protects_active_celery_tasks(self, app_context):
         """Celeryで実行中のタスクが保護されることのテスト"""
-        with patch('core.tasks.session_recovery.celery') as mock_celery:
+        with patch('cli.src.celery.celery_app.celery') as mock_celery:
             # 実行中タスクをモック
             mock_inspect = MagicMock()
             mock_inspect.active.return_value = {
@@ -87,7 +90,7 @@ class TestSessionRecovery:
             }
             mock_celery.control.inspect.return_value = mock_inspect
             
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             
             # 3時間前の古いセッション（Celeryで実行中）
             active_session = PickerSession(
@@ -120,10 +123,11 @@ class TestSessionRecovery:
             # 非実行中セッションはクリーンアップされた
             inactive = PickerSession.query.filter_by(session_id="inactive-session-id").first()
             assert inactive.status == "error"
+            assert "Z" in inactive.error_message
 
     def test_get_session_status_report(self, app_context):
         """セッション状況レポート生成のテスト"""
-        with patch('core.tasks.session_recovery.celery') as mock_celery:
+        with patch('cli.src.celery.celery_app.celery') as mock_celery:
             mock_inspect = MagicMock()
             mock_inspect.active.return_value = {
                 'worker1': [
@@ -138,18 +142,20 @@ class TestSessionRecovery:
             mock_celery.control.inspect.return_value = mock_inspect
             
             # テストセッション作成
+            timestamp = datetime.now(timezone.utc)
             session = PickerSession(
                 session_id="test-session",
                 status="processing",
-                created_at=datetime.now() - timedelta(minutes=30),
-                updated_at=datetime.now() - timedelta(minutes=30)
+                created_at=timestamp - timedelta(minutes=30),
+                updated_at=timestamp - timedelta(minutes=30)
             )
             db.session.add(session)
             db.session.commit()
             
             report = get_session_status_report()
-            
+
             assert 'timestamp' in report
+            assert report['timestamp'].endswith('Z')
             assert 'celery_workers_count' in report
             assert 'active_tasks_count' in report
             assert 'processing_sessions_count' in report
@@ -160,15 +166,17 @@ class TestSessionRecovery:
             assert session_info['session_id'] == "test-session"
             assert session_info['is_active_in_celery'] is True
             assert session_info['type'] == 'other'  # test-session は other タイプ
+            assert session_info['created_at'].endswith('Z')
+            assert session_info['updated_at'].endswith('Z')
 
     def test_cleanup_uses_updated_at_not_created_at(self, app_context):
         """updated_at を基準にタイムアウト判定することのテスト"""
-        with patch('core.tasks.session_recovery.celery') as mock_celery:
+        with patch('cli.src.celery.celery_app.celery') as mock_celery:
             mock_inspect = MagicMock()
             mock_inspect.active.return_value = {}
             mock_celery.control.inspect.return_value = mock_inspect
             
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             
             # 作成は古いが、最近更新されたセッション
             recent_update_session = PickerSession(
@@ -193,21 +201,23 @@ class TestSessionRecovery:
     def test_force_cleanup_all_processing_sessions(self, app_context):
         """全処理中セッションの強制クリーンアップテスト"""
         # 複数の処理中セッションを作成
+        sessions = []
         for i in range(3):
             session = PickerSession(
                 session_id=f"test-force-cleanup-{i}",
                 status="processing",
-                created_at=datetime.now(),
-                updated_at=datetime.now()
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc)
             )
             db.session.add(session)
+            sessions.append(session)
         
         # 完了済みセッションも作成（これは変更されないはず）
         completed_session = PickerSession(
             session_id="test-completed",
             status="ready",
-            created_at=datetime.now(),
-            updated_at=datetime.now()
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
         )
         db.session.add(completed_session)
         db.session.commit()
@@ -219,10 +229,11 @@ class TestSessionRecovery:
         assert "3個のセッション" in result["message"]
         
         # 全ての処理中セッションがエラー状態になっていることを確認
-        for i in range(3):
-            session = PickerSession.query.filter_by(session_id=f"test-force-cleanup-{i}").first()
+        for session in sessions:
+            db.session.refresh(session)
             assert session.status == "error"
             assert "強制クリーンアップ" in session.error_message
+            assert "Z" in session.error_message
         
         # 完了済みセッションは変更されていないことを確認
         completed = PickerSession.query.filter_by(session_id="test-completed").first()
@@ -237,7 +248,7 @@ class TestSessionRecovery:
         monkeypatch.setattr(db.session, "commit", mock_commit)
         
         # 古いセッションを作成
-        old_time = datetime.now() - timedelta(minutes=35)
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=35)
         session = PickerSession(
             session_id="test-error-handling",
             status="processing",


### PR DESCRIPTION
## Summary
- session recovery タスクで UTC タイムスタンプを使用し、ISO 8601 の Z 表記でロギングとメッセージを整形
- UTC 変換用ヘルパーを追加して `cleanup_stale_sessions` / `get_session_status_report` / `force_cleanup_all_processing_sessions` の日時処理を統一
- セッションリカバリのテストを UTC 前提に更新し、スキップ設定を調整してテストを実行可能に

## Testing
- pytest tests/test_session_recovery.py

------
https://chatgpt.com/codex/tasks/task_e_68d24a3110988323879eda2288afd08a