### PR TITLE
Adjust login layout spacing and language selector

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -3,26 +3,6 @@
 {% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
-{% if not current_user.is_authenticated and language_selector_languages %}
-<div class="d-flex justify-content-end mb-3">
-  <div class="dropdown">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
-            data-bs-toggle="dropdown" aria-expanded="false">
-      <i class="bi bi-translate me-1"></i>
-      {{ language_labels.get(current_language) or (current_language|upper) }}
-    </button>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
-      {% for lang_code in language_selector_languages %}
-      <li>
-        <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
-          {{ language_labels.get(lang_code) or (lang_code|upper) }}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-{% endif %}
 <div class="login-container">
   <div class="login-card">
     <div class="login-header">
@@ -88,6 +68,27 @@
     </div>
   </div>
 </div>
+
+{% if not current_user.is_authenticated and language_selector_languages %}
+<div class="d-flex justify-content-end mb-3">
+  <div class="dropdown">
+    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
+            data-bs-toggle="dropdown" aria-expanded="false">
+      <i class="bi bi-translate me-1"></i>
+      {{ language_labels.get(current_language) or (current_language|upper) }}
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
+      {% for lang_code in language_selector_languages %}
+      <li>
+        <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
+          {{ language_labels.get(lang_code) or (lang_code|upper) }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -20,7 +20,6 @@ body.login-page footer {
 }
 
 .login-container {
-  min-height: calc(100vh - 80px); /* ナビゲーションバー + 余白のみ */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -297,8 +296,7 @@ body.login-page main.container-fluid {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 60px 20px 40px;
-  min-height: calc(100vh - 60px);
+  min-height: calc(100vh - 100px);
   box-sizing: border-box;
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- remove extra vertical padding from the login layout container and adjust its minimum height to tighten spacing
- drop the fixed min-height from the login container to allow content to size naturally
- reposition the language selector dropdown beneath the login card for improved layout

## Testing
- `pytest` *(fails: tests/test_lifecycle_logging_unit.py::test_lifecycle_logging_records_startup - existing failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bbac302483238b5365aa8687f73e