### PR TITLE
Add X-Accel-Redirect support for media downloads

### DIFF
--- a/webapp/config.py
+++ b/webapp/config.py
@@ -65,6 +65,8 @@ class Config:
     FPV_URL_TTL_PLAYBACK = int(os.environ.get("FPV_URL_TTL_PLAYBACK", "600"))
     FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_DIR", "")
     FPV_NAS_PLAY_DIR = os.environ.get("FPV_NAS_PLAY_DIR", "")
+    FPV_ACCEL_THUMBS_LOCATION = os.environ.get("FPV_ACCEL_THUMBS_LOCATION", "")
+    FPV_ACCEL_PLAYBACK_LOCATION = os.environ.get("FPV_ACCEL_PLAYBACK_LOCATION", "")
     
     # Local import settings
     LOCAL_IMPORT_DIR = os.environ.get("LOCAL_IMPORT_DIR", "/mnt/nas/import")


### PR DESCRIPTION
## Summary
- add configuration options to point to Nginx internal locations for accelerated media delivery
- update the signed download endpoint to emit X-Accel-Redirect responses when configured while keeping existing streaming fallback
- cover the new behavior with an automated test for thumbnail downloads

## Testing
- pytest tests/test_media_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d3aad133f88323ac6d9286165a51f7