### PR TITLE
Fix slideshow close button layering

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -462,6 +462,7 @@ body {
   color: #f8fafc;
   cursor: pointer;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.35);
+  z-index: 2;
 }
 
 .album-slideshow-footer {


### PR DESCRIPTION
## Summary
- ensure the album slideshow close button renders above the stage content by adding an explicit stacking order

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d25c7064088323ad579365b813e7a0