### PR TITLE
Move login language selector to top right

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -3,6 +3,26 @@
 {% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
+{% if not current_user.is_authenticated and language_selector_languages %}
+<div class="d-flex justify-content-end mb-3">
+  <div class="dropdown">
+    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
+            data-bs-toggle="dropdown" aria-expanded="false">
+      <i class="bi bi-translate me-1"></i>
+      {{ language_labels.get(current_language) or (current_language|upper) }}
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
+      {% for lang_code in language_selector_languages %}
+      <li>
+        <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
+          {{ language_labels.get(lang_code) or (lang_code|upper) }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}
 <div class="login-container">
   <div class="login-card">
     <div class="login-header">
@@ -68,27 +88,6 @@
     </div>
   </div>
 </div>
-
-{% if not current_user.is_authenticated and language_selector_languages %}
-<div class="d-flex justify-content-end mb-3">
-  <div class="dropdown">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
-            data-bs-toggle="dropdown" aria-expanded="false">
-      <i class="bi bi-translate me-1"></i>
-      {{ language_labels.get(current_language) or (current_language|upper) }}
-    </button>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
-      {% for lang_code in language_selector_languages %}
-      <li>
-        <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
-          {{ language_labels.get(lang_code) or (lang_code|upper) }}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-{% endif %}
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- move the login page language selector to the upper-right corner to match the root page layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48ddc333883238373d6c4f7bf512b