### PR TITLE
feat: enable role selection via cards

### DIFF
--- a/webapp/admin/templates/admin/user_role_edit.html
+++ b/webapp/admin/templates/admin/user_role_edit.html
@@ -1,5 +1,76 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Edit User Roles') }}{% endblock %}
+{% block extra_head %}
+<style>
+  .role-card {
+    position: relative;
+    border: 1px solid var(--bs-border-color-translucent);
+    border-radius: 0.75rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    background-color: var(--bs-body-bg);
+  }
+
+  .role-card:hover {
+    border-color: rgba(var(--bs-primary-rgb), 0.35);
+    box-shadow: 0 0.75rem 1.5rem rgba(var(--bs-primary-rgb), 0.1);
+    transform: translateY(-1px);
+  }
+
+  .role-card:focus-visible {
+    outline: 0;
+    box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+  }
+
+  .role-card-active {
+    border-color: rgba(var(--bs-primary-rgb), 0.8);
+    box-shadow: 0 1.25rem 2.5rem rgba(var(--bs-primary-rgb), 0.18);
+  }
+
+  .role-card-active .role-card-title {
+    color: var(--bs-primary);
+  }
+
+  .role-card-indicator {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(var(--bs-primary-rgb), 0.12);
+    color: var(--bs-primary);
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+  }
+
+  .role-card-active .role-card-indicator {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  #selected-roles-summary:empty {
+    display: none;
+  }
+
+  #selected-roles-summary .btn-outline-primary {
+    background-color: rgba(var(--bs-primary-rgb), 0.08);
+    border-color: rgba(var(--bs-primary-rgb), 0.4);
+    color: var(--bs-primary);
+  }
+
+  #selected-roles-summary .btn-outline-primary:hover {
+    background-color: rgba(var(--bs-primary-rgb), 0.12);
+    border-color: rgba(var(--bs-primary-rgb), 0.5);
+    color: var(--bs-primary);
+  }
+</style>
+{% endblock %}
 
 {% block content %}
 <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-4">
@@ -9,90 +80,236 @@
   </div>
 </div>
 
-<div class="row g-4">
-  <div class="col-lg-5">
-    <div class="card shadow-sm h-100">
-      <div class="card-body">
-        <h2 class="h5 mb-3">{{ _('Account overview') }}</h2>
-        <dl class="row mb-0">
-          <dt class="col-sm-5 text-muted small text-uppercase">{{ _('Current User') }}</dt>
-          <dd class="col-sm-7 mb-3">{{ user.email }}</dd>
-          <dt class="col-sm-5 text-muted small text-uppercase">{{ _('Current Roles') }}</dt>
-          <dd class="col-sm-7 mb-0">
-            {% if user.roles %}
-              <div class="d-flex flex-wrap gap-2">
-                {% for role in user.roles %}
-                  <span class="badge bg-secondary">{{ role.name }}</span>
-                {% endfor %}
-              </div>
-            {% else %}
-              <span class="text-muted">{{ _('No roles assigned') }}</span>
-            {% endif %}
-          </dd>
-        </dl>
-      </div>
-    </div>
-  </div>
-  <div class="col-lg-7">
-    <div class="card shadow-sm h-100">
-      <div class="card-body">
-        <h2 class="h5 mb-4">{{ _('Role settings') }}</h2>
-        <form method="post" action="{{ url_for('admin.user_change_role', user_id=user.id) }}" class="d-flex flex-column h-100">
-          {% set options_size = roles|length %}
-          {% if options_size < 4 %}
-            {% set options_size = 4 %}
-          {% elif options_size > 12 %}
-            {% set options_size = 12 %}
-          {% endif %}
-          <div class="mb-3">
-            <label for="roles" class="form-label">{{ _('Select roles to assign') }}</label>
-            <select class="form-select" id="roles" name="roles" multiple size="{{ options_size }}" required>
-              {% for role in roles %}
-                <option value="{{ role.id }}" {% if user.roles and role.id in user.roles|map(attribute='id')|list %}selected{% endif %}>
-                  {{ role.name }}
-                  {% if role.permissions %}
-                    ({{ role.permissions|map(attribute='code')|join(', ') }})
-                  {% endif %}
-                </option>
-              {% endfor %}
-            </select>
-            <div class="form-text">{{ _('Hold Ctrl (Windows) or Command (macOS) to select multiple roles.') }}</div>
-          </div>
-          <div class="d-flex flex-column flex-sm-row flex-wrap gap-2">
-            <button type="submit" class="btn btn-primary btn-size-md w-100 w-sm-auto">{{ _('Update roles') }}</button>
-            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary btn-size-md w-100 w-sm-auto">{{ _('Cancel') }}</a>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="mt-5">
-  <h2 class="h5 mb-3">{{ _('Available Roles and Permissions') }}</h2>
-  <div class="row g-3">
-    {% for role in roles %}
-    <div class="col-md-6 col-xl-4">
-      <div class="card h-100 border-0 shadow-sm">
+<form method="post" action="{{ url_for('admin.user_change_role', user_id=user.id) }}" class="d-flex flex-column gap-4">
+  <div class="row g-4">
+    <div class="col-lg-5">
+      <div class="card shadow-sm h-100">
         <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start mb-3">
