### PR TITLE
Refactor import post-processing and enhance logging

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -26,6 +26,7 @@ from core.models.job_sync import JobSync
 from core.models.picker_session import PickerSession
 from core.utils import get_file_date_from_name, get_file_date_from_exif
 from core.logging_config import setup_task_logging, log_task_error, log_task_info
+from core.tasks.media_post_processing import process_media_post_import
 from webapp.config import Config
 
 # Setup logger for this module - use Celery task logger for consistency
@@ -621,7 +622,16 @@ def import_single_file(
             db.session.add(exif)
         
         db.session.commit()
-        
+
+        process_media_post_import(
+            media,
+            logger_override=logger,
+            request_context={
+                "session_id": session_id,
+                "source": "local_import",
+            },
+        )
+
         # 元ファイルの削除
         os.remove(file_path)
         _log_info(

--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -1,0 +1,277 @@
+"""Utilities for post-import media processing steps.
+
+This module centralises common operations that occur after a media item has
+been persisted, such as generating thumbnails for photos or scheduling
+transcoding for videos.  Both picker imports and local imports can leverage
+these helpers so that the behaviour and logging stay consistent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from core.db import db
+from core.logging_config import log_task_error, log_task_info, setup_task_logging
+from core.models.photo_models import Media, MediaPlayback
+
+# These imports are intentionally placed after SQLAlchemy models to avoid
+# circular import issues.
+from .thumbs_generate import thumbs_generate
+from .transcode import transcode_worker
+
+
+_logger = setup_task_logging(__name__)
+
+
+def _structured_task_log(
+    logger: logging.Logger,
+    *,
+    level: str,
+    event: str,
+    message: str,
+    operation_id: str,
+    media_id: int,
+    request_context: Optional[Dict[str, Any]] = None,
+    exc_info: bool = False,
+    **details: Any,
+) -> None:
+    """Emit a structured JSON log entry for background task processing."""
+
+    payload: Dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "level": level.upper(),
+        "message": message,
+        "operationId": operation_id,
+        "mediaId": media_id,
+    }
+
+    if request_context:
+        payload["requestContext"] = request_context
+
+    if details:
+        payload["details"] = details
+
+    serialized = json.dumps(payload, ensure_ascii=False, default=str)
+    extra = {"event": event, "operation_id": operation_id, "media_id": media_id, **details}
+
+    level_lower = level.lower()
+    if level_lower == "info":
+        log_task_info(logger, serialized, event=event, operation_id=operation_id, media_id=media_id, **details)
+    elif level_lower == "warning":
+        logger.warning(serialized, extra=extra)
+    else:
+        # Errors and unexpected levels fall back to the task error helper so the
+        # stack trace (if requested) is persisted in the database logs.
+        log_task_error(
+            logger,
+            serialized,
+            event=event,
+            exc_info=exc_info,
+            operation_id=operation_id,
+            media_id=media_id,
+            **details,
+        )
+
+
+def enqueue_thumbs_generate(
+    media_id: int,
+    *,
+    logger_override: Optional[logging.Logger] = None,
+    operation_id: Optional[str] = None,
+    request_context: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Synchronously generate thumbnails for *media_id* with structured logging."""
+
+    logger = logger_override or _logger
+    op_id = operation_id or str(uuid4())
+
+    try:
+        result = thumbs_generate(media_id=media_id)
+    except Exception as exc:  # pragma: no cover - unexpected failure path
+        _structured_task_log(
+            logger,
+            level="error",
+            event="thumbnail_generation.exception",
+            message=f"Exception during thumbnail generation: {exc}",
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+            exc_info=True,
+        )
+        return
+
+    generated = result.get("generated", [])
+    if result.get("ok"):
+        _structured_task_log(
+            logger,
+            level="info",
+            event="thumbnail_generation.complete",
+            message="Thumbnails generated successfully.",
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+            generated=generated,
+        )
+    else:
+        _structured_task_log(
+            logger,
+            level="warning",
+            event="thumbnail_generation.failed",
+            message=result.get("notes", "Thumbnail generation failed."),
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+            notes=result.get("notes"),
+        )
+
+
+def enqueue_media_playback(
+    media_id: int,
+    *,
+    logger_override: Optional[logging.Logger] = None,
+    operation_id: Optional[str] = None,
+    request_context: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Synchronously prepare video playback assets for *media_id*."""
+
+    logger = logger_override or _logger
+    op_id = operation_id or str(uuid4())
+
+    if not shutil.which("ffmpeg"):
+        _structured_task_log(
+            logger,
+            level="warning",
+            event="video_transcoding.ffmpeg_missing",
+            message="ffmpeg not available, skipping video transcoding.",
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+        )
+        return
+
+    try:
+        pb = MediaPlayback.query.filter_by(media_id=media_id, preset="std1080p").first()
+        if not pb:
+            media = Media.query.get(media_id)
+            if not media:
+                _structured_task_log(
+                    logger,
+                    level="error",
+                    event="video_transcoding.media_missing",
+                    message="Media record not found for playback generation.",
+                    operation_id=op_id,
+                    media_id=media_id,
+                    request_context=request_context,
+                    exc_info=False,
+                )
+                return
+
+            rel_path = str(Path(media.local_rel_path).with_suffix(".mp4"))
+            pb = MediaPlayback(
+                media_id=media_id,
+                preset="std1080p",
+                rel_path=rel_path,
+                status="pending",
+            )
+            db.session.add(pb)
+            db.session.commit()
+
+        if pb.status in {"done", "processing"}:
+            _structured_task_log(
+                logger,
+                level="info",
+                event="video_transcoding.skipped",
+                message=f"Video playback already {pb.status}.",
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                playback_status=pb.status,
+            )
+            return
+
+        result = transcode_worker(media_playback_id=pb.id)
+        if result.get("ok"):
+            _structured_task_log(
+                logger,
+                level="info",
+                event="video_transcoding.complete",
+                message="Video transcoding completed.",
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                width=result.get("width"),
+                height=result.get("height"),
+                duration_ms=result.get("duration_ms"),
+                note=result.get("note"),
+            )
+        else:
+            _structured_task_log(
+                logger,
+                level="warning",
+                event="video_transcoding.failed",
+                message=result.get("note", "Video transcoding failed."),
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                width=result.get("width"),
+                height=result.get("height"),
+                duration_ms=result.get("duration_ms"),
+                note=result.get("note"),
+            )
+    except Exception as exc:  # pragma: no cover - unexpected failure path
+        _structured_task_log(
+            logger,
+            level="error",
+            event="video_transcoding.exception",
+            message=f"Exception during video transcoding: {exc}",
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+            exc_info=True,
+        )
+
+
+def process_media_post_import(
+    media: Media,
+    *,
+    logger_override: Optional[logging.Logger] = None,
+    request_context: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Execute the appropriate post-import processing pipeline for *media*."""
+
+    logger = logger_override or _logger
+    op_id = str(uuid4())
+
+    _structured_task_log(
+        logger,
+        level="info",
+        event="media_post_process.start",
+        message="Starting post-import processing.",
+        operation_id=op_id,
+        media_id=media.id,
+        request_context=request_context,
+        media_type="video" if media.is_video else "photo",
+    )
+
+    if media.is_video:
+        enqueue_media_playback(
+            media.id,
+            logger_override=logger,
+            operation_id=op_id,
+            request_context=request_context,
+        )
+    else:
+        enqueue_thumbs_generate(
+            media.id,
+            logger_override=logger,
+            operation_id=op_id,
+            request_context=request_context,
+        )
+


### PR DESCRIPTION
## Summary
- add a shared media post-processing utility that centralises thumbnail generation, video transcoding, and task logging
- update picker and local import flows to call the shared helper so local imports now trigger thumbnail creation as well
- enhance local import API logging to emit structured JSON with hashed user identifiers, request metadata, and request IDs

## Testing
- pytest tests/test_picker_import_item.py
- pytest tests/test_media_api.py::test_media_thumbnail_route

------
https://chatgpt.com/codex/tasks/task_e_68d39bb51590832389ab207a32df3c65