### PR TITLE
Reuse ORM model during authentication

### DIFF
--- a/domain/user/entities.py
+++ b/domain/user/entities.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 from werkzeug.security import generate_password_hash, check_password_hash
 
 
@@ -12,6 +12,7 @@ class User:
     id: Optional[int] = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     is_active: bool = True
+    _model: Any = field(init=False, default=None, repr=False, compare=False)
 
     def set_password(self, raw: str) -> None:
         self.password_hash = generate_password_hash(raw)

--- a/infrastructure/user_repository.py
+++ b/infrastructure/user_repository.py
@@ -29,6 +29,7 @@ class SqlAlchemyUserRepository(UserRepository):
         self.session.add(model)
         self.session.commit()
         user.id = model.id
+        user._model = model
         return user
 
     def update(self, user: User) -> User:
@@ -43,6 +44,7 @@ class SqlAlchemyUserRepository(UserRepository):
         model.is_active = user.is_active
         
         self.session.commit()
+        user._model = model
         return user
 
     def delete(self, user: User) -> None:
@@ -53,15 +55,19 @@ class SqlAlchemyUserRepository(UserRepository):
             self.session.commit()
 
     def get_model(self, user: User) -> UserModel:
+        model = getattr(user, "_model", None)
+        if model is not None:
+            return model
         return UserModel.query.get(user.id)
 
     def _to_domain(self, model: UserModel) -> User:
         user = User(
-            email=model.email, 
-            totp_secret=model.totp_secret, 
+            email=model.email,
+            totp_secret=model.totp_secret,
             id=model.id, 
             created_at=model.created_at,
             is_active=model.is_active
         )
         user.password_hash = model.password_hash
+        user._model = model
         return user

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -898,8 +898,7 @@ def api_login():
         return jsonify({"error": "invalid_credentials"}), 401
     
     # TokenServiceを使用してトークンペアを生成
-    user_model = user_repo.get_model(user)
-    access_token, refresh_token = TokenService.generate_token_pair(user_model)
+    access_token, refresh_token = TokenService.generate_token_pair(user._model)
     
     resp = jsonify({"access_token": access_token, "refresh_token": refresh_token})
     resp.set_cookie(

--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -82,7 +82,7 @@ def _clear_setup_totp_session():
 def _complete_registration(user):
     """ユーザー登録完了後の共通処理"""
     flash(_("Registration successful"), "success")
-    login_user(user_repo.get_model(user))
+    login_user(user._model)
     return redirect(url_for("feature_x.dashboard"))
 
 
@@ -121,7 +121,7 @@ def login():
             if not token or not verify_totp(user.totp_secret, token):
                 flash(_("Invalid authentication code"), "error")
                 return render_template("auth/login.html")
-        login_user(user_repo.get_model(user))
+        login_user(user._model)
         return redirect(url_for("feature_x.dashboard"))
     return render_template("auth/login.html")
 
@@ -192,7 +192,7 @@ def register_totp():
             
             _clear_registration_session()
             flash(_("Registration successful"), "success")
-            login_user(user_repo.get_model(u))
+            login_user(u._model)
             return redirect(url_for("feature_x.dashboard"))
         except Exception as e:
             flash(_("Registration failed: {}").format(str(e)), "error")


### PR DESCRIPTION
## Summary
- store the underlying ORM model on domain users during authentication and persistence
- update login flows to rely on the authenticated model instead of fetching it again

## Testing
- pytest tests/test_auth_utils.py
- pytest tests/test_auth_profile.py
- pytest tests/test_api_logout.py
- pytest tests/test_api_refresh_token.py


------
https://chatgpt.com/codex/tasks/task_e_68d24e31e8c883239f44ad69d193b937