### PR TITLE
Refactor album editor and add dedicated slideshow page

### DIFF
--- a/webapp/photo_view/routes.py
+++ b/webapp/photo_view/routes.py
@@ -8,7 +8,7 @@ implementation work.
 
 import os
 
-from flask import current_app, render_template, request
+from flask import current_app, render_template, request, url_for
 from flask_login import current_user
 
 from core.models.authz import require_roles, require_perms
@@ -112,7 +112,44 @@ def album_detail(album_id: int):
 @require_perms("media:view", "album:view")
 def album_create():
     """Standalone page for creating a new album."""
-    return render_template("photo_view/albums.html", editor_view=True)
+    return render_template(
+        "photo_view/albums.html",
+        editor_view=True,
+        editor_album_id=None,
+        editor_success_url=url_for("photo_view.albums"),
+        editor_cancel_url=url_for("photo_view.albums"),
+    )
+
+
+@bp.route("/albums/<int:album_id>/edit")
+@require_perms("media:view", "album:view")
+def album_edit(album_id: int):
+    """Standalone page for editing an existing album."""
+
+    return render_template(
+        "photo_view/albums.html",
+        editor_view=True,
+        editor_album_id=album_id,
+        editor_success_url=url_for("photo_view.album_detail", album_id=album_id),
+        editor_cancel_url=url_for("photo_view.album_detail", album_id=album_id),
+    )
+
+
+@bp.route("/albums/<int:album_id>/slideshow")
+@require_perms("media:view", "album:view")
+def album_slideshow(album_id: int):
+    """Dedicated slideshow view for an album."""
+
+    start_index = request.args.get("start", type=int)
+    autoplay = request.args.get("autoplay", default="1")
+    autoplay_enabled = str(autoplay).lower() not in {"0", "false", "no"}
+
+    return render_template(
+        "photo_view/album_slideshow.html",
+        album_id=album_id,
+        start_index=start_index if isinstance(start_index, int) else None,
+        autoplay_enabled=autoplay_enabled,
+    )
 
 
 @bp.route("/tags")

--- a/webapp/photo_view/templates/photo_view/album_detail.html
+++ b/webapp/photo_view/templates/photo_view/album_detail.html
@@ -203,45 +203,9 @@
   </div>
 </div>
 
-<div id="album-slideshow-overlay" class="album-slideshow-overlay d-none" aria-hidden="true">
-  <div class="album-slideshow-dialog">
-    <button type="button" class="album-slideshow-close" id="album-slideshow-close" aria-label="{{ _('Close') }}">
-      <i class="bi bi-x-lg"></i>
-    </button>
-    <div id="album-slideshow-loading" class="album-slideshow-loading d-none">
-      <div class="spinner-border text-light" role="status"></div>
-      <span>{{ _('Loading slideshow...') }}</span>
-    </div>
-    <div id="album-slideshow-stage" class="album-slideshow-stage d-none">
-      <button type="button" class="album-slideshow-nav prev" id="album-slideshow-prev" aria-label="{{ _('Previous') }}">
-        <i class="bi bi-chevron-left"></i>
-      </button>
-      <img id="album-slideshow-image" src="" alt="" loading="lazy">
-      <button type="button" class="album-slideshow-nav next" id="album-slideshow-next" aria-label="{{ _('Next') }}">
-        <i class="bi bi-chevron-right"></i>
-      </button>
-    </div>
-    <div id="album-slideshow-empty" class="album-slideshow-empty d-none">
-      {{ _('This album has no media yet.') }}
-    </div>
-    <div class="album-slideshow-footer">
-      <div class="album-slideshow-info">
-        <span class="album-title" id="album-slideshow-title"></span>
-        <span class="album-meta" id="album-slideshow-meta"></span>
-      </div>
-      <div class="album-slideshow-controls">
-        <div class="album-slideshow-counter" id="album-slideshow-counter"></div>
-        <button type="button" class="btn btn-outline-light" id="album-slideshow-toggle">
-          <i class="bi bi-play-fill me-1"></i><span data-label>{{ _('Play') }}</span>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
 {% endblock %}
 
 {% block extra_scripts %}