-            <strong class="text-primary">{{ role.name }}</strong>
-            <span class="badge text-bg-light text-secondary">{{ role.permissions|length if role.permissions else 0 }}</span>
-          </div>
-          {% if role.permissions %}
-            <div class="d-flex flex-wrap gap-2">
-              {% for perm in role.permissions %}
-                <span class="badge bg-info text-dark">{{ perm.code }}</span>
-              {% endfor %}
-            </div>
-          {% else %}
-            <span class="text-muted">{{ _('No permissions') }}</span>
-          {% endif %}
+          <h2 class="h5 mb-3">{{ _('Account overview') }}</h2>
+          <dl class="row mb-0">
+            <dt class="col-sm-5 text-muted small text-uppercase">{{ _('Current User') }}</dt>
+            <dd class="col-sm-7 mb-3">{{ user.email }}</dd>
+            <dt class="col-sm-5 text-muted small text-uppercase">{{ _('Current Roles') }}</dt>
+            <dd class="col-sm-7 mb-0">
+              {% if user.roles %}
+                <div class="d-flex flex-wrap gap-2">
+                  {% for role in user.roles %}
+                    <span class="badge bg-secondary">{{ role.name }}</span>
+                  {% endfor %}
+                </div>
+              {% else %}
+                <span class="text-muted">{{ _('No roles assigned') }}</span>
+              {% endif %}
+            </dd>
+          </dl>
         </div>
       </div>
     </div>
