### PR TITLE
Remove all-roles option from active role selection

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -79,6 +79,7 @@ class User(db.Model, UserMixin):
                 selected = [role for role in roles if role.id == active_role_id]
                 if selected:
                     return selected
+            return [roles[0]]
         return roles
 
     @property

--- a/tests/test_auth_role_selection.py
+++ b/tests/test_auth_role_selection.py
@@ -107,16 +107,17 @@ def test_role_selection_sets_active_role(client, app):
     with client.session_transaction() as sess:
         assert sess["active_role_id"] == role_ids[0]
 
-    # Allow switching back to all roles
+    # Invalid selections should not clear the active role
     response = client.post(
         "/auth/select-role",
         data={"active_role": "all"},
         follow_redirects=False,
     )
-    assert response.status_code == 302
+    assert response.status_code == 200
+    assert b"Invalid role selection" in response.data
 
     with client.session_transaction() as sess:
-        assert "active_role_id" not in sess
+        assert sess["active_role_id"] == role_ids[0]
 
 
 def test_api_login_requires_role_selection(client, app):

--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -62,7 +62,7 @@ def _sync_active_role(user_model):
     if len(role_ids) == 1:
         session["active_role_id"] = role_ids[0]
     else:
-        session.pop("active_role_id", None)
+        session["active_role_id"] = role_ids[0]
 
 
 def _resolve_post_login_target() -> str:
@@ -196,12 +196,6 @@ def select_role():
     if request.method == "POST":
         role_choice = request.form.get("active_role")
         available_roles = {str(role.id): role for role in roles}
-        if role_choice == "all":
-            session.pop("active_role_id", None)
-            _sync_active_role(current_user)
-            flash(_("Active role cleared. All assigned roles are now in effect."), "success")
-            return redirect(_pop_role_selection_target())
-
         if role_choice and role_choice in available_roles:
             session["active_role_id"] = available_roles[role_choice].id
             flash(
@@ -392,12 +386,6 @@ def profile():
             response = make_response(redirect(url_for("auth.profile")))
             role_choice = request.form.get("active_role")
             available_roles = {str(role.id): role for role in current_user.roles}
-
-            if role_choice == "all":
-                session.pop("active_role_id", None)
-                _sync_active_role(current_user)
-                flash(_("Active role cleared. All assigned roles are now in effect."), "success")
-                return response
 
             if role_choice and role_choice in available_roles:
                 session["active_role_id"] = available_roles[role_choice].id

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -55,10 +55,10 @@
             <input type="hidden" name="action" value="switch-role">
             <div class="mb-3">
               <label for="active-role" class="form-label">{{ _('Active role') }}</label>
-              <select class="form-select" id="active-role" name="active_role">
-                <option value="all" {% if not active_role %}selected{% endif %}>{{ _('Use all assigned roles') }}</option>
+              <select class="form-select" id="active-role" name="active_role" required>
                 {% for role in current_user.roles %}
-                  <option value="{{ role.id }}" {% if active_role and role.id == active_role.id %}selected{% endif %}>{{ role.name }}</option>
+                  {% set is_selected = (active_role and role.id == active_role.id) or (not active_role and loop.first) %}
+                  <option value="{{ role.id }}" {% if is_selected %}selected{% endif %}>{{ role.name }}</option>
                 {% endfor %}
               </select>
               <div class="form-text">{{ _('Selecting a specific role limits your permissions to that role.') }}</div>

--- a/webapp/auth/templates/auth/select_role.html
+++ b/webapp/auth/templates/auth/select_role.html
@@ -11,19 +11,11 @@
           <p class="text-muted mb-4">{{ _('Choose which role should be active for this session.') }}</p>
           <form method="post" class="d-flex flex-column gap-3">
             <div class="list-group">
-              <label class="list-group-item d-flex align-items-center gap-3">
-                <input class="form-check-input me-2" type="radio" name="active_role" value="all"
-                       {% if not selected_role_id %}checked{% endif %} required>
-                <div>
-                  <div class="fw-semibold">{{ _('Use all assigned roles') }}</div>
-                  <div class="text-muted small">{{ _('Keep every role available just like before switching.') }}</div>
-                </div>
-              </label>
               {% for role in roles %}
               <label class="list-group-item d-flex align-items-center gap-3">
                 <input class="form-check-input me-2" type="radio" name="active_role" value="{{ role.id }}"
                        {% if selected_role_id and role.id == selected_role_id %}checked{% endif %}
-                       {% if not selected_role_id and loop.first %}required{% endif %}>
+                       {% if not selected_role_id and loop.first %}checked{% endif %} required>
                 <div>
                   <div class="fw-semibold">{{ role.name }}</div>
                   {% if role.permissions %}


### PR DESCRIPTION
## Summary
- remove the "use all assigned roles" choice from the role selection and profile UIs
- ensure the backend keeps a concrete active role for multi-role users and rejects invalid selections
- update the role selection test to reflect the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4c42cf8e88323a5dcca9b917a9d64