### PR TITLE
Refactor local import pipeline into expansion and queue processing

### DIFF
--- a/core/models/picker_session.py
+++ b/core/models/picker_session.py
@@ -21,6 +21,7 @@ class PickerSession(db.Model):
         db.Enum(
             "pending",
             "ready",
+            "expanding",
             "processing",
             "enqueued",
             "importing",

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -212,6 +212,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sessionStatusLabels = {
     pending: '{{ _("Pending") }}',
     ready: '{{ _("Ready") }}',
+    expanding: '{{ _("Expanding") }}',
     processing: '{{ _("Processing") }}',
     enqueued: '{{ _("Enqueued") }}',
     importing: '{{ _("Importing") }}',
@@ -243,6 +244,7 @@ document.addEventListener('DOMContentLoaded', () => {
     switch (status) {
       case 'pending': return 'secondary';
       case 'ready': return 'primary';
+      case 'expanding': return 'warning';
       case 'processing': return 'warning';
       case 'importing': return 'info';
       case 'imported': return 'success';

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -110,6 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sessionStatusLabels = {
     pending: '{{ _("Pending") }}',
     ready: '{{ _("Ready") }}',
+    expanding: '{{ _("Expanding") }}',
     processing: '{{ _("Processing") }}',
     enqueued: '{{ _("Enqueued") }}',
     importing: '{{ _("Importing") }}',
@@ -136,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
     switch (status) {
       case 'pending': return 'secondary';
       case 'ready': return 'primary';
+      case 'expanding': return 'warning';
       case 'processing': return 'warning';
       case 'importing': return 'info';
       case 'imported': return 'success';

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1106,39 +1106,44 @@ msgstr "セッションの読み込みでエラーが発生しました"
 msgid "Pending"
 msgstr "保留"
 
+#: webapp/photo_view/templates/photo_view/home.html:49
+#: webapp/photo_view/templates/photo_view/session_detail.html:70
+msgid "Expanding"
+msgstr "展開中"
+
 #: webapp/photo_view/templates/photo_view/home.html:85
-#: webapp/photo_view/templates/photo_view/session_detail.html:100
+#: webapp/photo_view/templates/photo_view/session_detail.html:101
 msgid "Ready"
 msgstr "準備完了"
 
-#: webapp/photo_view/templates/photo_view/home.html:49
-#: webapp/photo_view/templates/photo_view/session_detail.html:70
+#: webapp/photo_view/templates/photo_view/home.html:50
+#: webapp/photo_view/templates/photo_view/session_detail.html:71
 msgid "Enqueued"
 msgstr "キュー投入"
 
-#: webapp/photo_view/templates/photo_view/home.html:86
-#: webapp/photo_view/templates/photo_view/session_detail.html:101
+#: webapp/photo_view/templates/photo_view/home.html:87
+#: webapp/photo_view/templates/photo_view/session_detail.html:102
 msgid "Processing"
 msgstr "処理中"
 
-#: webapp/photo_view/templates/photo_view/home.html:50
-#: webapp/photo_view/templates/photo_view/session_detail.html:71
+#: webapp/photo_view/templates/photo_view/home.html:51
+#: webapp/photo_view/templates/photo_view/session_detail.html:72
 msgid "Running"
 msgstr "処理中"
 
-#: webapp/photo_view/templates/photo_view/home.html:88
-#: webapp/photo_view/templates/photo_view/session_detail.html:102
+#: webapp/photo_view/templates/photo_view/home.html:89
+#: webapp/photo_view/templates/photo_view/session_detail.html:103
 msgid "Importing"
 msgstr "インポート中"
 
 #: webapp/photo_view/templates/photo_view/home.html:47
-#: webapp/photo_view/templates/photo_view/home.html:87
-#: webapp/photo_view/templates/photo_view/session_detail.html:72
+#: webapp/photo_view/templates/photo_view/home.html:88
+#: webapp/photo_view/templates/photo_view/session_detail.html:73
 msgid "Imported"
 msgstr "取り込み完了"
 
-#: webapp/photo_view/templates/photo_view/home.html:89
-#: webapp/photo_view/templates/photo_view/session_detail.html:103
+#: webapp/photo_view/templates/photo_view/home.html:90
+#: webapp/photo_view/templates/photo_view/session_detail.html:104
 msgid "Canceled"
 msgstr "キャンセル済み"
 


### PR DESCRIPTION
## Summary
- add an `expanding` status to picker sessions and expose it in the UI labels
- split local import into explicit expansion and queue-processing helpers so sessions stay in processing until the queue drains
- update Japanese translations for the new status label

## Testing
- pytest tests/test_local_import.py tests/test_picker_session_service_local_import.py tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68d5253decf88323b0847c7f10a0a841