### PR TITLE
Adjust role selection flow and button sizing

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -140,16 +140,19 @@ body.login-page footer {
 .btn-size-lg {
   min-width: 16rem;
   padding: 0.9rem 1.75rem;
+  max-width: 20rem;
 }
 
 .btn-size-md {
   min-width: 12.5rem;
   padding: 0.75rem 1.5rem;
+  max-width: 16rem;
 }
 
 .btn-size-sm {
   min-width: 9rem;
   padding: 0.6rem 1.25rem;
+  max-width: 12rem;
 }
 
 .btn-login {


### PR DESCRIPTION
## Summary
- redirect domain-backed logins with multiple roles to the role selection screen before continuing
- cap the width of the large, medium, and small button helper classes for consistent sizing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b8ec248083238f7a77cc81203f89