### PR TITLE
Improve duplicate status badge contrast for local import sessions

### DIFF
--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
       case 'running': return 'warning';
       case 'imported': return 'success';
       case 'failed': return 'danger';
-      case 'dup': return 'light';
+      case 'dup': return 'light text-dark border border-secondary-subtle';
       default: return 'secondary';
     }
   }


### PR DESCRIPTION
## Summary
- update the duplicate status badge styling in the session detail view so it renders with dark text and a subtle border
- ensure duplicate indicators remain legible against the light background used for local import sessions

## Testing
- `pytest` *(fails: tests/test_auth_role_selection.py::test_role_selection_sets_active_role, tests/test_media_api.py::test_thumbnail_falls_back_to_default_path)*

------
https://chatgpt.com/codex/tasks/task_e_68d5257ac76883239f1c4cfafd987ef5