### PR TITLE
Use x-circle icon for canceled local import notice

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -312,7 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let localStatusMessage = '';
     if (session.isLocalImport) {
       if (session.status === 'canceled') {
-        localStatusMessage = `<div class="d-inline-flex align-items-center gap-1 small text-danger mt-1"><i class="bi bi-stop-circle"></i> ${localImportStopSuccessNotice}</div>`;
+        localStatusMessage = `<div class="d-inline-flex align-items-center gap-1 small text-muted mt-1"><i class="bi bi-x-circle"></i> ${localImportStopSuccessNotice}</div>`;
       } else if (showStopButton) {
         localStatusMessage = `<div class="d-inline-flex align-items-center gap-1 small text-muted mt-1"><i class="bi bi-info-circle"></i> ${localImportRunningMessage}</div>`;
       } else {

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -540,7 +540,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (sessionData.isLocalImport) {
       if (sessionData.status === 'canceled') {
-        infoParts.push(`<div class="mt-2 text-danger"><i class="bi bi-stop-circle"></i> {{ _("Local import was canceled.") }}</div>`);
+        infoParts.push(`<div class="mt-2 text-muted"><i class="bi bi-x-circle"></i> {{ _("Local import was canceled.") }}</div>`);
       } else if (stats.cancel_requested) {
         infoParts.push(`<div class="mt-2 text-warning"><i class="bi bi-hourglass-split"></i> {{ _("Canceling local import...") }}</div>`);
       } else {


### PR DESCRIPTION
## Summary
- update the canceled local import messaging to use the x-circle icon
- keep the canceled notice styled as muted text for clarity

## Testing
- pytest tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68d53cb4d3fc8323bfcb042761d2df78