### PR TITLE
Fix slideshow loading spinner for empty albums

### DIFF
--- a/webapp/photo_view/templates/photo_view/album_slideshow.html
+++ b/webapp/photo_view/templates/photo_view/album_slideshow.html
@@ -309,6 +309,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const albumTitle = album.title?.trim() || strings.untitledAlbum;
       slideshow.load(mediaItems, { albumTitle });
       updateAlbumMeta(album, mediaItems);
+      slideshow.setLoading(false);
 
       const normalizedIndex = Number.isInteger(startIndex) && startIndex >= 0 ? startIndex : 0;
       slideshow.open(normalizedIndex, { autoplay });


### PR DESCRIPTION
## Summary
- hide the slideshow loading spinner once album data is loaded
- ensure empty albums display the empty-state message without leaving the loader visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3595745588323a0a8f6b2ced238d9