### PR TITLE
Increase slideshow image resolution

### DIFF
--- a/webapp/photo_view/templates/photo_view/album_slideshow.html
+++ b/webapp/photo_view/templates/photo_view/album_slideshow.html
@@ -200,6 +200,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!item) {
       return '';
     }
+    if (typeof item.previewUrl === 'string' && item.previewUrl) {
+      return item.previewUrl;
+    }
     if (typeof item.fullUrl === 'string' && item.fullUrl) {
       return item.fullUrl;
     }


### PR DESCRIPTION
## Summary
- expose the largest available thumbnail URL for album media so the slideshow can show higher resolution photos
- fall back to existing 512px thumbnails when larger renditions are unavailable and update the slideshow script to use the richer URLs
- add regression tests covering the new album detail payload fields and fallback behaviour

## Testing
- pytest tests/test_media_api.py::test_album_detail_includes_full_size_thumbnail tests/test_media_api.py::test_album_detail_full_size_fallback

------
https://chatgpt.com/codex/tasks/task_e_68d36c40df248323aa0e1b5277183469