### PR TITLE
Add favicon link to base template

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="user-timezone" content="{{ current_timezone_name }}">
   <title>{% block title %}FlaskApp{% endblock %}</title>
+  <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">


### PR DESCRIPTION
## Summary
- ensure the base template references the existing favicon.ico so browsers display the app icon

## Testing
- pytest *(fails: tests/test_lifecycle_logging_unit.py::test_lifecycle_logging_records_startup)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b23055d48323b862c3dc77e86d23