### PR TITLE
Adjust login language selector alignment

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 {% if not current_user.is_authenticated and language_selector_languages %}
-<div class="d-flex justify-content-end mb-3">
+<div class="language-selector d-flex justify-content-end mb-3 w-100">
   <div class="dropdown">
     <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
             data-bs-toggle="dropdown" aria-expanded="false">

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -25,6 +25,8 @@ body.login-page footer {
   justify-content: center;
   padding: 20px;
   box-sizing: border-box;
+  flex: 1 1 auto;
+  width: 100%;
 }
 
 .login-card {
@@ -294,11 +296,17 @@ body.login-page main.container-fluid {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: stretch;
   min-height: calc(100vh - 100px);
   box-sizing: border-box;
   margin-top: 0;
+  padding: 40px 12px 40px;
+  gap: 32px;
+}
+
+body.login-page .language-selector {
+  align-self: stretch;
 }
 
 body.login-page .flash-messages {


### PR DESCRIPTION
## Summary
- ログイン画面の言語選択ドロップダウンをトップ画面と同じ位置に並ぶようクラスを追加
- ログインページ専用スタイルを調整し、言語選択エリアをフル幅に伸ばしてカード部分は中央寄せを維持

## Testing
- 未実施（フロントエンド表示調整のため）

------
https://chatgpt.com/codex/tasks/task_e_68d499e6798883239428aff7ee51458e