### PR TITLE
Add confirmation before canceling local import

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -198,6 +198,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportStopErrorNotice = '{{ _("Failed to stop local import.") }}';
   const stopLocalImportLabel = '{{ _("Stop Local Import") }}';
   const localImportRunningMessage = '{{ _("Local import is running. You can stop it if needed.") }}';
+  const localImportStopConfirmQuestion = '{{ _("Are you sure you want to cancel the local import?") }}';
 
   let totalLoaded = 0;
   const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
@@ -408,6 +409,10 @@ document.addEventListener('DOMContentLoaded', () => {
   window.stopLocalImport = async function(sessionId) {
     if (!isAdmin) {
       showErrorToast(localImportStopErrorNotice);
+      return;
+    }
+
+    if (!window.confirm(localImportStopConfirmQuestion)) {
       return;
     }
 

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -167,6 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportCancelingMessage = '{{ _("Canceling local import...") }}';
   const localImportCanceledMessage = '{{ _("Local import was canceled.") }}';
   const localImportStopFailedMessage = '{{ _("Failed to stop local import.") }}';
+  const localImportStopConfirmQuestion = '{{ _("Are you sure you want to cancel the local import?") }}';
 
   function getStatusBadgeClass(status) {
     switch (status) {
@@ -621,6 +622,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function stopLocalImportSession() {
     if (!pickerSessionId || !stopLocalImportBtn) {
+      return;
+    }
+
+    if (!window.confirm(localImportStopConfirmQuestion)) {
       return;
     }
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1201,6 +1201,11 @@ msgstr "ローカルインポートを停止しました。"
 msgid "Failed to stop local import."
 msgstr "ローカルインポートの停止に失敗しました。"
 
+#: webapp/photo_view/templates/photo_view/home.html:201
+#: webapp/photo_view/templates/photo_view/session_detail.html:170
+msgid "Are you sure you want to cancel the local import?"
+msgstr "ローカルインポートをキャンセルしますか？"
+
 #: webapp/photo_view/templates/photo_view/session_detail.html:94
 msgid "Local import session runs automatically."
 msgstr "ローカルインポートセッションは自動で実行されます。"

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -1103,6 +1103,11 @@ msgstr ""
 msgid "Import started."
 msgstr ""
 
+#: webapp/photo_view/templates/photo_view/home.html:201
+#: webapp/photo_view/templates/photo_view/session_detail.html:170
+msgid "Are you sure you want to cancel the local import?"
+msgstr ""
+
 #: webapp/photo_view/templates/photo_view/media_detail.html:147
 msgid "Back"
 msgstr ""


### PR DESCRIPTION
## Summary
- add a confirmation prompt before cancelling a local import from the sessions list and detail views
- add translation strings for the confirmation prompt

## Testing
- pytest *(fails: tests/test_auth_role_selection.py::test_role_selection_sets_active_role expects English flash text; tests/test_media_api.py::test_thumbnail_falls_back_to_default_path relies on internal _STORAGE_DEFAULTS attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68d540c1b2d88323ad134064bbe77467