-<script src="{{ url_for('static', filename='js/album-slideshow.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const albumId = Number('{{ album_id }}');
@@ -251,90 +215,13 @@ document.addEventListener('DOMContentLoaded', () => {
     media: [],
   };
 
-  const slideshowIntentStorageKey = 'photoView.slideshowIntent';
-  const autoplayQueryKeys = ['slideshow', 'autoplay'];
-
-  function parseAutoplayFlag(value) {
-    if (value === null || value === undefined) {
-      return false;
-    }
-    const normalized = value.toString().trim().toLowerCase();
-    if (!normalized) {
-      return false;
-    }
-    return !['0', 'false', 'no', 'off'].includes(normalized);
-  }
-
-  function consumeSlideshowIntent() {
-    let shouldAutoplay = false;
-    const params = new URLSearchParams(window.location.search);
-    const queryValues = autoplayQueryKeys.map((key) => params.get(key));
-    if (queryValues.some((value) => parseAutoplayFlag(value))) {
-      shouldAutoplay = true;
-    }
-
-    let storedIntentRaw = null;
-    try {
-      storedIntentRaw = window.sessionStorage?.getItem(slideshowIntentStorageKey) || null;
-    } catch (error) {
-      console.warn('Failed to access slideshow intent storage', error);
-    }
-
-    if (storedIntentRaw) {
-      try {
-        const parsedIntent = JSON.parse(storedIntentRaw);
-        if (Number(parsedIntent?.albumId) === albumId) {
-          const expiresAt = Number(parsedIntent?.expiresAt);
-          if (!Number.isFinite(expiresAt) || expiresAt >= Date.now()) {
-            shouldAutoplay = true;
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to parse slideshow intent payload', error);
-      }
-    }
-
-    try {
-      window.sessionStorage?.removeItem(slideshowIntentStorageKey);
-    } catch (error) {
-      console.warn('Failed to clear slideshow intent storage', error);
-    }
-
-    if (queryValues.some((value) => value !== null)) {
-      autoplayQueryKeys.forEach((key) => params.delete(key));
-      const newQuery = params.toString();
-      const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash}`;
-      try {
-        window.history.replaceState({}, document.title, newUrl);
-      } catch (error) {
-        console.warn('Failed to update URL after consuming slideshow intent', error);
-      }
-    }
-
-    return shouldAutoplay;
-  }
-
-  let autoplayOnLoad = consumeSlideshowIntent();
-
-  const reorderState = {
-    active: false,
-    originalMedia: [],
-    originalIds: [],
-    dirty: false,
-    saving: false,
-    dragSourceIndex: null,
-  };
-
   const strings = {
     untitledAlbum: "{{ _('Untitled Album')|escapejs }}",
     mediaCountSingular: "{{ ngettext('%(count)s photo', '%(count)s photos', 1, count='%(count)s')|escapejs }}",
     mediaCountPlural: "{{ ngettext('%(count)s photo', '%(count)s photos', 2, count='%(count)s')|escapejs }}",
     createdLabel: "{{ _('Created')|escapejs }}",
     updatedLabel: "{{ _('Updated')|escapejs }}",
-    shotAtLabel: "{{ _('Shot at')|escapejs }}",
-    positionLabel: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
     loadingError: "{{ _('Failed to load album information.')|escapejs }}",
-    slideshowLoading: "{{ _('Loading slideshow...')|escapejs }}",
     noMedia: "{{ _('This album has no media yet.')|escapejs }}",
     reorderHint: "{{ _('Drag and drop media tiles to change their order.')|escapejs }}",
     reorderDirtyHint: "{{ _('Don\'t forget to save your changes.')|escapejs }}",
@@ -347,172 +234,6 @@ document.addEventListener('DOMContentLoaded', () => {
       unlisted: "{{ _('Unlisted')|escapejs }}",
     },
   };
-
-  const THUMBNAIL_SIZE_PRIORITY = [2048, 1024, 512];
-
-  function sortAlbumMediaItems(items) {
-    if (!Array.isArray(items)) {
-      return [];
-    }
-    const normalizeIndex = (value, fallback = Number.MAX_SAFE_INTEGER) => {
-      const numeric = Number(value);
-      return Number.isFinite(numeric) ? numeric : fallback;
-    };
-    return items
-      .slice()
-      .sort((a, b) => {
-        const sortA = normalizeIndex(a?.sortIndex);
-        const sortB = normalizeIndex(b?.sortIndex);
-        if (sortA !== sortB) {
-          return sortA - sortB;
-        }
-        const idA = normalizeIndex(a?.id);
-        const idB = normalizeIndex(b?.id);
-        return idA - idB;
-      });
-  }
-
-  function normalizeThumbnailSize(value) {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-    if (typeof value === 'string') {
-      const trimmed = value.trim();
-      if (trimmed) {
-        const parsed = Number.parseInt(trimmed, 10);
-        if (Number.isFinite(parsed)) {
-          return parsed;
-        }
-      }
-    }
-    return null;
-  }
-
-  function collectThumbnailAvailability(item) {
-    const available = new Set();
-    const urlBySize = new Map();
-
-    const register = (size, url) => {
-      if (!Number.isFinite(size)) {
-        return;
-      }
-      available.add(size);
-      if (typeof url === 'string' && url) {
-        urlBySize.set(size, url);
-      }
-    };
-
-    const variantSources = [
-      item?.thumbnailUrls,
-      item?.thumbnails,
-      item?.thumbnail_variants,
-      item?.thumbnailVariants,
-    ];
-
-    variantSources.forEach((source) => {
-      if (!source) {
-        return;
-      }
-      if (Array.isArray(source)) {
-        source.forEach((entry) => {
-          if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
-            const size = normalizeThumbnailSize(entry.size ?? entry.dimension ?? entry.width ?? entry.height);
-            const url = entry.url ?? entry.href ?? entry.path ?? null;
-            if (size !== null) {
-              register(size, typeof url === 'string' ? url : null);
-            }
-          } else {
-            const size = normalizeThumbnailSize(entry);
-            if (size !== null) {
-              register(size);
-            }
-          }
-        });
-      } else if (typeof source === 'object') {
-        Object.entries(source).forEach(([key, value]) => {
-          const keySize = normalizeThumbnailSize(key);
-          if (typeof value === 'string') {
-            if (keySize !== null) {
-              register(keySize, value);
-            }
-            return;
-          }
-          if (value && typeof value === 'object' && !Array.isArray(value)) {
-            const nestedSize = normalizeThumbnailSize(
-              value.size ?? value.dimension ?? value.width ?? value.height ?? keySize,
-            );
-            const url = value.url ?? value.href ?? value.path ?? null;
-            if (nestedSize !== null) {
-              register(nestedSize, typeof url === 'string' ? url : null);
-            } else if (keySize !== null) {
-              register(keySize, typeof url === 'string' ? url : null);
-            }
-          } else if (value && keySize !== null) {
-            register(keySize);
-          }
-        });
-      }
-    });
-
-    const availabilitySources = [
-      item?.availableThumbnailSizes,
-      item?.thumbnailSizes,
-      item?.availableThumbnails,
-    ];
-
-    availabilitySources.forEach((source) => {
-      if (!source) {
-        return;
-      }
-      if (Array.isArray(source)) {
-        source.forEach((entry) => {
-          const size = normalizeThumbnailSize(entry);
-          if (size !== null) {
-            available.add(size);
-          }
-        });
-      } else if (typeof source === 'object') {
-        Object.entries(source).forEach(([key, value]) => {
-          if (!value) {
-            return;
-          }
-          const size = normalizeThumbnailSize(key);
-          if (size !== null) {
-            available.add(size);
-          }
-        });
-      }
-    });
-
-    return { available, urlBySize };
-  }
-
-  function resolveSlideshowImageUrl(item) {
-    if (!item) {
-      return '';
-    }
-
-    const { available, urlBySize } = collectThumbnailAvailability(item);
-    const buildUrl = (size) => (item.id ? `/api/media/${item.id}/thumbnail?size=${size}` : '');
-
-    for (const size of THUMBNAIL_SIZE_PRIORITY) {
-      if (urlBySize.has(size)) {
-        return urlBySize.get(size);
-      }
-      if (available.has(size)) {
-        const resolved = buildUrl(size);
-        if (resolved) {
-          return resolved;
-        }
-      }
-    }
-
-    if (typeof item.thumbnailUrl === 'string' && item.thumbnailUrl) {
-      return item.thumbnailUrl;
-    }
-
-    return buildUrl(512);
-  }
 
   const elements = {
     loading: document.getElementById('album-loading'),
@@ -536,48 +257,6 @@ document.addEventListener('DOMContentLoaded', () => {
     cancel: document.getElementById('album-reorder-cancel'),
     hint: document.getElementById('album-reorder-hint'),
   };
-
-  const slideshow = new AlbumSlideshow({
-    overlayElement: document.getElementById('album-slideshow-overlay'),
-    stageElement: document.getElementById('album-slideshow-stage'),
-    imageElement: document.getElementById('album-slideshow-image'),
-    titleElement: document.getElementById('album-slideshow-title'),
-    metaElement: document.getElementById('album-slideshow-meta'),
-    counterElement: document.getElementById('album-slideshow-counter'),
-    emptyStateElement: document.getElementById('album-slideshow-empty'),
-    loadingElement: document.getElementById('album-slideshow-loading'),
-    playPauseButton: document.getElementById('album-slideshow-toggle'),
-    prevButton: document.getElementById('album-slideshow-prev'),
-    nextButton: document.getElementById('album-slideshow-next'),
-    closeButton: document.getElementById('album-slideshow-close'),
-    labels: {
-      play: "{{ _('Play')|escapejs }}",
-      pause: "{{ _('Pause')|escapejs }}",
-      next: "{{ _('Next')|escapejs }}",
-      previous: "{{ _('Previous')|escapejs }}",
-      close: "{{ _('Close')|escapejs }}",
-      counter: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
-      noMedia: strings.noMedia,
-      shotAt: strings.shotAtLabel,
-      albumTitleFallback: "{{ _('Album')|escapejs }}",
-    },
-    imageUrlResolver: resolveSlideshowImageUrl,
-    metadataFormatter: (item, context) => {
-      const parts = [];
-      if (item?.shotAt) {
-        const formatted = formatDateTime(item.shotAt);
-        if (formatted) {
-          parts.push(`${strings.shotAtLabel} ${formatted}`);
-        }
-      }
-      parts.push(
-        strings.positionLabel
-          .replace('%(current)s', (context.index + 1).toString())
-          .replace('%(total)s', context.total.toString()),
-      );
-      return parts.join(' · ');
-    },
-  });
 
   function showReorderHint(message, level = 'info') {
     if (!reorderElements.hint) {
@@ -712,7 +391,6 @@ document.addEventListener('DOMContentLoaded', () => {
     state.media = reorderState.originalMedia.slice();
     resetReorderState();
     renderAlbumDetail();
-    slideshow.load(state.media, { albumTitle: state.album?.title || strings.untitledAlbum });
   }
 
   async function saveMediaOrder() {
@@ -745,7 +423,6 @@ document.addEventListener('DOMContentLoaded', () => {
       showSuccessToast(strings.reorderSaved);
       resetReorderState();
       renderAlbumDetail();
-      slideshow.load(state.media, { albumTitle: state.album?.title || strings.untitledAlbum });
     } catch (error) {
       console.error('Failed to save album media order', error);
       showErrorToast(strings.reorderSaveError);
@@ -885,16 +562,6 @@ document.addEventListener('DOMContentLoaded', () => {
       renderAlbumDetail();
       elements.content.classList.remove('d-none');
       updateSlideshowButtonState();
-      slideshow.load(state.media, { albumTitle: state.album.title || strings.untitledAlbum });
-      if (autoplayOnLoad) {
-        if (!state.media.length) {
-          showInfoToast(strings.noMedia);
-          slideshow.open(0, { autoplay: false });
-        } else {
-          slideshow.open(0);
-        }
-        autoplayOnLoad = false;
-      }
     } catch (error) {
       console.error('Failed to load album detail', error);
       elements.error.classList.remove('d-none');
@@ -953,6 +620,26 @@ document.addEventListener('DOMContentLoaded', () => {
     renderMediaGrid();
   }
 
+  function navigateToSlideshow(startIndex = 0, options = {}) {
+    const url = new URL(`/photo-view/albums/${albumId}/slideshow`, window.location.origin);
+    const params = new URLSearchParams();
+
+    const normalizedIndex = Number(startIndex);
+    if (Number.isInteger(normalizedIndex) && normalizedIndex >= 0) {
+      params.set('start', normalizedIndex.toString());
+    }
+
+    if (options.autoplay === false) {
+      params.set('autoplay', '0');
+    }
+
+    if ([...params.keys()].length > 0) {
+      url.search = params.toString();
+    }
+
+    window.location.href = url.toString();
+  }
+
   function renderMediaGrid() {
     elements.mediaGrid.innerHTML = '';
     elements.mediaGrid.classList.toggle('reorder-active', reorderState.active);
@@ -1004,7 +691,7 @@ document.addEventListener('DOMContentLoaded', () => {
         tile.addEventListener('dragend', onTileDragEnd);
       } else {
         tile.addEventListener('click', () => {
-          slideshow.open(index, { autoplay: false });
+          navigateToSlideshow(index, { autoplay: false });
         });
       }
 
@@ -1074,7 +761,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showInfoToast(strings.noMedia);
       return;
     }
-    slideshow.open(0);
+    navigateToSlideshow(0);
   });
 
   if (reorderElements.toggle) {

--- a/webapp/photo_view/templates/photo_view/album_slideshow.html
+++ b/webapp/photo_view/templates/photo_view/album_slideshow.html
@@ -1,0 +1,328 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Album Slideshow') }}{% endblock %}
+
+{% block extra_head %}
+<style>
+  .album-slideshow-page {
+    min-height: calc(100vh - var(--navbar-height, 0px));
+    background: rgba(15, 23, 42, 0.9);
+  }
+
+  .album-slideshow-dialog {
+    padding: 24px;
+  }
+
+  .album-slideshow-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .album-slideshow-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  @media (max-width: 576px) {
+    .album-slideshow-dialog {
+      padding: 16px;
+    }
+
+    .album-slideshow-actions {
+      width: 100%;
+      justify-content: space-between;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div
+  class="album-slideshow-page"
+  data-album-id="{{ album_id }}"
+  data-start-index="{{ start_index if start_index is not none else '' }}"
+  data-autoplay="{{ 'true' if autoplay_enabled else 'false' }}"
+  data-back-url="{{ url_for('photo_view.album_detail', album_id=album_id) }}"
+  data-albums-url="{{ url_for('photo_view.albums') }}"
+>
+  <div id="album-slideshow-overlay" class="album-slideshow-overlay d-none" aria-hidden="true">
+    <div class="album-slideshow-dialog">
+      <div class="album-slideshow-header">
+        <div class="album-slideshow-actions">
+          <a href="{{ url_for('photo_view.album_detail', album_id=album_id) }}" class="btn btn-outline-light btn-sm" id="album-slideshow-back">
+            <i class="bi bi-arrow-left"></i> {{ _('Back to album') }}
+          </a>
+          <a href="{{ url_for('photo_view.albums') }}" class="btn btn-outline-light btn-sm" id="album-slideshow-albums">
+            <i class="bi bi-collection"></i> {{ _('Albums') }}
+          </a>
+        </div>
+        <button type="button" class="album-slideshow-close" id="album-slideshow-close" aria-label="{{ _('Close') }}">
+          <i class="bi bi-x-lg"></i>
+        </button>
+      </div>
+      <div id="album-slideshow-loading" class="album-slideshow-loading">
+        <div class="spinner-border text-light" role="status"></div>
+        <span>{{ _('Loading slideshow...') }}</span>
+      </div>
+      <div id="album-slideshow-stage" class="album-slideshow-stage d-none">
+        <button type="button" class="album-slideshow-nav prev" id="album-slideshow-prev" aria-label="{{ _('Previous') }}">
+          <i class="bi bi-chevron-left"></i>
+        </button>
+        <img id="album-slideshow-image" src="" alt="" loading="lazy">
+        <button type="button" class="album-slideshow-nav next" id="album-slideshow-next" aria-label="{{ _('Next') }}">
+          <i class="bi bi-chevron-right"></i>
+        </button>
+      </div>
+      <div id="album-slideshow-empty" class="album-slideshow-empty d-none">
+        {{ _('This album has no media yet.') }}
+      </div>
+      <div class="album-slideshow-footer">
+        <div class="album-slideshow-info">
+          <span class="album-title" id="album-slideshow-title"></span>
+          <span class="album-meta" id="album-slideshow-meta"></span>
+        </div>
+        <div class="album-slideshow-controls">
+          <div class="album-slideshow-counter" id="album-slideshow-counter"></div>
+          <button type="button" class="btn btn-outline-light" id="album-slideshow-toggle">
+            <i class="bi bi-play-fill me-1"></i><span data-label>{{ _('Play') }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/album-slideshow.js') }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.querySelector('.album-slideshow-page');
+  if (!container) {
+    return;
+  }
+
+  const albumId = Number(container.dataset.albumId);
+  if (!Number.isInteger(albumId) || albumId <= 0) {
+    console.error('Invalid album id for slideshow');
+    return;
+  }
+
+  const startIndex = Number.parseInt(container.dataset.startIndex || '', 10);
+  const autoplay = container.dataset.autoplay !== 'false';
+  const backUrl = container.dataset.backUrl || `/photo-view/albums/${albumId}`;
+  const albumsUrl = container.dataset.albumsUrl || '/photo-view/albums';
+
+  const strings = {
+    untitledAlbum: "{{ _('Untitled Album')|escapejs }}",
+    noMedia: "{{ _('This album has no media yet.')|escapejs }}",
+    loadError: "{{ _('Unable to load album for slideshow.')|escapejs }}",
+    play: "{{ _('Play')|escapejs }}",
+    pause: "{{ _('Pause')|escapejs }}",
+    next: "{{ _('Next')|escapejs }}",
+    previous: "{{ _('Previous')|escapejs }}",
+    close: "{{ _('Close')|escapejs }}",
+    shotAt: "{{ _('Shot at')|escapejs }}",
+    position: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
+    mediaCountSingular: "{{ ngettext('%(count)s photo', '%(count)s photos', 1, count='%(count)s')|escapejs }}",
+    mediaCountPlural: "{{ ngettext('%(count)s photo', '%(count)s photos', 2, count='%(count)s')|escapejs }}",
+    createdLabel: "{{ _('Created')|escapejs }}",
+    updatedLabel: "{{ _('Updated')|escapejs }}",
+    visibilityLabels: {
+      public: "{{ _('Public')|escapejs }}",
+      private: "{{ _('Private')|escapejs }}",
+      unlisted: "{{ _('Unlisted')|escapejs }}",
+    },
+  };
+
+  function formatDateTime(isoString) {
+    if (!isoString) {
+      return '';
+    }
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      try {
+        const formatted = helper.formatDateTime(isoString, { dateStyle: 'medium', timeStyle: 'short' });
+        if (formatted) {
+          return formatted;
+        }
+      } catch (error) {
+        console.warn('formatDateTime failed', error);
+      }
+    }
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    return date.toLocaleString();
+  }
+
+  function formatMediaCount(count) {
+    const value = Number(count) || 0;
+    const template = value === 1 ? strings.mediaCountSingular : strings.mediaCountPlural;
+    return template.replace('%(count)s', value.toString());
+  }
+
+  function updateAlbumMeta(album, mediaItems) {
+    const metaElement = document.getElementById('album-slideshow-meta');
+    if (!metaElement) {
+      return;
+    }
+
+    const parts = [];
+    const visibilityLabel = strings.visibilityLabels[album.visibility] || album.visibility || '';
+    if (visibilityLabel) {
+      parts.push(visibilityLabel);
+    }
+
+    const mediaCountText = formatMediaCount(mediaItems.length);
+    if (mediaCountText) {
+      parts.push(mediaCountText);
+    }
+
+    const createdText = formatDateTime(album.createdAt);
+    if (createdText) {
+      parts.push(`${strings.createdLabel}: ${createdText}`);
+    }
+
+    const updatedText = formatDateTime(album.lastModified);
+    if (updatedText) {
+      parts.push(`${strings.updatedLabel}: ${updatedText}`);
+    }
+
+    metaElement.textContent = parts.join(' · ');
+  }
+
+  function resolveImageUrl(item) {
+    if (!item) {
+      return '';
+    }
+    if (typeof item.fullUrl === 'string' && item.fullUrl) {
+      return item.fullUrl;
+    }
+    if (typeof item.thumbnailUrl === 'string' && item.thumbnailUrl) {
+      return item.thumbnailUrl;
+    }
+    if (Number.isFinite(Number(item.id))) {
+      return `/api/media/${item.id}/thumbnail?size=2048`;
+    }
+    return '';
+  }
+
+  function navigateTo(url) {
+    window.location.href = url;
+  }
+
+  function handleExit(targetUrl) {
+    return (event) => {
+      event.preventDefault();
+      try {
+        if (window.history.length > 1) {
+          window.history.back();
+          return;
+        }
+      } catch (error) {
+        console.warn('History navigation failed', error);
+      }
+      navigateTo(targetUrl);
+    };
+  }
+
+  const backButton = document.getElementById('album-slideshow-back');
+  if (backButton) {
+    backButton.addEventListener('click', handleExit(backUrl));
+  }
+
+  const closeButton = document.getElementById('album-slideshow-close');
+  if (closeButton) {
+    closeButton.addEventListener('click', handleExit(backUrl));
+  }
+
+  const albumsButton = document.getElementById('album-slideshow-albums');
+  if (albumsButton) {
+    albumsButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      navigateTo(albumsUrl);
+    });
+  }
+
+  const emptyElement = document.getElementById('album-slideshow-empty');
+
+  const slideshow = new AlbumSlideshow({
+    overlayElement: document.getElementById('album-slideshow-overlay'),
+    stageElement: document.getElementById('album-slideshow-stage'),
+    imageElement: document.getElementById('album-slideshow-image'),
+    titleElement: document.getElementById('album-slideshow-title'),
+    metaElement: document.getElementById('album-slideshow-meta'),
+    counterElement: document.getElementById('album-slideshow-counter'),
+    emptyStateElement: emptyElement,
+    loadingElement: document.getElementById('album-slideshow-loading'),
+    playPauseButton: document.getElementById('album-slideshow-toggle'),
+    prevButton: document.getElementById('album-slideshow-prev'),
+    nextButton: document.getElementById('album-slideshow-next'),
+    closeButton,
+    labels: {
+      play: strings.play,
+      pause: strings.pause,
+      next: strings.next,
+      previous: strings.previous,
+      close: strings.close,
+      counter: strings.position,
+      noMedia: strings.noMedia,
+      shotAt: strings.shotAt,
+      albumTitleFallback: strings.untitledAlbum,
+    },
+    imageUrlResolver: resolveImageUrl,
+    metadataFormatter: (item, context) => {
+      const parts = [];
+      const shot = formatDateTime(item?.shotAt);
+      if (shot) {
+        parts.push(`${strings.shotAt} ${shot}`);
+      }
+      parts.push(
+        strings.position
+          .replace('%(current)s', (context.index + 1).toString())
+          .replace('%(total)s', context.total.toString()),
+      );
+      return parts.join(' · ');
+    },
+  });
+
+  const apiClient = new APIClient();
+
+  async function loadSlideshow() {
+    slideshow.setLoading(true);
+    try {
+      const response = await apiClient.get(`/api/albums/${albumId}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      const album = data?.album;
+      if (!album) {
+        throw new Error('Missing album payload');
+      }
+      const mediaItems = Array.isArray(album.media) ? album.media : [];
+      const albumTitle = album.title?.trim() || strings.untitledAlbum;
+      slideshow.load(mediaItems, { albumTitle });
+      updateAlbumMeta(album, mediaItems);
+
+      const normalizedIndex = Number.isInteger(startIndex) && startIndex >= 0 ? startIndex : 0;
+      slideshow.open(normalizedIndex, { autoplay });
+    } catch (error) {
+      console.error('Failed to load slideshow', error);
+      slideshow.setLoading(false);
+      if (emptyElement) {
+        emptyElement.textContent = strings.loadError;
+        emptyElement.classList.remove('d-none');
+      }
+    }
+  }
+
+  loadSlideshow();
+});
+</script>
+{% endblock %}

