### PR TITLE
Embed log status metadata in stored log messages

### DIFF
--- a/core/db_log_handler.py
+++ b/core/db_log_handler.py
@@ -146,6 +146,10 @@ class DBLogHandler(logging.Handler):
         except Exception:
             payload = {"message": raw_message}
 
+        status_value = getattr(record, "status", None)
+        if status_value is not None:
+            payload.setdefault("status", status_value)
+
         # Attach metadata for better traceability.
         payload.setdefault("_meta", {})
         payload["_meta"].update(

--- a/migrations/versions/8c2b4a987654_add_status_column_to_log.py
+++ b/migrations/versions/8c2b4a987654_add_status_column_to_log.py
@@ -1,0 +1,23 @@
+"""Add status column to log table
+
+Revision ID: 8c2b4a987654
+Revises: 31b1901dba43
+Create Date: 2024-05-09 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8c2b4a987654'
+down_revision = '31b1901dba43'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('log', sa.Column('status', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    op.drop_column('log', 'status')

--- a/migrations/versions/9f2c3d1a6b7e_remove_status_column_from_log.py
+++ b/migrations/versions/9f2c3d1a6b7e_remove_status_column_from_log.py
@@ -1,0 +1,25 @@
+"""Remove status column from log table
+
+Revision ID: 9f2c3d1a6b7e
+Revises: 8c2b4a987654
+Create Date: 2024-05-10 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9f2c3d1a6b7e'
+down_revision = '8c2b4a987654'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('log', schema=None) as batch_op:
+        batch_op.drop_column('status')
+
+
+def downgrade():
+    with op.batch_alter_table('log', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('status', sa.String(length=50), nullable=True))

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -308,12 +308,29 @@ def api_picker_session_logs(session_id: str):
         if not session_matches:
             continue
 
+        excluded_keys = {
+            "session_id",
+            "session_db_id",
+            "active_session_id",
+            "target_session_id",
+            "status",
+        }
+
         details = {
             key: value
             for key, value in extras.items()
-            if key
-            not in {"session_id", "session_db_id", "active_session_id", "target_session_id"}
+            if key not in excluded_keys
         }
+
+        status_value = payload.get("status")
+        if status_value is None:
+            status_value = extras.get("status")
+
+        if status_value is not None and not isinstance(status_value, str):
+            try:
+                status_value = str(status_value)
+            except Exception:
+                status_value = None
 
         message = payload.get("message")
         if not isinstance(message, str):
@@ -330,6 +347,7 @@ def api_picker_session_logs(session_id: str):
                 else None,
                 "level": row.level,
                 "event": row.event,
+                "status": status_value,
                 "message": message,
                 "details": details,
             }

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -67,13 +67,14 @@
         <tr>
           <th style="width: 18%">{{ _("Time") }}</th>
           <th style="width: 18%">{{ _("Event") }}</th>
+          <th style="width: 14%">{{ _("Status") }}</th>
           <th style="width: 12%">{{ _("Level") }}</th>
           <th>{{ _("Message") }}</th>
         </tr>
       </thead>
       <tbody id="local-import-log-body">
         <tr id="local-import-log-empty">
-          <td colspan="4" class="text-center text-muted py-3">{{ _("No logs yet.") }}</td>
+          <td colspan="5" class="text-center text-muted py-3">{{ _("No logs yet.") }}</td>
         </tr>
       </tbody>
     </table>
@@ -213,6 +214,40 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function getStatusBadgeClass(status) {
+    switch ((status || '').toLowerCase()) {
+      case 'success':
+      case 'completed':
+      case 'extracted':
+      case 'imported':
+        return 'success';
+      case 'processing':
+      case 'running':
+      case 'scanning':
+      case 'queued':
+        return 'primary';
+      case 'copied':
+      case 'cleaned':
+      case 'duplicate':
+      case 'skipped':
+      case 'detected':
+        return 'secondary';
+      case 'warning':
+      case 'retrying':
+      case 'empty':
+        return 'warning';
+      case 'failed':
+      case 'error':
+      case 'missing':
+      case 'unsupported':
+        return 'danger';
+      case 'canceled':
+        return 'dark';
+      default:
+        return 'secondary';
+    }
+  }
+
   function formatLogDetails(details) {
     if (!details || typeof details !== 'object') {
       return '';
@@ -255,7 +290,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!logs || logs.length === 0) {
       const emptyRow = document.createElement('tr');
       emptyRow.id = 'local-import-log-empty';
-      emptyRow.innerHTML = `<td colspan="4" class="text-center text-muted py-3">${escapeHtml(noLogsMessage)}</td>`;
+      emptyRow.innerHTML = `<td colspan="5" class="text-center text-muted py-3">${escapeHtml(noLogsMessage)}</td>`;
       logBody.appendChild(emptyRow);
       return;
     }
@@ -264,6 +299,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const row = document.createElement('tr');
       const level = (log.level || '').toUpperCase();
       const badgeClass = getLevelBadgeClass(level);
+      const statusText = (log.status || '').toString();
+      const statusBadgeClass = getStatusBadgeClass(statusText);
       const detailsText = formatLogDetails(log.details);
 
       const messageHtml = [
@@ -274,6 +311,7 @@ document.addEventListener('DOMContentLoaded', () => {
       row.innerHTML = `
         <td>${escapeHtml(formatDateTime(log.createdAt))}</td>
         <td>${log.event ? `<code>${escapeHtml(log.event)}</code>` : '-'}</td>
+        <td>${statusText ? `<span class="badge bg-${statusBadgeClass}">${escapeHtml(statusText)}</span>` : '-'}</td>
         <td>${level ? `<span class="badge bg-${badgeClass}">${escapeHtml(level)}</span>` : '-'}</td>
         <td>${messageHtml}</td>
       `;


### PR DESCRIPTION
## Summary
- keep Celery task status metadata inside the stored log message payload instead of a dedicated database column
- drop the temporary `status` column from the `log` table and update the picker session log API to read the status from the payload
- add an Alembic migration that removes the column for existing deployments

## Testing
- pytest tests/test_local_import_ui.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d5395688a88323b795446d910ca34f