### PR TITLE
Fix layout overflow on Edit User Roles actions

### DIFF
--- a/webapp/admin/templates/admin/user_role_edit.html
+++ b/webapp/admin/templates/admin/user_role_edit.html
@@ -58,9 +58,9 @@
             </select>
             <div class="form-text">{{ _('Hold Ctrl (Windows) or Command (macOS) to select multiple roles.') }}</div>
           </div>
-          <div class="mt-auto d-flex flex-wrap gap-2">
-            <button type="submit" class="btn btn-primary">{{ _('Update roles') }}</button>
-            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary">{{ _('Cancel') }}</a>
+          <div class="mt-auto d-flex flex-column flex-sm-row gap-2">
+            <button type="submit" class="btn btn-primary flex-fill flex-sm-grow-0">{{ _('Update roles') }}</button>
+            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary flex-fill flex-sm-grow-0">{{ _('Cancel') }}</a>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- stack the action buttons vertically on small screens and keep them aligned in a row on larger screens
- allow both buttons to grow to the container width on narrow viewports to prevent overflow

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4ae92718483239c3e218a6c8f41e1