### PR TITLE
Add cancellation support for local import sessions

### DIFF
--- a/webapp/photo_view/routes.py
+++ b/webapp/photo_view/routes.py
@@ -60,9 +60,14 @@ def home():
     """Photo view home page."""
     # クエリパラメータでsession_idが指定されている場合は詳細ページを表示
     session_id = request.args.get('session_id')
+    is_admin = hasattr(current_user, "has_role") and current_user.has_role("admin")
     if session_id:
-        return render_template("photo_view/session_detail.html", picker_session_id=session_id)
-    
+        return render_template(
+            "photo_view/session_detail.html",
+            picker_session_id=session_id,
+            is_admin=is_admin,
+        )
+
     # session_idがない場合は、すべてのセッション一覧を表示
     google_accounts = []
     if current_user.is_authenticated and getattr(current_user, "id", None):
@@ -76,7 +81,7 @@ def home():
         "photo_view/home.html",
         google_accounts=google_accounts,
         local_import_info=_build_local_import_info(),
-        is_admin=hasattr(current_user, "has_role") and current_user.has_role("admin"),
+        is_admin=is_admin,
     )
 
 

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -23,6 +23,8 @@
   </div>
 </div>
 
+<div id="photo-view-flags" data-is-admin="{{ '1' if is_admin else '0' }}" hidden></div>
+
 <div class="row g-3 align-items-stretch mb-4">
   <div class="col-xl-7">
     <div class="card shadow-sm h-100">
@@ -162,6 +164,8 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const flagsEl = document.getElementById('photo-view-flags');
+  const isAdmin = flagsEl?.dataset?.isAdmin === '1';
   const sessionsBody = document.getElementById('sessions-body');
   const loadingIndicator = document.getElementById('loading-indicator');
   const noMoreData = document.getElementById('no-more-data');
@@ -183,6 +187,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportSuccessNotice = '{{ _("Local import has started. Track the progress in the session list.") }}';
   const localImportErrorNotice = '{{ _("Failed to start the local import.") }}';
   const startingImportNotice = '{{ _("Starting import...") }}';
+  const cancelConfirmMessage = '{{ _("Stop the local import session? This will skip any remaining files.") }}';
+  const cancelingNotice = '{{ _("Stopping local import...") }}';
+  const cancelFailedNotice = '{{ _("Failed to stop the local import session.") }}';
+  const cancelSuccessNotice = '{{ _("Local import session has been stopped.") }}';
 
   let totalLoaded = 0;
   const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
@@ -297,6 +305,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <td>
         <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary">{{ _("View Details") }}</a>
         ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success ms-1" onclick="startImport('${session.sessionId}')">{{ _("Start Import") }}</button>` : ''}