--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -546,14 +546,21 @@
 
 {% block content %}
 {% set is_editor_view = editor_view|default(False) %}
+{% set editor_album_id = editor_album_id|default(None) %}
+{% set editor_success_url = editor_success_url|default(url_for('photo_view.albums')) %}
+{% set editor_cancel_url = editor_cancel_url|default(url_for('photo_view.albums')) %}
+{% set is_edit_mode = is_editor_view and editor_album_id is not none %}
+{% set editor_heading = _('Edit Album') if is_edit_mode else _('Create Album') %}
+{% set editor_description = _('Update the album details and media selection.') if is_edit_mode else _('Select media and configure details to build a new album.') %}
+{% set editor_back_label = _('Back to album') if is_edit_mode else _('Back to albums') %}
 {% if is_editor_view %}
   <div class="album-editor-header d-flex flex-wrap justify-content-between align-items-start gap-3">
     <div>
-      <h1 class="mb-1">{{ _('Create Album') }}</h1>
-      <p class="text-muted mb-0">{{ _('Select media and configure details to build a new album.') }}</p>
+      <h1 class="mb-1">{{ editor_heading }}</h1>
+      <p class="text-muted mb-0">{{ editor_description }}</p>
     </div>
-    <a href="{{ url_for('photo_view.albums') }}" class="btn btn-outline-secondary">
-      <i class="bi bi-arrow-left me-1"></i>{{ _('Back to albums') }}
+    <a href="{{ editor_cancel_url }}" class="btn btn-outline-secondary">
+      <i class="bi bi-arrow-left me-1"></i>{{ editor_back_label }}
     </a>
   </div>
 {% else %}
