### PR TITLE
Refactor login styling

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Login') }} - PhotoNest{% endblock %}
+{% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
 <div class="login-container">
@@ -67,54 +68,6 @@
     </div>
   </div>
 </div>
-
-<style>
-/* Additional page-specific styles */
-body {
-  overflow-x: hidden;
-}
-
-/* Hide footer on login page to prevent unnecessary scrolling */
-footer {
-  display: none;
-}
-
-/* Adjust container height since footer is hidden */
-.login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Loading state for button */
-.btn-login.loading {
-  pointer-events: none;
-  color: transparent; /* Hide the original text/icon */
-}
-
-.btn-login.loading * {
-  opacity: 0; /* Hide all child elements */
-}
-
-.btn-login.loading::after {
-  content: '';
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid transparent;
-  border-top-color: #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-</style>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/webapp/auth/templates/auth/register.html
+++ b/webapp/auth/templates/auth/register.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Register') }} - PhotoNest{% endblock %}
+{% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
 <div class="login-container">
@@ -58,54 +59,6 @@
     </div>
   </div>
 </div>
-
-<style>
-/* Additional page-specific styles */
-body {
-  overflow-x: hidden;
-}
-
-/* Hide footer on register page to prevent unnecessary scrolling */
-footer {
-  display: none;
-}
-
-/* Adjust container height since footer is hidden */
-.login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Loading state for button */
-.btn-login.loading {
-  pointer-events: none;
-  color: transparent; /* Hide the original text/icon */
-}
-
-.btn-login.loading * {
-  opacity: 0; /* Hide all child elements */
-}
-
-.btn-login.loading::after {
-  content: '';
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid transparent;
-  border-top-color: #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-</style>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/webapp/auth/templates/auth/register_no_totp.html
+++ b/webapp/auth/templates/auth/register_no_totp.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Register') }} - PhotoNest{% endblock %}
+{% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
 <div class="login-container">
@@ -58,54 +59,6 @@
     </div>
   </div>
 </div>
-
-<style>
-/* Additional page-specific styles */
-body {
-  overflow-x: hidden;
-}
-
-/* Hide footer on register page to prevent unnecessary scrolling */
-footer {
-  display: none;
-}
-
-/* Adjust container height since footer is hidden */
-.login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
-/* Loading state for button */
-.btn-login.loading {
-  pointer-events: none;
-  color: transparent; /* Hide the original text/icon */
-}
-
-.btn-login.loading * {
-  opacity: 0; /* Hide all child elements */
-}
-
-.btn-login.loading::after {
-  content: '';
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid transparent;
-  border-top-color: #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-</style>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/webapp/auth/templates/auth/register_totp.html
+++ b/webapp/auth/templates/auth/register_totp.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Verify TOTP') }} - PhotoNest{% endblock %}
+{% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
 <div class="login-container">
@@ -93,21 +94,6 @@
 </div>
 
 <style>
-/* Additional page-specific styles */
-body {
-  overflow-x: hidden;
-}
-
-/* Hide footer on register page to prevent unnecessary scrolling */
-footer {
-  display: none;
-}
-
-/* Adjust container height since footer is hidden */
-.login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
 /* QR Code specific styles */
 .qr-code-container {
   text-align: center;
@@ -344,36 +330,6 @@ footer {
   text-decoration: underline;
 }
 
-/* Loading state for button */
-.btn-login.loading {
-  pointer-events: none;
-  color: transparent; /* Hide the original text/icon */
-}
-
-.btn-login.loading * {
-  opacity: 0; /* Hide all child elements */
-}
-
-.btn-login.loading::after {
-  content: '';
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid transparent;
-  border-top-color: #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
 </style>
 
 <script>

--- a/webapp/auth/templates/auth/setup_totp.html
+++ b/webapp/auth/templates/auth/setup_totp.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Setup Two-Factor Authentication') }} - PhotoNest{% endblock %}
+{% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
 <div class="login-container">
@@ -95,21 +96,6 @@
 </div>
 
 <style>
-/* Additional page-specific styles */
-body {
-  overflow-x: hidden;
-}
-
-/* Hide footer on setup page to prevent unnecessary scrolling */
-footer {
-  display: none;
-}
-
-/* Adjust container height since footer is hidden */
-.login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
-}
-
 /* QR Code specific styles */
 .qr-code-container {
   text-align: center;
@@ -346,36 +332,6 @@ footer {
   text-decoration: underline;
 }
 
-/* Loading state for button */
-.btn-login.loading {
-  pointer-events: none;
-  color: transparent; /* Hide the original text/icon */
-}
-
-.btn-login.loading * {
-  opacity: 0; /* Hide all child elements */
-}
-
-.btn-login.loading::after {
-  content: '';
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid transparent;
-  border-top-color: #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
 </style>
 
 <script>

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -11,8 +11,16 @@ body {
 }
 
 /* Modern Login Page Styles */
+body.login-page {
+  overflow-x: hidden;
+}
+
+body.login-page footer {
+  display: none;
+}
+
 .login-container {
-  min-height: calc(100vh - 140px); /* ナビゲーションバー(56px) + フッター(約60px) + 余白(24px) */
+  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -125,6 +133,31 @@ body {
   margin-top: 20px;
   position: relative;
   overflow: hidden;
+}
+
+.btn-login.loading {
+  pointer-events: none;
+  color: transparent;
+}
+
+.btn-login.loading * {
+  opacity: 0;
+}
+
+.btn-login.loading::after {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  margin: auto;
+  border: 2px solid transparent;
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: loginButtonSpin 1s linear infinite;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 .btn-login:hover {
@@ -253,14 +286,27 @@ body {
   }
 }
 
+.login-page main.container-fluid {
+  margin-top: 0;
+}
+
 .login-card {
   animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes loginButtonSpin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /* Responsive Design */
 @media (max-width: 480px) {
   .login-container {
-    min-height: calc(100vh - 120px); /* モバイル時のナビゲーションバー + フッター + 余白 */
+    min-height: calc(100vh - 80px); /* モバイル時のナビゲーションバー + 余白 */
     padding: 10px;
   }
   

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   {% block extra_head %}{% endblock %}
 </head>
-<body>
+<body{% block body_attributes %}{% endblock %}>
 
 <header>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">


### PR DESCRIPTION
## Summary
- allow overriding body attributes from the base template so login flows can share a common page class
- centralize login layout rules (container height, footer visibility, loading spinner) in the main stylesheet
- remove the duplicated inline CSS from login/register/TOTP templates while keeping their unique QR code styles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a466007c8323a1cb1e00a8b5b1c3