### PR TITLE
Localize FlaskApp title

### DIFF
--- a/webapp/templates/admin/version_view.html
+++ b/webapp/templates/admin/version_view.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _('Version Information') }} - FlaskApp{% endblock %}
+{% block title %}{{ _('Version Information') }} - {{ _('FlaskApp') }}{% endblock %}
 
 {% block content %}
 <div class="container mt-4">

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="user-timezone" content="{{ current_timezone_name }}">
-  <title>{% block title %}FlaskApp{% endblock %}</title>
+  <title>{% block title %}{{ _('FlaskApp') }}{% endblock %}</title>
   <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
@@ -17,7 +17,7 @@
 <header>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">FlaskApp</a>
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('FlaskApp') }}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -131,7 +131,7 @@
 </div>
 
 <footer class="text-center mt-5 mb-3">
-  <p class="text-muted">&copy; 2025 FlaskApp</p>
+  <p class="text-muted">&copy; 2025 {{ _('FlaskApp') }}</p>
   <p class="text-muted small">Version: {{ app_version }}</p>
 </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1,6 +1,9 @@
 msgid "Home"
 msgstr "Home"
 
+msgid "FlaskApp"
+msgstr "FlaskApp"
+
 msgid "Dashboard"
 msgstr "Dashboard"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -27,9 +27,14 @@ msgstr "このページにアクセスするにはログインが必要です。
 msgid "Login"
 msgstr "ログイン"
 
-#: webapp/__init__.py:263 webapp/templates/base.html:26
+#: webapp/__init__.py:263 webapp/templates/base.html:28
 msgid "Home"
 msgstr "ホーム"
+
+#: webapp/templates/base.html:7 webapp/templates/base.html:20
+#: webapp/templates/base.html:134 webapp/templates/admin/version_view.html:3
+msgid "FlaskApp"
+msgstr "FlaskApp"
 
 #: webapp/admin/routes.py:21 webapp/admin/routes.py:36
 #: webapp/admin/routes.py:50 webapp/admin/routes.py:66

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -26,8 +26,13 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: webapp/__init__.py:263 webapp/templates/base.html:26
+#: webapp/__init__.py:263 webapp/templates/base.html:28
 msgid "Home"
+msgstr ""
+
+#: webapp/templates/base.html:7 webapp/templates/base.html:20
+#: webapp/templates/base.html:134 webapp/templates/admin/version_view.html:3
+msgid "FlaskApp"
 msgstr ""
 
 #: webapp/admin/routes.py:21 webapp/admin/routes.py:36


### PR DESCRIPTION
## Summary
- wrap the default page title, navbar brand, and footer app name in gettext lookups
- ensure the admin version view title uses the localized project name
- add the new FlaskApp string to the translation template and both en/ja catalogs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d48e4e3ef483238ec852bfde7d645a