### PR TITLE
Update base layout to use AppName translation key

### DIFF
--- a/webapp/templates/admin/version_view.html
+++ b/webapp/templates/admin/version_view.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _('Version Information') }} - {{ _('FlaskApp') }}{% endblock %}
+{% block title %}{{ _('Version Information') }} - {{ _('AppName') }}{% endblock %}
 
 {% block content %}
 <div class="container mt-4">

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="user-timezone" content="{{ current_timezone_name }}">
-  <title>{% block title %}{{ _('FlaskApp') }}{% endblock %}</title>
+  <title>{% block title %}{{ _('AppName') }}{% endblock %}</title>
   <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
@@ -17,7 +17,7 @@
 <header>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('FlaskApp') }}</a>
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('AppName') }}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -131,7 +131,7 @@
 </div>
 
 <footer class="text-center mt-5 mb-3">
-  <p class="text-muted">&copy; 2025 {{ _('FlaskApp') }}</p>
+  <p class="text-muted">&copy; 2025 {{ _('AppName') }}</p>
   <p class="text-muted small">Version: {{ app_version }}</p>
 </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1,8 +1,8 @@
 msgid "Home"
 msgstr "Home"
 
-msgid "FlaskApp"
-msgstr "FlaskApp"
+msgid "AppName"
+msgstr "AppName"
 
 msgid "Dashboard"
 msgstr "Dashboard"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -33,8 +33,8 @@ msgstr "ホーム"
 
 #: webapp/templates/base.html:7 webapp/templates/base.html:20
 #: webapp/templates/base.html:134 webapp/templates/admin/version_view.html:3
-msgid "FlaskApp"
-msgstr "FlaskApp"
+msgid "AppName"
+msgstr "AppName"
 
 #: webapp/admin/routes.py:21 webapp/admin/routes.py:36
 #: webapp/admin/routes.py:50 webapp/admin/routes.py:66

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -32,7 +32,7 @@ msgstr ""
 
 #: webapp/templates/base.html:7 webapp/templates/base.html:20
 #: webapp/templates/base.html:134 webapp/templates/admin/version_view.html:3
-msgid "FlaskApp"
+msgid "AppName"
 msgstr ""
 
 #: webapp/admin/routes.py:21 webapp/admin/routes.py:36


### PR DESCRIPTION
## Summary
- replace hardcoded FlaskApp name in the base template with a localized AppName resource
- update the admin version view title to reference the new AppName key
- rename the translation entries from FlaskApp to AppName in the POT and PO files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d49a96bfa88323a0c6abcdb8f28159