@@ -611,48 +618,13 @@
     </a>
   </div>
 
-  <div id="album-slideshow-overlay" class="album-slideshow-overlay d-none" aria-hidden="true">
-    <div class="album-slideshow-dialog">
-      <button type="button" class="album-slideshow-close" id="album-slideshow-close" aria-label="{{ _('Close') }}">
-        <i class="bi bi-x-lg"></i>
-      </button>
-      <div id="album-slideshow-loading" class="album-slideshow-loading d-none">
-        <div class="spinner-border text-light" role="status"></div>
-        <span>{{ _('Loading slideshow...') }}</span>
-      </div>
-      <div id="album-slideshow-stage" class="album-slideshow-stage d-none">
-        <button type="button" class="album-slideshow-nav prev" id="album-slideshow-prev" aria-label="{{ _('Previous') }}">
-          <i class="bi bi-chevron-left"></i>
-        </button>
-        <img id="album-slideshow-image" src="" alt="" loading="lazy">
-        <button type="button" class="album-slideshow-nav next" id="album-slideshow-next" aria-label="{{ _('Next') }}">
-          <i class="bi bi-chevron-right"></i>
-        </button>
-      </div>
-      <div id="album-slideshow-empty" class="album-slideshow-empty d-none">
-        {{ _('This album has no media yet.') }}
-      </div>
-      <div class="album-slideshow-footer">
-        <div class="album-slideshow-info">
-          <span class="album-title" id="album-slideshow-title"></span>
-          <span class="album-meta" id="album-slideshow-meta"></span>
-        </div>
-        <div class="album-slideshow-controls">
-          <div class="album-slideshow-counter" id="album-slideshow-counter"></div>
-          <button type="button" class="btn btn-outline-light" id="album-slideshow-toggle">
-            <i class="bi bi-play-fill me-1"></i><span data-label>{{ _('Play') }}</span>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
 {% endif %}
 
 {% if is_editor_view %}
