### PR TITLE
Fix album slideshow controls and media ordering

### DIFF
--- a/webapp/photo_view/templates/photo_view/album_detail.html
+++ b/webapp/photo_view/templates/photo_view/album_detail.html
@@ -285,6 +285,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const THUMBNAIL_SIZE_PRIORITY = [2048, 1024, 512];
 
+  function sortAlbumMediaItems(items) {
+    if (!Array.isArray(items)) {
+      return [];
+    }
+    const normalizeIndex = (value, fallback = Number.MAX_SAFE_INTEGER) => {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : fallback;
+    };
+    return items
+      .slice()
+      .sort((a, b) => {
+        const sortA = normalizeIndex(a?.sortIndex);
+        const sortB = normalizeIndex(b?.sortIndex);
+        if (sortA !== sortB) {
+          return sortA - sortB;
+        }
+        const idA = normalizeIndex(a?.id);
+        const idB = normalizeIndex(b?.id);
+        return idA - idB;
+      });
+  }
+
   function normalizeThumbnailSize(value) {
     if (typeof value === 'number' && Number.isFinite(value)) {
       return value;
@@ -653,7 +675,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if (data?.album) {
         state.album = data.album;
-        state.media = Array.isArray(data.album.media) ? data.album.media : state.media;
+        state.media = sortAlbumMediaItems(Array.isArray(data.album.media) ? data.album.media : state.media);
       }
       showSuccessToast(strings.reorderSaved);
       resetReorderState();
@@ -793,7 +815,7 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error('Missing album payload');
       }
       state.album = data.album;
-      state.media = Array.isArray(data.album.media) ? data.album.media : [];
+      state.media = sortAlbumMediaItems(Array.isArray(data.album.media) ? data.album.media : []);
       resetReorderState();
       renderAlbumDetail();
       elements.content.classList.remove('d-none');
@@ -908,7 +930,7 @@ document.addEventListener('DOMContentLoaded', () => {
         tile.addEventListener('dragend', onTileDragEnd);
       } else {
         tile.addEventListener('click', () => {
-          slideshow.open(index);
+          slideshow.open(index, { autoplay: false });
         });
       }
 

--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -2075,8 +2075,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const actionButton = event.target.closest('[data-album-action]');
       if (actionButton) {
+        event.preventDefault();
         event.stopPropagation();
         const albumId = Number(actionButton.dataset.albumId);
+        if (!Number.isFinite(albumId)) {
+          return;
+        }
         if (actionButton.dataset.albumAction === 'edit') {
           loadAlbumForEdit(albumId);
         } else if (actionButton.dataset.albumAction === 'delete') {
@@ -2088,6 +2092,23 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       window.location.href = `/photo-view/albums/${album.id}`;
     });
+
+    const slideshowButton = card.querySelector('button[data-album-action="slideshow"]');
+    if (slideshowButton) {
+      slideshowButton.addEventListener('click', (event) => {
+        if (reorderMode) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        const albumId = Number(slideshowButton.dataset.albumId);
+        if (Number.isFinite(albumId)) {
+          openAlbumSlideshow(albumId);
+        }
+      });
+    }
 
     const reorderControls = card.querySelector('.album-reorder-controls');
     if (reorderControls) {

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -449,8 +449,8 @@ body {
 
 .album-slideshow-close {
   position: absolute;
-  top: 16px;
-  right: 16px;
+  top: 28px;
+  right: 28px;
   background: rgba(15, 23, 42, 0.85);
   border-radius: 50%;
   border: 1px solid rgba(148, 163, 184, 0.4);
@@ -525,6 +525,11 @@ body {
   .album-slideshow-nav {
     width: 40px;
     height: 40px;
+  }
+
+  .album-slideshow-close {
+    top: 20px;
+    right: 20px;
   }
 
   .album-slideshow-info .album-title {


### PR DESCRIPTION
## Summary
- ensure album detail loads album media using the saved sort order so drag-and-drop changes persist into the slideshow
- stop auto-playing when opening the slideshow from a media tile and keep the start button behaviour explicit
- fix the album list slideshow button to open the overlay instead of navigating away and reposition the close icon for better alignment

## Testing
- not run (frontend changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d256c0e5388323902bd3fee21e94c9