### PR TITLE
Fix lifecycle logging DB persistence

### DIFF
--- a/core/db_log_handler.py
+++ b/core/db_log_handler.py
@@ -62,6 +62,14 @@ class DBLogHandler(logging.Handler):
         self._fallback_engine: Optional[Engine] = None
         self._ensured_engines: Set[int] = set()
 
+    def bind_to_app(self, app: "Flask") -> None:
+        """Rebind this handler to *app* and reset cached engines."""
+
+        self._app = app
+        self._engine = None
+        self._fallback_engine = None
+        self._ensured_engines.clear()
+
     def _resolve_engine(self) -> Engine:
         if self._engine is not None:
             return self._engine


### PR DESCRIPTION
## Summary
- ensure lifecycle logging binds existing database log handlers to the current application when safe
- add a helper on `DBLogHandler` to reset cached engines before logging lifecycle events
- rebind database log handlers in the Flask app factory so startup logging is recorded

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b91c530c8323b6d4e7b8cc9dc543