-    {% endfor %}
+    <div class="col-lg-7">
+      <div class="card shadow-sm h-100">
+        <div class="card-body d-flex flex-column h-100">
+          <div class="mb-4">
+            <h2 class="h5 mb-1">{{ _('Role settings') }}</h2>
+            <p class="text-muted small mb-0">{{ _('Select roles by clicking the cards below. Click again to deselect.') }}</p>
+          </div>
+          <div class="mb-4">
+            <label class="form-label fw-semibold">{{ _('Selected roles') }}</label>
+            <div class="bg-light border rounded-3 p-3">
+              <div class="d-flex align-items-center justify-content-between mb-3">
+                <span class="text-muted small text-uppercase">{{ _('Selected count') }}</span>
+                <span class="badge bg-primary" id="selected-roles-count">0</span>
+              </div>
+              <div id="selected-roles-summary" class="d-flex flex-wrap gap-2"></div>
+              <p class="text-muted small mb-0" id="selected-roles-empty">{{ _('No roles selected yet. Choose from the list below.') }}</p>
+            </div>
+          </div>
+          <div id="selected-roles-inputs" class="d-none" aria-hidden="true"></div>
+          <div class="mt-auto d-flex flex-column flex-sm-row flex-wrap gap-2">
+            <button type="submit" class="btn btn-primary btn-size-md w-100 w-sm-auto">{{ _('Update roles') }}</button>
+            <a href="{{ url_for('admin.user') }}" class="btn btn-outline-secondary btn-size-md w-100 w-sm-auto">{{ _('Cancel') }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-</div>
 
+  <div class="mt-2">
+    <h2 class="h5 mb-2">{{ _('Available Roles and Permissions') }}</h2>
+    <p class="text-muted small mb-3">{{ _('Click a role card to include it for the user. Permission counts are shown on each card.') }}</p>
+    <div class="row g-3">
+      {% for role in roles %}
+      <div class="col-md-6 col-xl-4">
+        <div
+          class="role-card card h-100 border shadow-sm"
+          role="checkbox"
+          tabindex="0"
+          data-role-card
+          data-role-id="{{ role.id }}"
+          data-role-name="{{ role.name }}"
+          data-role-permission-count="{{ role.permissions|length if role.permissions else 0 }}"
+        >
+          <span class="role-card-indicator" aria-hidden="true"><i class="bi bi-check-lg"></i></span>
+          <div class="card-body">
+            <div class="d-flex justify-content-between align-items-start mb-3 pe-3">
+              <strong class="role-card-title">{{ role.name }}</strong>
+              <span class="badge text-bg-light text-secondary">{{ role.permissions|length if role.permissions else 0 }}</span>
+            </div>
+            {% if role.permissions %}
+              <div class="d-flex flex-wrap gap-2">
+                {% for perm in role.permissions %}
+                  <span class="badge bg-info text-dark">{{ perm.code }}</span>
+                {% endfor %}
+              </div>
+            {% else %}
+              <span class="text-muted">{{ _('No permissions') }}</span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</form>
+
+{% endblock %}
+{% block extra_scripts %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const roleCards = Array.from(document.querySelectorAll('[data-role-card]'));
+    const summaryContainer = document.getElementById('selected-roles-summary');
+    const emptyMessage = document.getElementById('selected-roles-empty');
+    const countElement = document.getElementById('selected-roles-count');
+    const inputsContainer = document.getElementById('selected-roles-inputs');
+
+    if (!summaryContainer || !countElement || !inputsContainer) {
+      return;
+    }
+
+    const initialRoleIds = JSON.parse('{{ user.roles|map(attribute="id")|list|tojson|safe }}');
+    const selectedRoleIds = new Set(initialRoleIds.map((value) => String(value)));
+
+    const roleLookup = new Map();
+    roleCards.forEach((card) => {
+      const roleId = String(card.dataset.roleId || '');
+      roleLookup.set(roleId, {
+        name: card.dataset.roleName || '',
+      });
+    });
+
+    function updateEmptyState() {
+      if (!emptyMessage) {
+        return;
+      }
+
+      if (selectedRoleIds.size === 0) {
+        emptyMessage.classList.remove('d-none');
+      } else {
+        emptyMessage.classList.add('d-none');
+      }
+    }
+
+    function updateCount() {
+      countElement.textContent = selectedRoleIds.size.toString();
+    }
+
+    function renderSummary() {
+      summaryContainer.innerHTML = '';
+
+      selectedRoleIds.forEach((roleId) => {
+        const info = roleLookup.get(roleId);
+        if (!info) {
+          return;
+        }
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-outline-primary rounded-pill d-inline-flex align-items-center gap-2';
+        button.dataset.roleId = roleId;
+
+        const label = document.createElement('span');
+        label.textContent = info.name;
+        button.appendChild(label);
+
+        const icon = document.createElement('i');
+        icon.className = 'bi bi-x-lg small';
+        icon.setAttribute('aria-hidden', 'true');
+        button.appendChild(icon);
+
+        button.setAttribute('aria-label', `{{ _('Remove role') }}: ${info.name}`);
+        summaryContainer.appendChild(button);
+      });
+    }
+
+    function renderInputs() {
+      inputsContainer.innerHTML = '';
+
+      selectedRoleIds.forEach((roleId) => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'roles';
+        input.value = roleId;
+        inputsContainer.appendChild(input);
+      });
+    }
+
+    function updateCardStates() {
+      roleCards.forEach((card) => {
+        const roleId = String(card.dataset.roleId || '');
+        const isActive = selectedRoleIds.has(roleId);
+        card.classList.toggle('role-card-active', isActive);
+        card.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      });
+    }
+
+    function syncUI() {
+      updateCardStates();
+      updateCount();
+      updateEmptyState();
+      renderSummary();
+      renderInputs();
+    }
+
+    function toggleRole(roleId) {
+      if (!roleId) {
+        return;
+      }
+
+      if (selectedRoleIds.has(roleId)) {
+        selectedRoleIds.delete(roleId);
+      } else {
+        selectedRoleIds.add(roleId);
+      }
+
+      syncUI();
+    }
+
+    roleCards.forEach((card) => {
+      const roleId = String(card.dataset.roleId || '');
+      card.addEventListener('click', (event) => {
+        event.preventDefault();
+        toggleRole(roleId);
+      });
+
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggleRole(roleId);
+        }
+      });
+    });
+
+    summaryContainer.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-role-id]');
+      if (!button) {
+        return;
+      }
+
+      event.preventDefault();
+      const roleId = String(button.dataset.roleId || '');
+      toggleRole(roleId);
+    });
+
+    syncUI();
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the Edit User Roles form select box with clickable role cards
- show a live summary of the chosen roles and highlight selected cards
- add client-side scripting to sync the selected card state with the submitted form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4b9396da88323b4da2097fab21ac1