### PR TITLE
Improve role selection border visibility

### DIFF
--- a/webapp/auth/templates/auth/select_role.html
+++ b/webapp/auth/templates/auth/select_role.html
@@ -10,13 +10,14 @@
           <h1 class="h4 mb-3">{{ _('Select the role to use') }}</h1>
           <p class="text-muted mb-4">{{ _('Choose which role should be active for this session.') }}</p>
           <form method="post" class="d-flex flex-column gap-3">
-            <div class="list-group">
+            <div class="list-group role-selection-list">
               {% for role in roles %}
-              <label class="list-group-item d-flex align-items-center gap-3">
+              <label class="role-option list-group-item d-flex align-items-center gap-3">
                 <input class="form-check-input me-2" type="radio" name="active_role" value="{{ role.id }}"
+                       data-role-option-radio
                        {% if selected_role_id and role.id == selected_role_id %}checked{% endif %}
                        {% if not selected_role_id and loop.first %}checked{% endif %} required>
-                <div>
+                <div class="role-option-body">
                   <div class="fw-semibold">{{ role.name }}</div>
                   {% if role.permissions %}
                   <div class="text-muted small">
@@ -42,4 +43,34 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const radios = Array.from(document.querySelectorAll('[data-role-option-radio]'));
+
+    const updateSelectionState = () => {
+      radios.forEach((radio) => {
+        const label = radio.closest('.role-option');
+        if (!label) {
+          return;
+        }
+
+        if (radio.checked) {
+          label.classList.add('role-option-active');
+        } else {
+          label.classList.remove('role-option-active');
+        }
+      });
+    };
+
+    radios.forEach((radio) => {
+      radio.addEventListener('change', updateSelectionState);
+    });
+
+    updateSelectionState();
+  });
+</script>
 {% endblock %}

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -451,6 +451,42 @@ body.login-page .flash-messages .alert {
   padding: 0.4rem 0.65rem;
 }
 
+/* Role selection page */
+.role-selection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.role-selection-list .role-option {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.75rem;
+  padding: 0.875rem 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.role-selection-list .role-option:hover {
+  border-color: rgba(var(--bs-primary-rgb), 0.4);
+  box-shadow: 0 0.75rem 1.5rem rgba(var(--bs-primary-rgb), 0.12);
+  transform: translateY(-1px);
+}
+
+.role-selection-list .role-option:focus-within {
+  outline: 0;
+  border-color: rgba(var(--bs-primary-rgb), 0.55);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.2);
+}
+
+.role-selection-list .role-option.role-option-active {
+  border-color: rgba(var(--bs-primary-rgb), 0.95);
+  box-shadow: 0 1.25rem 2.5rem rgba(var(--bs-primary-rgb), 0.18);
+  transform: translateY(-1px);
+}
+
+.role-selection-list .role-option .role-option-body {
+  flex: 1;
+}
+
 .admin-filter-form .btn,
 .admin-filter-actions .btn {
   padding: 0.4rem 0.75rem;


### PR DESCRIPTION
## Summary
- add styling hooks for the role selection list so radio items always render borders
- highlight the active role option with richer hover and focus feedback

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4ca2fc39c83238b940d8be0267e3a