### PR TITLE
Fix local import storage path resolution

### DIFF
--- a/core/storage_paths.py
+++ b/core/storage_paths.py
@@ -1,0 +1,124 @@
+"""Utility helpers for resolving NAS storage paths used across the app.
+
+These helpers mirror the logic previously embedded in the web routes so that
+background tasks (such as the local import and thumbnail workers) can resolve
+container-friendly storage paths without duplicating code."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+from webapp.config import Config
+
+# Mapping of config keys to environment variable fallbacks (in priority order).
+_STORAGE_ENV_FALLBACKS: dict[str, Tuple[str, ...]] = {
+    "FPV_NAS_THUMBS_DIR": (
+        "FPV_NAS_THUMBS_CONTAINER_DIR",
+        "FPV_NAS_THUMBS_DIR",
+    ),
+    "FPV_NAS_PLAY_DIR": (
+        "FPV_NAS_PLAY_CONTAINER_DIR",
+        "FPV_NAS_PLAY_DIR",
+    ),
+    "FPV_NAS_ORIGINALS_DIR": (
+        "FPV_NAS_ORIGINALS_CONTAINER_DIR",
+        "FPV_NAS_ORIGINALS_DIR",
+    ),
+    "LOCAL_IMPORT_DIR": (
+        "LOCAL_IMPORT_CONTAINER_DIR",
+        "LOCAL_IMPORT_DIR",
+    ),
+}
+
+# Default fallback paths (ordered) when config/environment do not provide
+# anything usable.  These defaults prefer the container mount points but also
+# keep legacy fallbacks for backwards compatibility.
+_STORAGE_DEFAULTS: dict[str, Tuple[str, ...]] = {
+    "FPV_NAS_THUMBS_DIR": ("/app/data/thumbs", "/tmp/fpv_thumbs"),
+    "FPV_NAS_PLAY_DIR": ("/app/data/playback", "/tmp/fpv_play"),
+    "FPV_NAS_ORIGINALS_DIR": ("/app/data/media", "/tmp/fpv_orig"),
+    "LOCAL_IMPORT_DIR": ("/tmp/local_import",),
+}
+
+
+def _config_value(config_key: str) -> str | None:
+    """Return the configured value for *config_key* if available."""
+
+    try:
+        from flask import current_app  # Imported lazily to avoid hard dependency
+
+        value = current_app.config.get(config_key)  # type: ignore[attr-defined]
+    except Exception:
+        value = getattr(Config, config_key, None)
+
+    if value:
+        return str(value)
+    return None
+
+
+def storage_path_candidates(config_key: str) -> List[str]:
+    """Return an ordered list of candidate paths for *config_key*."""
+
+    seen: set[str] = set()
+    candidates: List[str] = []
+
+    config_value = _config_value(config_key)
+    if config_value and config_value not in seen:
+        candidates.append(config_value)
+        seen.add(config_value)
+
+    for env_name in _STORAGE_ENV_FALLBACKS.get(config_key, (config_key,)):
+        env_value = os.environ.get(env_name)
+        if env_value and env_value not in seen:
+            candidates.append(env_value)
+            seen.add(env_value)
+
+    for default_value in _STORAGE_DEFAULTS.get(config_key, ()):  # type: ignore[arg-type]
+        if default_value and default_value not in seen:
+            candidates.append(default_value)
+            seen.add(default_value)
+
+    return [candidate for candidate in candidates if candidate]
+
+
+def first_existing_storage_path(config_key: str) -> str | None:
+    """Return the first candidate path that exists for *config_key*.
+
+    If none of the candidates currently exist, the first candidate (if any) is
+    returned so that callers can create the directory proactively.
+    """
+
+    candidates = storage_path_candidates(config_key)
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+
+    return candidates[0] if candidates else None
+
+
+def resolve_storage_file(config_key: str, *path_parts: str) -> Tuple[str | None, str | None, bool]:
+    """Resolve a file path relative to *config_key* storage directories.
+
+    Returns a tuple of ``(base_path, resolved_path, exists)`` where ``exists``
+    indicates whether the resolved path is present on disk.
+    """
+
+    candidates = storage_path_candidates(config_key)
+    for base in candidates:
+        candidate_path = os.path.join(base, *path_parts)
+        if os.path.exists(candidate_path):
+            return base, candidate_path, True
+
+    fallback_base = candidates[0] if candidates else None
+    fallback_path = os.path.join(fallback_base, *path_parts) if fallback_base else None
+    return fallback_base, fallback_path, False
+
+
+def ensure_directory(path: str | Path) -> Path:
+    """Ensure that *path* exists as a directory and return it as ``Path``."""
+
+    directory = Path(path)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory

--- a/core/tasks/thumbs_generate.py
+++ b/core/tasks/thumbs_generate.py
@@ -17,6 +17,10 @@ import os
 from PIL import Image, ImageOps
 
 from core.models.photo_models import Media, MediaPlayback
+from core.storage_paths import (
+    ensure_directory,
+    first_existing_storage_path,
+)
 
 # Target thumbnail sizes (long side)
 SIZES = [256, 512, 1024, 2048]
@@ -36,23 +40,25 @@ class _ThumbResult:
 
 def _thumb_base_dir() -> Path:
     """Return thumbnail base directory creating it if necessary."""
-    base = Path(
-        os.environ.get("FPV_NAS_THUMBS_CONTAINER_DIR")
-        or os.environ.get("FPV_NAS_THUMBS_DIR", "/tmp/fpv_thumbs")
-    )
-    base.mkdir(parents=True, exist_ok=True)
-    return base
+
+    base = first_existing_storage_path("FPV_NAS_THUMBS_DIR")
+    if not base:
+        base = "/tmp/fpv_thumbs"
+    return ensure_directory(base)
 
 
 def _orig_dir() -> Path:
-    return Path(os.environ.get("FPV_NAS_ORIGINALS_DIR", "/tmp/fpv_orig"))
+    base = first_existing_storage_path("FPV_NAS_ORIGINALS_DIR")
+    if not base:
+        base = "/tmp/fpv_orig"
+    return Path(base)
 
 
 def _play_dir() -> Path:
-    return Path(
-        os.environ.get("FPV_NAS_PLAY_CONTAINER_DIR")
-        or os.environ.get("FPV_NAS_PLAY_DIR", "/tmp/fpv_play")
-    )
+    base = first_existing_storage_path("FPV_NAS_PLAY_DIR")
+    if not base:
+        base = "/tmp/fpv_play"
+    return Path(base)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add shared storage path resolver utilities so workers pick container-friendly directories
- update local import, thumbnail generation, and API helpers to reuse the shared logic

## Testing
- pytest tests/test_thumbs_generate.py -q
- pytest tests/test_local_import.py::test_local_import_task_with_session -q

------
https://chatgpt.com/codex/tasks/task_e_68d51f8904fc8323b08177828c933048