### PR TITLE
Add HEIC support to local import pipeline

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -16,6 +16,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from core.utils import register_heif_support
+
+register_heif_support()
+
 from PIL import Image
 from PIL.ExifTags import TAGS
 from flask import current_app

--- a/core/tasks/thumbs_generate.py
+++ b/core/tasks/thumbs_generate.py
@@ -14,6 +14,10 @@ from pathlib import Path
 from typing import Dict, List
 import os
 
+from core.utils import register_heif_support
+
+register_heif_support()
+
 from PIL import Image, ImageOps
 
 from core.models.photo_models import Media, MediaPlayback

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,10 +2,36 @@
 
 import json
 import logging
+import importlib
+import importlib.util
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Final
 
 from flask import current_app
+
+_HEIF_PLUGIN_NAME: Final[str] = "pillow_heif"
+_HEIF_REGISTERED: bool = False
+
+
+def register_heif_support() -> bool:
+    """Register HEIF/HEIC format support if the Pillow plugin is available."""
+
+    global _HEIF_REGISTERED
+    if _HEIF_REGISTERED:
+        return True
+
+    spec = importlib.util.find_spec(_HEIF_PLUGIN_NAME)
+    if spec is None:
+        return False
+
+    module = importlib.import_module(_HEIF_PLUGIN_NAME)
+    register = getattr(module, "register_heif_opener", None)
+    if callable(register):
+        register()
+        _HEIF_REGISTERED = True
+        return True
+
+    return False
 
 
 def greet(name: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask-babel
 Flask-Login
 Flask-SQLAlchemy
 pillow
+pillow-heif
 PyMySQL
 click
 cryptography

--- a/tests/test_heic_support.py
+++ b/tests/test_heic_support.py
@@ -1,0 +1,128 @@
+"""Tests verifying HEIC/HEIF support in local import pipeline."""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from pillow_heif import register_heif_opener
+
+from core.tasks.local_import import (
+    get_image_dimensions,
+    import_single_file,
+    scan_import_directory,
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_heif_support() -> None:
+    """Register the HEIF plugin for Pillow once per test session."""
+
+    register_heif_opener()
+
+
+@pytest.fixture
+def local_import_app(tmp_path: Path):
+    """Create a minimal Flask app configured for local import tests."""
+
+    db_path = tmp_path / "test.db"
+    tmp_dir = tmp_path / "tmp"
+    orig_dir = tmp_path / "orig"
+    import_dir = tmp_path / "import"
+    tmp_dir.mkdir()
+    orig_dir.mkdir()
+    import_dir.mkdir()
+
+    env = {
+        "SECRET_KEY": "test",
+        "DATABASE_URI": f"sqlite:///{db_path}",
+        "FPV_TMP_DIR": str(tmp_dir),
+        "FPV_NAS_ORIGINALS_DIR": str(orig_dir),
+        "LOCAL_IMPORT_DIR": str(import_dir),
+    }
+    prev_env = {key: os.environ.get(key) for key in env}
+    os.environ.update(env)
+
+    import webapp.config as config_module
+    importlib.reload(config_module)
+    import webapp as webapp_module
+    importlib.reload(webapp_module)
+
+    from webapp.config import Config
+    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp import create_app
+
+    app = create_app()
+    app.config.update(TESTING=True)
+
+    from webapp.extensions import db
+
+    with app.app_context():
+        db.create_all()
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+    sys.modules.pop("webapp.config", None)
+    sys.modules.pop("webapp", None)
+    for key, value in prev_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def test_scan_directory_handles_heic(tmp_path: Path) -> None:
+    """HEICファイルがスキャン対象として検出されることを確認。"""
+
+    heic_path = tmp_path / "sample.heic"
+    Image.new("RGB", (12, 8), "blue").save(heic_path)
+
+    scanned = scan_import_directory(str(tmp_path))
+
+    assert str(heic_path) in scanned
+
+
+def test_get_image_dimensions_for_heic(tmp_path: Path) -> None:
+    """HEIC画像から寸法情報を取得できることを確認。"""
+
+    heic_path = tmp_path / "dimensions.heic"
+    Image.new("RGB", (64, 48), "green").save(heic_path)
+
+    width, height, orientation = get_image_dimensions(str(heic_path))
+
+    assert (width, height) == (64, 48)
+    assert orientation in (None, 1)
+
+
+def test_import_single_heic_file(local_import_app) -> None:
+    """HEICファイルの取り込みが成功し、メタ情報が保存されることを確認。"""
+
+    from core.models.photo_models import Media
+
+    import_dir = Path(local_import_app.config["LOCAL_IMPORT_DIR"])
+    originals_dir = Path(local_import_app.config["FPV_NAS_ORIGINALS_DIR"])
+
+    heic_path = import_dir / "import_target.heic"
+    Image.new("RGB", (32, 24), "red").save(heic_path)
+
+    with local_import_app.app_context():
+        result = import_single_file(str(heic_path), str(import_dir), str(originals_dir))
+
+        assert result["success"] is True
+        assert result["media_id"] is not None
+
+        media = Media.query.get(result["media_id"])
+
+        assert media is not None
+        assert media.mime_type == "image/heic"
+        assert media.width == 32
+        assert media.height == 24
+
+    stored_files = list(originals_dir.rglob("*.heic"))
+    assert stored_files


### PR DESCRIPTION
## Summary
- register the Pillow HEIF plugin during local import and thumbnail generation so HEIC images can be opened
- expose a reusable `register_heif_support` helper and add the `pillow-heif` dependency
- add focused tests that cover scanning, metadata extraction, and importing HEIC files

## Testing
- pytest tests/test_heic_support.py

------
https://chatgpt.com/codex/tasks/task_e_68d52d6fa3488323a7a410ca189da8c9