### PR TITLE
Fix role selection handling after API login

### DIFF
--- a/tests/test_api_login_totp.py
+++ b/tests/test_api_login_totp.py
@@ -80,3 +80,6 @@ def test_api_login_requires_totp(client, app):
         json={"email": totp_email, "password": "pass", "token": valid_token},
     )
     assert res.status_code == 200
+    data = res.get_json()
+    assert data["requires_role_selection"] is False
+    assert data["redirect_url"].endswith("/feature-x/dashboard")

--- a/tests/test_api_refresh_token.py
+++ b/tests/test_api_refresh_token.py
@@ -42,6 +42,7 @@ def login(client, app, *, token: str | None = None):
     res = client.post("/api/login", json=payload)
     assert res.status_code == 200
     data = res.get_json()
+    assert data["requires_role_selection"] is False
     return data["access_token"], data["refresh_token"]
 
 

--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -105,12 +105,14 @@ document.addEventListener('DOMContentLoaded', function() {
     
     try {
       const formData = new FormData(form);
+      const storedRedirectPath = localStorage.getItem('redirect_after_login');
       const loginData = {
         email: formData.get('email'),
         password: formData.get('password'),
-        token: formData.get('token') || null
+        token: formData.get('token') || null,
+        next: storedRedirectPath || null
       };
-      
+
       const response = await fetch('/api/login', {
         method: 'POST',
         headers: {
@@ -118,25 +120,34 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         body: JSON.stringify(loginData)
       });
-      
+
       if (response.ok) {
         const result = await response.json();
-        
+
         // リフレッシュトークンをlocalStorageに保存
         if (result.refresh_token) {
           localStorage.setItem('refresh_token', result.refresh_token);
         }
-        
+
+        if (result.requires_role_selection) {
+          if (storedRedirectPath) {
+            localStorage.removeItem('redirect_after_login');
+          }
+          window.location.href = result.redirect_url || '/auth/select-role';
+          return;
+        }
+
         // ログイン成功メッセージ
         if (typeof showSuccessToast === 'function') {
           showSuccessToast('{{ _("Login successful") }}');
         }
-        
+
         // リダイレクト処理
-        const redirectPath = localStorage.getItem('redirect_after_login');
-        if (redirectPath) {
+        if (storedRedirectPath) {
           localStorage.removeItem('redirect_after_login');
-          window.location.href = redirectPath;
+          window.location.href = storedRedirectPath;
+        } else if (result.redirect_url) {
+          window.location.href = result.redirect_url;
         } else {
           window.location.href = '{{ url_for("feature_x.dashboard") }}';
         }


### PR DESCRIPTION
## Summary
- ensure the API login endpoint mirrors the session handling of the web login when multiple roles are present
- update the login form script to forward the desired redirect path and react to the new API response shape
- expand API login and role selection tests to cover the new behaviour and keep regressions out

## Testing
- `pytest tests/test_auth_role_selection.py tests/test_api_login_totp.py tests/test_api_refresh_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d4bfc4f47083238667d951fb4829dd