### PR TITLE
Support MOV playback downloads with MP4 extension

### DIFF
--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1989,12 +1989,14 @@ def _resolve_download_filename(payload: dict, rel: str, abs_path: str) -> str | 
         else:
             filename = os.path.basename(abs_path) if abs_path else None
 
+    path_ext = os.path.splitext(abs_path)[1] if abs_path else ""
     if filename:
         base, ext = os.path.splitext(filename)
-        if not ext:
-            path_ext = os.path.splitext(abs_path)[1] if abs_path else ""
-            if path_ext:
+        if payload.get("typ") == "playback" and path_ext:
+            if ext.lower() != path_ext.lower():
                 filename = base + path_ext
+        elif not ext and path_ext:
+            filename = base + path_ext
     return filename
 
 


### PR DESCRIPTION
## Summary
- update playback download filename resolution to replace mismatched extensions with the generated file type
- add an API regression test covering MOV originals to ensure playback downloads use the MP4 extension

## Testing
- pytest tests/test_media_api.py::test_playback_filename_for_mov

------
https://chatgpt.com/codex/tasks/task_e_68d52fef6fd88323b35e5039ef4b4ee8