### PR TITLE
Refine user role action buttons

### DIFF
--- a/webapp/admin/templates/admin/user_role_edit.html
+++ b/webapp/admin/templates/admin/user_role_edit.html
@@ -58,9 +58,9 @@
             </select>
             <div class="form-text">{{ _('Hold Ctrl (Windows) or Command (macOS) to select multiple roles.') }}</div>
           </div>
-          <div class="mt-auto d-flex flex-wrap gap-2">
-            <button type="submit" class="btn btn-primary">{{ _('Update roles') }}</button>
-            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary">{{ _('Cancel') }}</a>
+          <div class="d-flex flex-column flex-sm-row flex-wrap gap-2">
+            <button type="submit" class="btn btn-primary btn-size-md w-100 w-sm-auto">{{ _('Update roles') }}</button>
+            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary btn-size-md w-100 w-sm-auto">{{ _('Cancel') }}</a>
           </div>
         </form>
       </div>

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -125,6 +125,33 @@ body.login-page footer {
   color: #667eea;
 }
 
+.btn-size-lg,
+.btn-size-md,
+.btn-size-sm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  white-space: nowrap;
+  border-radius: 0.75rem;
+}
+
+.btn-size-lg {
+  min-width: 16rem;
+  padding: 0.9rem 1.75rem;
+}
+
+.btn-size-md {
+  min-width: 12.5rem;
+  padding: 0.75rem 1.5rem;
+}
+
+.btn-size-sm {
+  min-width: 9rem;
+  padding: 0.6rem 1.25rem;
+}
+
 .btn-login {
   width: 100%;
   padding: 14px;


### PR DESCRIPTION
## Summary
- introduce reusable fixed-width button size utility classes to provide consistent sizing options
- update the Edit User Roles action bar to use the medium button size and responsive width helpers while removing the overflowing mt-auto layout

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4ae92718483239c3e218a6c8f41e1