### PR TITLE
Redirect to session details after starting local import

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -523,10 +523,18 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
 
-        await resp.json();
+        const payload = await resp.json().catch(() => ({}));
         showSuccessToast(localImportSuccessNotice, 8000);
 
-        // Automatically refresh the session list
+        const sessionId = payload && payload.session_id;
+        if (sessionId) {
+          setTimeout(() => {
+            window.location.href = `/photo-view?session_id=${encodeURIComponent(sessionId)}`;
+          }, 1500);
+          return;
+        }
+
+        // Automatically refresh the session list when no session ID is returned
         setTimeout(() => {
           refreshSessions();
         }, 2000);


### PR DESCRIPTION
## Summary
- redirect the UI to the newly created local import session details after starting an import
- fall back to refreshing the session list when the API response does not include a session id

## Testing
- pytest tests/test_local_import_ui.py -k home -q

------
https://chatgpt.com/codex/tasks/task_e_68d536b6c2888323913328f6d2ddfa9e