### PR TITLE
Ensure lifecycle startup logs persist

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from webapp import create_app
 from core.lifecycle_logging import register_lifecycle_logging
 
 app = create_app()
+register_lifecycle_logging(app)
 
 if __name__ == '__main__':
-    register_lifecycle_logging(app)
     app.run(debug=True)

--- a/tests/test_lifecycle_logging_unit.py
+++ b/tests/test_lifecycle_logging_unit.py
@@ -1,0 +1,90 @@
+"""ライフサイクルログのユニットテスト。"""
+
+import atexit
+import importlib
+import json
+import sys
+import signal
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle_logging import register_lifecycle_logging
+from core.models.log import Log
+
+
+@pytest.fixture
+def lifecycle_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "lifecycle.sqlite"
+
+    env_vars = {
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "SECRET_KEY": "test-secret-key",
+        "JWT_SECRET_KEY": "test-jwt-secret",
+        "FEATURE_X_DB_URI": "",
+    }
+
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    import webapp.config as config_module
+    import webapp as webapp_module
+
+    importlib.reload(config_module)
+    importlib.reload(webapp_module)
+
+    from webapp import create_app
+    from webapp.extensions import db
+
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+
+    try:
+        yield app
+    finally:
+        lifecycle_state = app.extensions.get("lifecycle_logging", {})
+        handler = lifecycle_state.get("atexit_handler")
+        if handler is not None:
+            atexit.unregister(handler)
+
+        for sig, previous in lifecycle_state.get("signal_handlers", {}).items():
+            try:
+                signal.signal(sig, previous)
+            except (ValueError, OSError):
+                pass
+
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+        for module_name in ("webapp.config", "webapp"):
+            if module_name in sys.modules:
+                del sys.modules[module_name]
+
+
+def test_lifecycle_logging_records_startup(lifecycle_app):
+    app = lifecycle_app
+
+    register_lifecycle_logging(app)
+    register_lifecycle_logging(app)
+
+    with app.app_context():
+        logs = Log.query.order_by(Log.id).all()
+        assert len(logs) == 1
+
+        log = logs[0]
+        assert log.event == "app.lifecycle"
+
+        payload = json.loads(log.message)
+        assert payload["event"] == "app.lifecycle"
+        assert payload["action"] == "startup"
+        assert payload["timezone"] == "UTC"
+        assert payload["_meta"]["level"] == "INFO"
+        assert payload["_extra"]["action"] == "startup"
+
+        lifecycle_id = payload["_extra"]["lifecycle_id"]
+        assert lifecycle_id
+        assert app.extensions["lifecycle_logging"]["lifecycle_id"] == lifecycle_id

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,7 +2,7 @@ from webapp import create_app
 from core.lifecycle_logging import register_lifecycle_logging
 
 app = create_app()
+register_lifecycle_logging(app)
 
 if __name__ == "__main__":
-    register_lifecycle_logging(app)
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- ensure lifecycle startup logging is registered for all Flask entrypoints
- extend the lifecycle logger to prevent duplicate registration and retain handler references
- add a unit test that verifies lifecycle startup logs are saved into the log table

## Testing
- pytest tests/test_lifecycle_logging_unit.py
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a979acf883239296c2d6c92da118