### PR TITLE
Improve login page flash positioning

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -83,6 +83,11 @@ body.login-page footer {
   box-sizing: border-box;
 }
 
+.form-control::placeholder {
+  color: #cbd5e0;
+  opacity: 1;
+}
+
 .form-control:focus {
   outline: none;
   border-color: #667eea;
@@ -286,8 +291,36 @@ body.login-page footer {
   }
 }
 
-.login-page main.container-fluid {
+body.login-page main.container-fluid {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 60px 20px 40px;
+  min-height: calc(100vh - 60px);
+  box-sizing: border-box;
   margin-top: 0;
+}
+
+body.login-page .flash-messages {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(420px, calc(100% - 40px));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 20;
+  pointer-events: none;
+}
+
+body.login-page .flash-messages .alert {
+  margin: 0;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+  border-radius: 12px;
+  pointer-events: auto;
 }
 
 .login-card {
@@ -305,6 +338,15 @@ body.login-page footer {
 
 /* Responsive Design */
 @media (max-width: 480px) {
+  body.login-page main.container-fluid {
+    padding: 80px 16px 30px;
+  }
+
+  body.login-page .flash-messages {
+    top: 16px;
+    width: calc(100% - 32px);
+  }
+
   .login-container {
     min-height: calc(100vh - 80px); /* モバイル時のナビゲーションバー + 余白 */
     padding: 10px;

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -108,12 +108,14 @@
 <main class="container-fluid mt-4">
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
-      {% for cat, msg in messages %}
-        <div class="alert alert-{{ 'danger' if cat == 'error' else cat }} alert-dismissible fade show" role="alert">
-          {{ msg }}
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-      {% endfor %}
+      <div class="flash-messages">
+        {% for cat, msg in messages %}
+          <div class="alert alert-{{ 'danger' if cat == 'error' else cat }} alert-dismissible fade show" role="alert">
+            {{ msg }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        {% endfor %}
+      </div>
     {% endif %}
   {% endwith %}
 


### PR DESCRIPTION
## Summary
- wrap flash messages in a dedicated container so login alerts float without pushing the form
- adjust login page layout styles to keep the form centered while displaying alerts
- lighten form placeholder color for better distinction from actual input values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a6955c2c83239d7d7b8f72bcdd61