+        ${(isAdmin && session.isLocalImport && ['processing', 'importing'].includes(session.status)) ? `<button class="btn btn-sm btn-outline-danger ms-1" onclick="cancelLocalImport('${session.sessionId}')">{{ _("Stop Local Import") }}</button>` : ''}
       </td>
     `;
     return tr;
@@ -368,6 +377,34 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       console.error(err);
       showErrorToast('{{ _("Failed to start import.") }}');
+    }
+  };
+
+  window.cancelLocalImport = async function(sessionId) {
+    if (!isAdmin) {
+      return;
+    }
+
+    if (!confirm(cancelConfirmMessage)) {
+      return;
+    }
+
+    try {
+      showInfoToast(cancelingNotice, 3000);
+      const resp = await window.apiClient.post(`/api/sync/local-import/${sessionId}/cancel`);
+
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '');
+        console.error('Cancel local import failed:', resp.status, text);
+        showErrorToast(cancelFailedNotice);
+        return;
+      }
+
+      showSuccessToast(cancelSuccessNotice, 5000);
+      refreshSessions();
+    } catch (err) {
+      console.error(err);
+      showErrorToast(cancelFailedNotice);
     }
   };
 

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -17,9 +17,14 @@
 </div>
 
 <div class="mb-3">
-  <button id="btn-import-start" class="btn btn-primary" disabled aria-disabled="true">
-    {{ _("Start Import") }}
-  </button>
+  <div class="d-flex flex-wrap gap-2 align-items-center">
+    <button id="btn-import-start" class="btn btn-primary" disabled aria-disabled="true">
+      {{ _("Start Import") }}
+    </button>
+    <button id="btn-import-cancel" type="button" class="btn btn-outline-danger d-none" aria-disabled="true">
+      {{ _("Stop Local Import") }}
+    </button>
+  </div>
   <div id="session-info" class="text-muted mt-2">
     {{ _("Loading session info...") }}
   </div>
@@ -50,12 +55,20 @@
   </div>
 </div>
 
-<div id="server-data" 
-     data-picker-session-id="{{ picker_session_id or '' }}" 
+<div id="server-data"
+     data-picker-session-id="{{ picker_session_id or '' }}"
+     data-is-admin="{{ '1' if is_admin|default(False) else '0' }}"
      style="display: none;"></div>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+  const serverDataEl = document.getElementById('server-data');
+  const isAdmin = serverDataEl?.getAttribute('data-is-admin') === '1';
+
+  const cancelConfirmMessage = '{{ _("Stop the local import session? This will skip any remaining files.") }}';
+  const cancelingNotice = '{{ _("Stopping local import...") }}';
+  const cancelFailedNotice = '{{ _("Failed to stop the local import session.") }}';
+  const cancelSuccessNotice = '{{ _("Local import session has been stopped.") }}';
   function escapeHtml(value) {
     if (value === null || value === undefined) {
       return '';
@@ -72,8 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const params = new URLSearchParams(window.location.search);
     const fromQuery = params.get('session_id');
     if (fromQuery) return fromQuery;
-    const serverDataEl = document.getElementById('server-data');
-    const fromServer = serverDataEl.getAttribute('data-picker-session-id');
+    const fromServer = serverDataEl?.getAttribute('data-picker-session-id');
     return fromServer || '';
   }
 
@@ -90,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const importBtn = document.getElementById('btn-import-start');
+  const cancelBtn = document.getElementById('btn-import-cancel');
   const statusEl = document.getElementById('import-status');
   const selectionBody = document.getElementById('selection-body');
   const countsEl = document.getElementById('selection-counts');
@@ -281,18 +294,30 @@ document.addEventListener('DOMContentLoaded', () => {
       countsEl.textContent = '処理完了: 0件';
     } else if (sessionStatus === 'error') {
       countsEl.textContent = 'ステータス: エラー';
+    } else if (sessionStatus === 'canceled') {
+      countsEl.textContent = '{{ _("Status") }}: ' + (sessionStatusLabels.canceled || 'canceled');
     } else {
       countsEl.textContent = '選択されたファイル: 0件';
     }
   }
 
-  function updateImportButtonState(sessionData) {
+  function updateActionButtons(sessionData) {
     if (!sessionData) return;
+    const rawStatus = sessionData.rawStatus || sessionData.status || 'pending';
+
     if (sessionData.isLocalImport) {
       importBtn.style.display = 'none';
       importBtn.disabled = true;
       importBtn.classList.add('disabled');
       importBtn.setAttribute('aria-disabled', 'true');
+
+      if (cancelBtn) {
+        const canCancel = isAdmin && ['processing', 'importing'].includes(rawStatus);
+        cancelBtn.classList.toggle('d-none', !canCancel);
+        cancelBtn.disabled = !canCancel;
+        cancelBtn.classList.toggle('disabled', !canCancel);
+        cancelBtn.setAttribute('aria-disabled', (!canCancel).toString());
+      }
       return;
     }
 
@@ -301,6 +326,13 @@ document.addEventListener('DOMContentLoaded', () => {
     importBtn.disabled = !canImport;
     importBtn.classList.toggle('disabled', !canImport);
     importBtn.setAttribute('aria-disabled', (!canImport).toString());
+
+    if (cancelBtn) {
+      cancelBtn.classList.add('d-none');
+      cancelBtn.disabled = true;
+      cancelBtn.classList.add('disabled');
+      cancelBtn.setAttribute('aria-disabled', 'true');
+    }
   }
 
   function updateSessionInfo(sessionData) {
@@ -385,9 +417,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const data = await resp.json();
       data.counts = data.counts || {};
-      data.status = determineDisplayStatus(data);
+      const rawStatus = data.status;
+      const displayStatus = determineDisplayStatus({ status: rawStatus, counts: data.counts });
+      data.rawStatus = rawStatus;
+      data.status = displayStatus;
       isLocalImport = Boolean(data.isLocalImport);
-      updateImportButtonState(data);
+      updateActionButtons(data);
       updateSessionInfo(data);
       return data;
     } catch (error) {
@@ -406,6 +441,9 @@ document.addEventListener('DOMContentLoaded', () => {
       latestStatus = sessionData?.status || latestStatus;
       currentCounts = sessionData?.counts || currentCounts || {};
       updateCountsDisplay(currentCounts, latestStatus);
+      if (sessionData?.status === 'canceled') {
+        statusEl.textContent = cancelSuccessNotice;
+      }
 
       if (!paginationClient) {
         paginationClient = new PaginationClient({
@@ -480,6 +518,41 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', async () => {
+      if (!pickerSessionId || !isAdmin) {
+        return;
+      }
+
+      if (!window.confirm(cancelConfirmMessage)) {
+        return;
+      }
+
+      await withBusy(cancelBtn, async () => {
+        try {
+          statusEl.textContent = cancelingNotice;
+          const resp = await window.apiClient.post(`/api/sync/local-import/${encodeURIComponent(pickerSessionId)}/cancel`);
+
+          if (!resp.ok) {
+            const text = await resp.text().catch(() => '');
+            console.error('Cancel local import failed:', resp.status, text);
+            statusEl.textContent = cancelFailedNotice;
+            showErrorToast(cancelFailedNotice);
+            return;
+          }
+
+          statusEl.textContent = cancelSuccessNotice;
+          showSuccessToast(cancelSuccessNotice);
+          refreshSelections();
+        } catch (err) {
+          console.error(err);
+          statusEl.textContent = cancelFailedNotice;
+          showErrorToast(cancelFailedNotice);
+        }
+      });
+    });
+  }
 
   setInterval(refreshSelections, 3000);
   refreshSelections();

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1542,3 +1542,44 @@ msgstr "権限を検索"
 msgid "No permissions match your search."
 msgstr "該当する権限がありません。"
 
+#: webapp/photo_view/templates/photo_view/session_detail.html:17
+#: webapp/photo_view/templates/photo_view/home.html:305
+msgid "Stop Local Import"
+msgstr "ローカルインポートを停止"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:23
+#: webapp/photo_view/templates/photo_view/home.html:168
+msgid "Stop the local import session? This will skip any remaining files."
+msgstr "ローカルインポートセッションを停止しますか？残りのファイルはスキップされます。"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:24
+#: webapp/photo_view/templates/photo_view/home.html:169
+msgid "Stopping local import..."
+msgstr "ローカルインポートを停止しています..."
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:25
+#: webapp/photo_view/templates/photo_view/home.html:170
+msgid "Failed to stop the local import session."
+msgstr "ローカルインポートセッションの停止に失敗しました。"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:26
+#: webapp/photo_view/templates/photo_view/home.html:171
+msgid "Local import session has been stopped."
+msgstr "ローカルインポートセッションを停止しました。"
+
+#: webapp/api/routes.py:239
+msgid "You do not have permission to stop a local import."
+msgstr "ローカルインポートを停止する権限がありません。"
+
+#: webapp/api/routes.py:249
+msgid "Session not found."
+msgstr "セッションが見つかりません。"
+
+#: webapp/api/routes.py:258
+msgid "Session has already finished."
+msgstr "セッションはすでに完了しています。"
+
+#: webapp/api/routes.py:275
+msgid "Local import was canceled before processing."
+msgstr "処理前にローカルインポートがキャンセルされました。"
+

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -1289,3 +1289,44 @@ msgstr ""
 msgid "No permissions match your search."
 msgstr ""
 
+#: webapp/photo_view/templates/photo_view/session_detail.html:17
+#: webapp/photo_view/templates/photo_view/home.html:305
+msgid "Stop Local Import"
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:23
+#: webapp/photo_view/templates/photo_view/home.html:168
+msgid "Stop the local import session? This will skip any remaining files."
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:24
+#: webapp/photo_view/templates/photo_view/home.html:169
+msgid "Stopping local import..."
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:25
+#: webapp/photo_view/templates/photo_view/home.html:170
+msgid "Failed to stop the local import session."
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:26
+#: webapp/photo_view/templates/photo_view/home.html:171
+msgid "Local import session has been stopped."
+msgstr ""
+
+#: webapp/api/routes.py:239
+msgid "You do not have permission to stop a local import."
+msgstr ""
+
+#: webapp/api/routes.py:249
+msgid "Session not found."
+msgstr ""
+
+#: webapp/api/routes.py:258
+msgid "Session has already finished."
+msgstr ""
+
+#: webapp/api/routes.py:275
+msgid "Local import was canceled before processing."
+msgstr ""
+


### PR DESCRIPTION
## Summary
- allow admins to cancel in-progress local import sessions and mark pending items as skipped
- update the local import worker to detect cancellation requests and stop processing gracefully
- surface a Stop Local Import action in the session detail and home views with supporting tests and translations

## Testing
- pytest tests/test_local_import_ui.py *(skipped via existing skip rules)*

------
https://chatgpt.com/codex/tasks/task_e_68d5238c69a08323a901f073e68a386b