### PR TITLE
Highlight selected role cards using border emphasis

### DIFF
--- a/webapp/admin/templates/admin/user_role_edit.html
+++ b/webapp/admin/templates/admin/user_role_edit.html
@@ -7,7 +7,7 @@
     border: 1px solid var(--bs-border-color-translucent);
     border-radius: 0.75rem;
     cursor: pointer;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    transition: border-color 0.2s ease, border-width 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     background-color: var(--bs-body-bg);
   }
 
@@ -23,35 +23,14 @@
   }
 
   .role-card-active {
-    border-color: rgba(var(--bs-primary-rgb), 0.8);
+    border-width: 2px;
+    border-color: rgba(var(--bs-primary-rgb), 0.95);
     box-shadow: 0 1.25rem 2.5rem rgba(var(--bs-primary-rgb), 0.18);
+    transform: translateY(-1px);
   }
 
   .role-card-active .role-card-title {
     color: var(--bs-primary);
-  }
-
-  .role-card-indicator {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(var(--bs-primary-rgb), 0.12);
-    color: var(--bs-primary);
-    opacity: 0;
-    transform: scale(0.85);
-    transition: opacity 0.2s ease, transform 0.2s ease;
-    pointer-events: none;
-  }
-
-  .role-card-active .role-card-indicator {
-    opacity: 1;
-    transform: scale(1);
   }
 
   #selected-roles-summary:empty {
@@ -148,7 +127,6 @@
           data-role-name="{{ role.name }}"
           data-role-permission-count="{{ role.permissions|length if role.permissions else 0 }}"
         >
-          <span class="role-card-indicator" aria-hidden="true"><i class="bi bi-check-lg"></i></span>
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-start mb-3 pe-3">
               <strong class="role-card-title">{{ role.name }}</strong>


### PR DESCRIPTION
## Summary
- emphasize selected role cards by strengthening their border styling
- remove the floating check indicator so the active state relies on the border highlight

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4bf93217c8323a58f2cd2fbd1d1ac