### PR TITLE
Add password visibility toggles to forms

### DIFF
--- a/webapp/admin/templates/admin/user_add.html
+++ b/webapp/admin/templates/admin/user_add.html
@@ -9,7 +9,16 @@
   </div>
   <div class="mb-3">
     <label for="password" class="form-label">{{ _('Password') }}</label>
-    <input type="password" class="form-control" id="password" name="password" required>
+    <div class="password-toggle-wrapper">
+      <input type="password" class="form-control" id="password" name="password" required>
+      <button type="button" class="toggle-password-btn" aria-label="{{ _('Show password') }}"
+              aria-pressed="false" aria-controls="password"
+              data-show-label="{{ _('Show password') }}"
+              data-hide-label="{{ _('Hide password') }}">
+        <i class="fas fa-eye"></i>
+        <span class="visually-hidden">{{ _('Toggle password visibility') }}</span>
+      </button>
+    </div>
   </div>
   <div class="mb-3">
     <label for="role" class="form-label">{{ _('Role') }}</label>

--- a/webapp/auth/templates/auth/edit.html
+++ b/webapp/auth/templates/auth/edit.html
@@ -30,9 +30,16 @@
           <i class="fas fa-lock"></i>
           {{ _('New Password') }}
         </label>
-        <div class="input-wrapper">
+        <div class="input-wrapper password-toggle-wrapper">
           <input type="password" class="form-control" id="password" name="password"
                  placeholder="{{ _('Leave blank to keep current password') }}">
+          <button type="button" class="toggle-password-btn" aria-label="{{ _('Show password') }}"
+                  aria-pressed="false" aria-controls="password"
+                  data-show-label="{{ _('Show password') }}"
+                  data-hide-label="{{ _('Hide password') }}">
+            <i class="fas fa-eye"></i>
+            <span class="visually-hidden">{{ _('Toggle password visibility') }}</span>
+          </button>
           <div class="input-icon">
             <i class="fas fa-lock"></i>
           </div>

--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -50,9 +50,16 @@
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-wrapper">
+        <div class="input-wrapper password-toggle-wrapper">
           <input type="password" class="form-control" id="password" name="password"
                  placeholder="{{ _('Enter your password') }}" required>
+          <button type="button" class="toggle-password-btn" aria-label="{{ _('Show password') }}"
+                  aria-pressed="false" aria-controls="password"
+                  data-show-label="{{ _('Show password') }}"
+                  data-hide-label="{{ _('Hide password') }}">
+            <i class="fas fa-eye"></i>
+            <span class="visually-hidden">{{ _('Toggle password visibility') }}</span>
+          </button>
           <div class="input-icon">
             <i class="fas fa-lock"></i>
           </div>

--- a/webapp/auth/templates/auth/register.html
+++ b/webapp/auth/templates/auth/register.html
@@ -30,9 +30,16 @@
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-wrapper">
+        <div class="input-wrapper password-toggle-wrapper">
           <input type="password" class="form-control" id="password" name="password"
                  placeholder="{{ _('Create a strong password') }}" required>
+          <button type="button" class="toggle-password-btn" aria-label="{{ _('Show password') }}"
+                  aria-pressed="false" aria-controls="password"
+                  data-show-label="{{ _('Show password') }}"
+                  data-hide-label="{{ _('Hide password') }}">
+            <i class="fas fa-eye"></i>
+            <span class="visually-hidden">{{ _('Toggle password visibility') }}</span>
+          </button>
           <div class="input-icon">
             <i class="fas fa-lock"></i>
           </div>

--- a/webapp/auth/templates/auth/register_no_totp.html
+++ b/webapp/auth/templates/auth/register_no_totp.html
@@ -30,9 +30,16 @@
           <i class="fas fa-lock"></i>
           {{ _('Password') }}
         </label>
-        <div class="input-wrapper">
+        <div class="input-wrapper password-toggle-wrapper">
           <input type="password" class="form-control" id="password" name="password"
                  placeholder="{{ _('Create a strong password') }}" required>
+          <button type="button" class="toggle-password-btn" aria-label="{{ _('Show password') }}"
+                  aria-pressed="false" aria-controls="password"
+                  data-show-label="{{ _('Show password') }}"
+                  data-hide-label="{{ _('Hide password') }}">
+            <i class="fas fa-eye"></i>
+            <span class="visually-hidden">{{ _('Toggle password visibility') }}</span>
+          </button>
           <div class="input-icon">
             <i class="fas fa-lock"></i>
           </div>

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -13,6 +13,52 @@ window.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const toggleButtons = document.querySelectorAll('.toggle-password-btn');
+  toggleButtons.forEach(button => {
+    const wrapper = button.closest('.password-toggle-wrapper');
+    const input = wrapper ? wrapper.querySelector('input') : null;
+
+    if (!input) {
+      return;
+    }
+
+    const icon = button.querySelector('i');
+    const showLabel = button.dataset.showLabel || 'Show password';
+    const hideLabel = button.dataset.hideLabel || 'Hide password';
+
+    const updateButtonState = visible => {
+      if (visible) {
+        button.setAttribute('aria-label', hideLabel);
+        button.setAttribute('aria-pressed', 'true');
+        if (icon) {
+          icon.classList.remove('fa-eye');
+          icon.classList.add('fa-eye-slash');
+        }
+      } else {
+        button.setAttribute('aria-label', showLabel);
+        button.setAttribute('aria-pressed', 'false');
+        if (icon) {
+          icon.classList.add('fa-eye');
+          icon.classList.remove('fa-eye-slash');
+        }
+      }
+    };
+
+    button.addEventListener('click', () => {
+      const isVisible = input.type === 'text';
+      input.type = isVisible ? 'password' : 'text';
+      updateButtonState(!isVisible);
+
+      if (!isVisible) {
+        input.focus({ preventScroll: true });
+        const valueLength = input.value.length;
+        input.setSelectionRange(valueLength, valueLength);
+      }
+    });
+
+    updateButtonState(input.type === 'text');
+  });
 });
 
 // Toast notification function

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -116,13 +116,52 @@ body.login-page footer {
   z-index: 2;
 }
 
-.input-wrapper .form-control:focus + .input-icon,
-.input-wrapper .form-control:valid + .input-icon {
+.input-wrapper .form-control:focus ~ .input-icon,
+.input-wrapper .form-control:valid ~ .input-icon {
   color: #667eea;
 }
 
 .input-wrapper:focus-within .input-icon {
   color: #667eea;
+}
+
+.password-toggle-wrapper {
+  position: relative;
+}
+
+.password-toggle-wrapper .form-control {
+  padding-right: 48px;
+}
+
+.password-toggle-wrapper .toggle-password-btn {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.password-toggle-wrapper .toggle-password-btn:hover {
+  color: #4f46e5;
+  background-color: rgba(79, 70, 229, 0.08);
+}
+
+.password-toggle-wrapper .toggle-password-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.25rem rgba(102, 126, 234, 0.25);
+}
+
+.password-toggle-wrapper .toggle-password-btn:active {
+  color: #4338ca;
 }
 
 .btn-size-lg,


### PR DESCRIPTION
## Summary
- add password visibility toggle controls to login, registration, profile update, and admin user creation forms
- style the toggle button and enhance main JavaScript to handle password visibility changes accessibly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d509000083239d2805bd5f9bb7e6