### PR TITLE
Reuse ORM model during authentication

### DIFF
--- a/tests/test_auth_service_repository_integration.py
+++ b/tests/test_auth_service_repository_integration.py
@@ -49,6 +49,7 @@ def test_register_and_authenticate_with_custom_session(session, auth_service):
 
     authenticated = auth_service.authenticate("user@example.com", "secret")
     assert authenticated is not None
+    assert isinstance(authenticated, UserModel)
     assert authenticated.id == user.id
 
     assert auth_service.authenticate("user@example.com", "wrong") is None
@@ -98,5 +99,6 @@ def test_inactive_user_replaced_on_register(session, auth_service):
 
     authenticated = auth_service.authenticate("replace@example.com", "new-secret")
     assert authenticated is not None
+    assert isinstance(authenticated, UserModel)
     assert authenticated.id == new_user.id
     assert auth_service.authenticate("replace@example.com", "old-secret") is None

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1000,14 +1000,11 @@ def api_login():
     data = request.get_json(silent=True) or {}
     email = data.get("email")
     password = data.get("password")
-    user = auth_service.authenticate(email, password)
-    if not user:
+    user_model = auth_service.authenticate(email, password)
+    if not user_model:
         return jsonify({"error": "invalid_credentials"}), 401
 
     # TokenServiceを使用してトークンペアを生成
-    user_model = getattr(user, "_model", None)
-    if user_model is None:
-        user_model = user_repo.get_model(user)
     access_token, refresh_token = TokenService.generate_token_pair(user_model)
     
     resp = jsonify({"access_token": access_token, "refresh_token": refresh_token})


### PR DESCRIPTION
## Summary
- update `AuthService.authenticate` to return the ORM `UserModel`, reusing the instance retrieved during lookup
- adjust web and API login flows to use the authenticated ORM model directly without extra repository queries
- refresh repository integration tests to expect the ORM model result

## Testing
- pytest tests/test_auth_service_repository_integration.py
- pytest tests/test_auth_profile.py tests/test_api_refresh_token.py

------
https://chatgpt.com/codex/tasks/task_e_68d25592f64483239f7b2b8c343c29a3