### PR TITLE
Add local import cancellation support

### DIFF
--- a/webapp/api/picker_session_service.py
+++ b/webapp/api/picker_session_service.py
@@ -311,6 +311,10 @@ class PickerSessionService:
             selected_count_response = ps.selected_count or 0
         is_local_import = ps.account_id is None
 
+        stats = ps.stats() if hasattr(ps, "stats") else {}
+        if not isinstance(stats, dict):
+            stats = {}
+
         return {
             "status": ps.status,
             "selectedCount": selected_count_response,
@@ -328,6 +332,7 @@ class PickerSessionService:
             "isLocalImport": is_local_import,
             "lastProgressAt": ps.last_progress_at.isoformat().replace("+00:00", "Z") if ps.last_progress_at else None,
             "createdAt": ps.created_at.isoformat().replace("+00:00", "Z") if ps.created_at else None,
+            "stats": stats,
         }
 
     @staticmethod

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -170,6 +170,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const createSessionBtn = document.getElementById('create-session-btn');
   const accountSelect = document.getElementById('session-account');
   const localImportBtn = document.getElementById('local-import-btn');
+  const isAdmin = {{ 'true' if is_admin else 'false' }};
 
   const selectAccountMessage = '{{ _("Please choose a Google account first.") }}';
   const localImportPromptHeader = '{{ _("Start a local import from the following directories?") }}';
@@ -183,6 +184,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportSuccessNotice = '{{ _("Local import has started. Track the progress in the session list.") }}';
   const localImportErrorNotice = '{{ _("Failed to start the local import.") }}';
   const startingImportNotice = '{{ _("Starting import...") }}';
+  const localImportStopStartingNotice = '{{ _("Canceling local import...") }}';
+  const localImportStopSuccessNotice = '{{ _("Local import was canceled.") }}';
+  const localImportStopErrorNotice = '{{ _("Failed to stop local import.") }}';
+  const stopLocalImportLabel = '{{ _("Stop Local Import") }}';
+  const localImportRunningMessage = '{{ _("Local import is running. You can stop it if needed.") }}';
 
   let totalLoaded = 0;
   const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
@@ -289,6 +295,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const tr = document.createElement('tr');
     const displayStatus = determineDisplayStatus(session);
     const statusLabel = sessionStatusLabels[displayStatus] || displayStatus;
+    const cancellableStatuses = ['expanding', 'processing', 'importing', 'enqueued'];
+    const showStopButton = Boolean(isAdmin) && session.isLocalImport && cancellableStatuses.includes(session.status);
+    const stopButtonHtml = showStopButton
+      ? `<button class="btn btn-sm btn-outline-danger ms-1" onclick="stopLocalImport('${session.sessionId}')"><i class="bi bi-stop-circle"></i> ${stopLocalImportLabel}</button>`
+      : '';
+    let localStatusMessage = '';
+    if (session.isLocalImport) {
+      if (session.status === 'canceled') {
+        localStatusMessage = `<div class="small text-danger mt-1"><i class="bi bi-stop-circle"></i> ${localImportStopSuccessNotice}</div>`;
+      } else if (showStopButton) {
+        localStatusMessage = `<div class="small text-muted mt-1"><i class="bi bi-info-circle"></i> ${localImportRunningMessage}</div>`;
+      } else {
+        localStatusMessage = `<div class="small text-muted mt-1"><i class="bi bi-info-circle"></i> {{ _("Local Import Session. Import runs automatically.") }}</div>`;
+      }
+    }
     tr.innerHTML = `
       <td>${session.sessionId || 'N/A'}</td>
       <td><span class="badge bg-${getStatusBadgeClass(displayStatus)}">${statusLabel}</span></td>
@@ -299,6 +320,8 @@ document.addEventListener('DOMContentLoaded', () => {
       <td>
         <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary">{{ _("View Details") }}</a>
         ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success ms-1" onclick="startImport('${session.sessionId}')">{{ _("Start Import") }}</button>` : ''}
