### PR TITLE
Fix log created_at default to current time

### DIFF
--- a/core/models/log.py
+++ b/core/models/log.py
@@ -12,7 +12,11 @@ class Log(db.Model):
     trace = db.Column(db.Text)
     path = db.Column(db.String(255))
     request_id = db.Column(db.String(36))
-    created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
+    created_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
 
 
 __all__ = ["Log"]


### PR DESCRIPTION
## Summary
- ensure log model uses a callable default for `created_at`
- make new log entries record the actual creation timestamp instead of module import time

## Testing
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d55f70e4948323b5368cde6ec60734