### PR TITLE
Avoid showing placeholder cover for albums without media

### DIFF
--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -117,6 +117,10 @@
     overflow: hidden;
   }
 
+  .album-cover.album-cover--empty {
+    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+  }
+
   .album-cover img {
     width: 100%;
     height: 100%;
@@ -1908,7 +1912,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const coverUrl = album.coverImageId
       ? `/api/media/${album.coverImageId}/thumbnail?size=512`
-      : defaultCoverDataUrl;
+      : null;
+    const coverClass = coverUrl ? '' : ' album-cover--empty';
 
     const visibilityLabel = strings.visibilityLabels[album.visibility] || album.visibility;
 
@@ -1933,8 +1938,8 @@ document.addEventListener('DOMContentLoaded', () => {
           <i class="bi bi-trash"></i>
         </button>
       </div>
-      <div class="album-cover">
-        <img src="${coverUrl}" alt="${escapeHtml(album.title || 'Album')}" loading="lazy">
+      <div class="album-cover${coverClass}">
+        ${coverUrl ? `<img src="${coverUrl}" alt="${escapeHtml(album.title || 'Album')}" loading="lazy">` : ''}
         <div class="album-overlay">
           <span class="badge">${visibilityLabel}</span>
           <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## Summary
- skip rendering the album cover image when an album has no associated media
- add a specific style for empty covers so the gradient background still looks intentional

## Testing
- not run (frontend template change only)


------
https://chatgpt.com/codex/tasks/task_e_68d34cd75ac0832387adb1edcccc63a2