-  <div class="album-editor-page modal d-block show" id="albumModal" tabindex="-1" aria-labelledby="albumModalLabel" data-editor-mode="page" data-success-url="{{ url_for('photo_view.albums') }}">
+  <div class="album-editor-page modal d-block show" id="albumModal" tabindex="-1" aria-labelledby="albumModalLabel" data-editor-mode="page" data-success-url="{{ editor_success_url }}" data-album-id="{{ editor_album_id if editor_album_id is not none else '' }}">
     <div class="modal-dialog modal-xl modal-dialog-scrollable">
       <div class="modal-content">
-        {{ render_album_form(True, url_for('photo_view.albums')) }}
+        {{ render_album_form(True, editor_cancel_url) }}
       </div>
     </div>
   </div>
@@ -668,7 +640,6 @@
 {% endblock %}
 
 {% block extra_scripts %}
-<script src="{{ url_for('static', filename='js/album-slideshow.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const albumsGrid = document.getElementById('albums-grid');
@@ -686,6 +657,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const albumModalElement = document.getElementById('albumModal');
   const editorView = albumModalElement?.dataset.editorMode === 'page';
   const successRedirectUrl = albumModalElement?.dataset.successUrl || '/photo-view/albums';
+  const editorAlbumIdRaw = albumModalElement?.dataset.albumId || '';
+  const editorAlbumId = Number.parseInt(editorAlbumIdRaw, 10);
   const albumModal = albumModalElement
     ? editorView
       ? {
@@ -761,15 +734,6 @@ document.addEventListener('DOMContentLoaded', () => {
     createdLabel: "{{ _('Created')|escapejs }}",
     updatedLabel: "{{ _('Updated')|escapejs }}",
     photosLabel: "{{ _('photos')|escapejs }}",
-    playLabel: "{{ _('Play')|escapejs }}",
-    pauseLabel: "{{ _('Pause')|escapejs }}",
-    nextLabel: "{{ _('Next')|escapejs }}",
-    previousLabel: "{{ _('Previous')|escapejs }}",
-    closeLabel: "{{ _('Close')|escapejs }}",
-    shotAtLabel: "{{ _('Shot at')|escapejs }}",
-    positionLabel: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
-    slideshowLoadError: "{{ _('Unable to load album for slideshow.')|escapejs }}",
-    slideshowNoMedia: "{{ _('This album has no media yet.')|escapejs }}",
     startSlideshow: "{{ _('Start Slideshow')|escapejs }}",
     customOrderLabel: "{{ _('Custom Order')|escapejs }}",
     reorderHint: "{{ _('Use the arrow buttons to change the album order, then choose "Save Order".')|escapejs }}",
@@ -781,150 +745,6 @@ document.addEventListener('DOMContentLoaded', () => {
     moveUp: "{{ _('Move up')|escapejs }}",
     moveDown: "{{ _('Move down')|escapejs }}",
   };
-
-  const THUMBNAIL_SIZE_PRIORITY = [2048, 1024, 512];
-
-  function normalizeThumbnailSize(value) {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-    if (typeof value === 'string') {
-      const trimmed = value.trim();
-      if (trimmed) {
-        const parsed = Number.parseInt(trimmed, 10);
-        if (Number.isFinite(parsed)) {
-          return parsed;
-        }
-      }
-    }
-    return null;
-  }
-
-  function collectThumbnailAvailability(item) {
-    const available = new Set();
-    const urlBySize = new Map();
-
-    const register = (size, url) => {
-      if (!Number.isFinite(size)) {
-        return;
-      }
-      available.add(size);
-      if (typeof url === 'string' && url) {
-        urlBySize.set(size, url);
-      }
-    };
-
-    const variantSources = [
-      item?.thumbnailUrls,
-      item?.thumbnails,
-      item?.thumbnail_variants,
-      item?.thumbnailVariants,
-    ];
-
-    variantSources.forEach((source) => {
-      if (!source) {
-        return;
-      }
-      if (Array.isArray(source)) {
-        source.forEach((entry) => {
-          if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
-            const size = normalizeThumbnailSize(entry.size ?? entry.dimension ?? entry.width ?? entry.height);
-            const url = entry.url ?? entry.href ?? entry.path ?? null;
-            if (size !== null) {
-              register(size, typeof url === 'string' ? url : null);
-            }
-          } else {
-            const size = normalizeThumbnailSize(entry);
-            if (size !== null) {
-              register(size);
-            }
-          }
-        });
-      } else if (typeof source === 'object') {
-        Object.entries(source).forEach(([key, value]) => {
-          const keySize = normalizeThumbnailSize(key);
-          if (typeof value === 'string') {
-            if (keySize !== null) {
-              register(keySize, value);
-            }
-            return;
-          }
-          if (value && typeof value === 'object' && !Array.isArray(value)) {
-            const nestedSize = normalizeThumbnailSize(
-              value.size ?? value.dimension ?? value.width ?? value.height ?? keySize,
-            );
-            const url = value.url ?? value.href ?? value.path ?? null;
-            if (nestedSize !== null) {
-              register(nestedSize, typeof url === 'string' ? url : null);
-            } else if (keySize !== null) {
-              register(keySize, typeof url === 'string' ? url : null);
-            }
-          } else if (value && keySize !== null) {
-            register(keySize);
-          }
-        });
-      }
-    });
-
-    const availabilitySources = [
-      item?.availableThumbnailSizes,
-      item?.thumbnailSizes,
-      item?.availableThumbnails,
-    ];
-
-    availabilitySources.forEach((source) => {
-      if (!source) {
-        return;
-      }
-      if (Array.isArray(source)) {
-        source.forEach((entry) => {
-          const size = normalizeThumbnailSize(entry);
-          if (size !== null) {
-            available.add(size);
-          }
-        });
-      } else if (typeof source === 'object') {
-        Object.entries(source).forEach(([key, value]) => {
-          if (!value) {
-            return;
-          }
-          const size = normalizeThumbnailSize(key);
-          if (size !== null) {
-            available.add(size);
-          }
-        });
-      }
-    });
-
-    return { available, urlBySize };
-  }
-
-  function resolveSlideshowImageUrl(item) {
-    if (!item) {
-      return '';
-    }
-
-    const { available, urlBySize } = collectThumbnailAvailability(item);
-    const buildUrl = (size) => (item.id ? `/api/media/${item.id}/thumbnail?size=${size}` : '');
-
-    for (const size of THUMBNAIL_SIZE_PRIORITY) {
-      if (urlBySize.has(size)) {
-        return urlBySize.get(size);
-      }
-      if (available.has(size)) {
-        const resolved = buildUrl(size);
-        if (resolved) {
-          return resolved;
-        }
-      }
-    }
-
-    if (typeof item.thumbnailUrl === 'string' && item.thumbnailUrl) {
-      return item.thumbnailUrl;
-    }
-
-    return buildUrl(512);
-  }
 
   const albumState = {
     mode: 'create',
@@ -942,63 +762,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const defaultCoverDataUrl = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcw48bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPjxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiM2NjdlZWEiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM3NjRiYTIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2cpIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJBcmlhbCIgZm9udC1zaXplPSIyNCIgZmlsbD0id2hpdGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIj7wn5OCPC90ZXh0Pjwvc3ZnPg==';
 
   const apiClient = new APIClient();
-
-  const slideshowOverlay = document.getElementById('album-slideshow-overlay');
-  const slideshowStage = document.getElementById('album-slideshow-stage');
-  const slideshowImage = document.getElementById('album-slideshow-image');
-  const slideshowMeta = document.getElementById('album-slideshow-meta');
-  const slideshowCounter = document.getElementById('album-slideshow-counter');
-  const slideshowTitle = document.getElementById('album-slideshow-title');
-  const slideshowEmpty = document.getElementById('album-slideshow-empty');
-  const slideshowLoading = document.getElementById('album-slideshow-loading');
-  const slideshowToggle = document.getElementById('album-slideshow-toggle');
-  const slideshowPrev = document.getElementById('album-slideshow-prev');
-  const slideshowNext = document.getElementById('album-slideshow-next');
-  const slideshowClose = document.getElementById('album-slideshow-close');
-
-  const albumSlideshow = new AlbumSlideshow({
-    overlayElement: slideshowOverlay,
-    stageElement: slideshowStage,
-    imageElement: slideshowImage,
-    titleElement: slideshowTitle,
-    metaElement: slideshowMeta,
-    counterElement: slideshowCounter,
-    emptyStateElement: slideshowEmpty,
-    loadingElement: slideshowLoading,
-    playPauseButton: slideshowToggle,
-    prevButton: slideshowPrev,
-    nextButton: slideshowNext,
-    closeButton: slideshowClose,
-    labels: {
-      play: strings.playLabel,
-      pause: strings.pauseLabel,
-      next: strings.nextLabel,
-      previous: strings.previousLabel,
-      close: strings.closeLabel,
-      counter: strings.positionLabel,
-      noMedia: strings.slideshowNoMedia,
-      shotAt: strings.shotAtLabel,
-      albumTitleFallback: strings.untitledAlbum,
-    },
-    imageUrlResolver: resolveSlideshowImageUrl,
-    metadataFormatter: (item, context) => {
-      const parts = [];
-      if (item?.shotAt) {
-        const formatted = formatDateTime(item.shotAt);
-        if (formatted) {
-          parts.push(`${strings.shotAtLabel} ${formatted}`);
-        }
-      }
-      parts.push(
-        strings.positionLabel
-          .replace('%(current)s', (context.index + 1).toString())
-          .replace('%(total)s', context.total.toString()),
-      );
-      return parts.join(' · ');
-    },
-  });
-
-  const slideshowIntentStorageKey = 'photoView.slideshowIntent';
 
   let reorderMode = false;
   let reorderDirty = false;
@@ -1860,24 +1623,28 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function openAlbumSlideshow(albumId) {
+  function openAlbumSlideshow(albumId, options = {}) {
     if (!Number.isFinite(albumId)) {
       return;
     }
-    try {
-      if (window.sessionStorage) {
-        const intent = {
-          albumId,
-          expiresAt: Date.now() + 2 * 60 * 1000,
-        };
-        window.sessionStorage.setItem(slideshowIntentStorageKey, JSON.stringify(intent));
-      }
-    } catch (error) {
-      console.warn('Failed to persist slideshow intent', error);
+
+    const url = new URL(`/photo-view/albums/${albumId}/slideshow`, window.location.origin);
+    const params = new URLSearchParams();
+
+    const startIndex = Number(options.startIndex);
+    if (Number.isInteger(startIndex) && startIndex >= 0) {
+      params.set('start', startIndex.toString());
     }
-    const targetUrl = new URL(`/photo-view/albums/${albumId}`, window.location.origin);
-    targetUrl.searchParams.set('slideshow', '1');
-    window.location.href = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+
+    if (options.autoplay === false) {
+      params.set('autoplay', '0');
+    }
+
+    if ([...params.keys()].length > 0) {
+      url.search = params.toString();
+    }
+
+    window.location.href = url.toString();
   }
 
   function showReorderHint(message, type = 'info') {
@@ -2200,7 +1967,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         if (actionButton.dataset.albumAction === 'edit') {
-          loadAlbumForEdit(albumId);
+          window.location.href = `/photo-view/albums/${albumId}/edit`;
         } else if (actionButton.dataset.albumAction === 'delete') {
           deleteAlbum(albumId);
         } else if (actionButton.dataset.albumAction === 'slideshow') {
@@ -2467,7 +2234,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (editorView) {
-    openAlbumModal('create');
+    if (Number.isInteger(editorAlbumId) && editorAlbumId > 0) {
+      loadAlbumForEdit(editorAlbumId);
+    } else {
+      openAlbumModal('create');
+    }
   } else {
     initializeAlbumsScroll();
   }


### PR DESCRIPTION
## Summary
- add dedicated `/photo-view/albums/<id>/edit` and `/photo-view/albums/<id>/slideshow` routes
- update album list/detail templates to use the shared editor page and redirect to the new slideshow view
- create a standalone slideshow page that reuses the slideshow component with navigation controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2623218cc83238e1e120e4efe07fb