+        ${stopButtonHtml}
+        ${localStatusMessage}
       </td>
     `;
     return tr;
@@ -370,6 +393,34 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       console.error(err);
       showErrorToast('{{ _("Failed to start import.") }}');
+    }
+  };
+
+  window.stopLocalImport = async function(sessionId) {
+    if (!isAdmin) {
+      showErrorToast(localImportStopErrorNotice);
+      return;
+    }
+
+    try {
+      showInfoToast(localImportStopStartingNotice, 3000);
+
+      const resp = await window.apiClient.post(`/api/sync/local-import/${encodeURIComponent(sessionId)}/stop`);
+
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '');
+        console.error('Local import stop failed:', resp.status, text);
+        showErrorToast(localImportStopErrorNotice);
+        return;
+      }
+
+      const payload = await resp.json().catch(() => ({}));
+      const message = (payload && payload.message) ? payload.message : localImportStopSuccessNotice;
+      showInfoToast(message, 4000);
+      refreshSessions();
+    } catch (err) {
+      console.error(err);
+      showErrorToast(localImportStopErrorNotice);
     }
   };
 

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -17,9 +17,15 @@
 </div>
 
 <div class="mb-3">
-  <button id="btn-import-start" class="btn btn-primary" disabled aria-disabled="true">
-    {{ _("Start Import") }}
-  </button>
+  <div class="d-flex flex-wrap gap-2">
+    <button id="btn-import-start" class="btn btn-primary" disabled aria-disabled="true">
+      {{ _("Start Import") }}
+    </button>
+    <button id="btn-local-import-stop" class="btn btn-outline-danger d-none" type="button">
+      <i class="bi bi-stop-circle"></i> {{ _("Stop Local Import") }}
+    </button>
+  </div>
+  <div id="local-import-status" class="mt-2 small text-muted d-none"></div>
   <div id="session-info" class="text-muted mt-2">
     {{ _("Loading session info...") }}
   </div>
@@ -90,12 +96,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const importBtn = document.getElementById('btn-import-start');
+  const stopLocalImportBtn = document.getElementById('btn-local-import-stop');
   const statusEl = document.getElementById('import-status');
   const selectionBody = document.getElementById('selection-body');
   const countsEl = document.getElementById('selection-counts');
   const sessionInfoEl = document.getElementById('session-info');
   const sessionTitleEl = document.getElementById('session-title');
   const sessionSubtitleEl = document.getElementById('session-subtitle');
+  const localImportStatusEl = document.getElementById('local-import-status');
 
   const selectionStatusLabels = {
     pending: '{{ _("Pending") }}',
@@ -120,6 +128,11 @@ document.addEventListener('DOMContentLoaded', () => {
     error: '{{ _("Error") }}',
     failed: '{{ _("Failed") }}'
   };
+
+  const localImportRunningMessage = '{{ _("Local import is running. You can stop it if needed.") }}';
+  const localImportCancelingMessage = '{{ _("Canceling local import...") }}';
+  const localImportCanceledMessage = '{{ _("Local import was canceled.") }}';
+  const localImportStopFailedMessage = '{{ _("Failed to stop local import.") }}';
 
   function getStatusBadgeClass(status) {
     switch (status) {
@@ -305,6 +318,55 @@ document.addEventListener('DOMContentLoaded', () => {
     importBtn.setAttribute('aria-disabled', (!canImport).toString());
   }
 
+  function updateLocalImportControls(sessionData) {
+    if (!stopLocalImportBtn || !localImportStatusEl) {
+      return;
+    }
+
+    stopLocalImportBtn.classList.add('d-none');
+    stopLocalImportBtn.disabled = true;
+    stopLocalImportBtn.setAttribute('aria-disabled', 'true');
+    localImportStatusEl.classList.add('d-none');
+    localImportStatusEl.classList.remove('text-warning', 'text-danger', 'text-success');
+    localImportStatusEl.classList.add('text-muted');
+    localImportStatusEl.textContent = '';
+
+    if (!sessionData || !sessionData.isLocalImport) {
+      return;
+    }
+
+    const cancellableStatuses = ['expanding', 'processing', 'importing', 'enqueued'];
+    const stats = sessionData.stats || {};
+    const cancelRequested = Boolean(stats.cancel_requested);
+    const displayStatus = sessionData.status;
+
+    localImportStatusEl.classList.remove('d-none');
+
+    if (displayStatus === 'canceled') {
+      localImportStatusEl.textContent = localImportCanceledMessage;
+      localImportStatusEl.classList.remove('text-muted');
+      localImportStatusEl.classList.add('text-danger');
+      return;
+    }
+
+    if (cancelRequested) {
+      localImportStatusEl.textContent = localImportCancelingMessage;
+      localImportStatusEl.classList.remove('text-muted');
+      localImportStatusEl.classList.add('text-warning');
+      return;
+    }
+
+    if (cancellableStatuses.includes(displayStatus)) {
+      localImportStatusEl.textContent = localImportRunningMessage;
+      stopLocalImportBtn.classList.remove('d-none');
+      stopLocalImportBtn.disabled = false;
+      stopLocalImportBtn.setAttribute('aria-disabled', 'false');
+      return;
+    }
+
+    localImportStatusEl.textContent = '{{ _("Local import session runs automatically.") }}';
+  }
+
   function updateSessionInfo(sessionData) {
     if (!sessionData) {
       return;
@@ -328,6 +390,7 @@ document.addEventListener('DOMContentLoaded', () => {
       sessionSubtitleEl.classList.toggle('d-none', subtitleParts.length === 0);
     }
 
+    const stats = sessionData.stats || {};
     const accountLabel = sessionData.isLocalImport
       ? '{{ _("Local Import") }}'
       : (sessionData.accountEmail || '-');
@@ -348,12 +411,19 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
 
     if (sessionData.isLocalImport) {
-      infoParts.push(`<div class="mt-2 text-muted"><i class="bi bi-info-circle"></i> {{ _("Local Import Session. Import runs automatically.") }}</div>`);
+      if (sessionData.status === 'canceled') {
+        infoParts.push(`<div class="mt-2 text-danger"><i class="bi bi-stop-circle"></i> {{ _("Local import was canceled.") }}</div>`);
+      } else if (stats.cancel_requested) {
+        infoParts.push(`<div class="mt-2 text-warning"><i class="bi bi-hourglass-split"></i> {{ _("Canceling local import...") }}</div>`);
+      } else {
+        infoParts.push(`<div class="mt-2 text-muted"><i class="bi bi-info-circle"></i> {{ _("Local Import Session. Import runs automatically.") }}</div>`);
+      }
     } else if (sessionData.status !== 'ready') {
       infoParts.push(`<div class="mt-2 text-warning"><i class="bi bi-exclamation-triangle"></i> {{ _("Import can only be started when the session status is ready.") }}</div>`);
     }
 
     sessionInfoEl.innerHTML = infoParts.join('');
+    updateLocalImportControls(sessionData);
   }
 
   async function withBusy(btn, fn) {
@@ -396,6 +466,37 @@ document.addEventListener('DOMContentLoaded', () => {
       console.warn('Failed to fetch session status:', error);
       return null;
     }
+  }
+
+  async function stopLocalImportSession() {
+    if (!pickerSessionId || !stopLocalImportBtn) {
+      return;
+    }
+
+    await withBusy(stopLocalImportBtn, async () => {
+      try {
+        const resp = await window.apiClient.post(`/api/sync/local-import/${encodeURIComponent(pickerSessionId)}/stop`);
+
+        if (!resp.ok) {
+          const text = await resp.text().catch(() => '');
+          console.error('Failed to stop local import:', resp.status, text);
+          statusEl.textContent = localImportStopFailedMessage;
+          showErrorToast(localImportStopFailedMessage);
+          return;
+        }
+
+        const payload = await resp.json().catch(() => ({}));
+        const message = (payload && payload.message) ? payload.message : localImportCanceledMessage;
+        statusEl.textContent = message;
+        showInfoToast(message, 4000);
+        await fetchSessionStatus();
+        await refreshSelections();
+      } catch (error) {
+        console.error('Stop local import failed:', error);
+        statusEl.textContent = localImportStopFailedMessage;
+        showErrorToast(localImportStopFailedMessage);
+      }
+    });
   }
 
   async function refreshSelections() {
@@ -446,6 +547,12 @@ document.addEventListener('DOMContentLoaded', () => {
     } finally {
       isRefreshing = false;
     }
+  }
+
+  if (stopLocalImportBtn) {
+    stopLocalImportBtn.addEventListener('click', () => {
+      stopLocalImportSession();
+    });
   }
 
   importBtn.addEventListener('click', async () => {

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1176,6 +1176,35 @@ msgstr "スキップ"
 msgid "Local Import"
 msgstr "ローカルインポート"
 
+#: webapp/photo_view/templates/photo_view/home.html:131
+#: webapp/photo_view/templates/photo_view/session_detail.html:24
+msgid "Stop Local Import"
+msgstr "ローカルインポートを停止"
+
+#: webapp/photo_view/templates/photo_view/home.html:73
+#: webapp/photo_view/templates/photo_view/session_detail.html:90
+msgid "Local import is running. You can stop it if needed."
+msgstr "ローカルインポートを実行中です。必要に応じてここから停止できます。"
+
+#: webapp/photo_view/templates/photo_view/home.html:70
+#: webapp/photo_view/templates/photo_view/session_detail.html:91
+msgid "Canceling local import..."
+msgstr "ローカルインポートを停止しています..."
+
+#: webapp/photo_view/templates/photo_view/home.html:71
+#: webapp/photo_view/templates/photo_view/session_detail.html:92
+msgid "Local import was canceled."
+msgstr "ローカルインポートを停止しました。"
+
+#: webapp/photo_view/templates/photo_view/home.html:72
+#: webapp/photo_view/templates/photo_view/session_detail.html:93
+msgid "Failed to stop local import."
+msgstr "ローカルインポートの停止に失敗しました。"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:94
+msgid "Local import session runs automatically."
+msgstr "ローカルインポートセッションは自動で実行されます。"
+
 #: webapp/photo_view/templates/photo_view/session_detail.html:117
 msgid "Local Import Session. Import runs automatically."
 msgstr "ローカルインポートセッションです。インポートは自動的に実行されました。"
@@ -1546,4 +1575,24 @@ msgstr "権限を検索"
 
 msgid "No permissions match your search."
 msgstr "該当する権限がありません。"
+
+#: webapp/api/routes.py:239
+msgid "You do not have permission to stop a local import."
+msgstr "ローカルインポートを停止する権限がありません。"
+
+#: webapp/api/routes.py:247
+msgid "Local import session not found."
+msgstr "ローカルインポートセッションが見つかりません。"
+
+#: webapp/api/routes.py:255
+msgid "Local import session is already canceled."
+msgstr "ローカルインポートセッションはすでに停止済みです。"
+
+#: webapp/api/routes.py:262
+msgid "Local import session is not currently running."
+msgstr "ローカルインポートセッションは実行中ではありません。"
+
+#: webapp/api/routes.py:301
+msgid "Local import session was canceled."
+msgstr "ローカルインポートセッションを停止しました。"
 


### PR DESCRIPTION
## Summary
- detect and propagate cancellation in the local import task, updating picker session statistics to the canceled state
- add an admin-only API for stopping local import sessions and skipping remaining selections while revoking the celery task
- expose "Stop Local Import" controls and status messages in the photo view UI and extend tests/translations for cancellation flows

## Testing
- pytest tests/test_local_import_ui.py tests/test_picker_session_service_local_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d528a3789c8323a86efeee8889ee00