### PR TITLE
Improve HEIC handling when Pillow plugin is unavailable

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -16,11 +16,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from core.utils import register_heif_support
+from core.utils import open_image_compat, register_heif_support
 
 register_heif_support()
 
-from PIL import Image
 from PIL.ExifTags import TAGS
 from flask import current_app
 
@@ -348,9 +347,9 @@ def calculate_file_hash(file_path: str) -> str:
 def get_image_dimensions(file_path: str) -> Tuple[Optional[int], Optional[int], Optional[int]]:
     """画像の幅、高さ、向きを取得"""
     try:
-        with Image.open(file_path) as img:
+        with open_image_compat(file_path) as img:
             width, height = img.size
-            
+
             # EXIF orientationを取得
             orientation = None
             if hasattr(img, '_getexif') and img._getexif() is not None:
@@ -359,7 +358,7 @@ def get_image_dimensions(file_path: str) -> Tuple[Optional[int], Optional[int], 
                     if TAGS.get(tag) == 'Orientation':
                         orientation = value
                         break
-            
+
             return width, height, orientation
     except Exception:
         return None, None, None
@@ -369,10 +368,10 @@ def extract_exif_data(file_path: str) -> Dict:
     """EXIFデータを抽出"""
     exif_data = {}
     try:
-        with Image.open(file_path) as img:
+        with open_image_compat(file_path) as img:
             if hasattr(img, '_getexif') and img._getexif() is not None:
                 exif_dict = img._getexif()
-                
+
                 for tag_id, value in exif_dict.items():
                     tag = TAGS.get(tag_id, tag_id)
                     exif_data[tag] = value

--- a/core/tasks/thumbs_generate.py
+++ b/core/tasks/thumbs_generate.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Dict, List
 import os
 
-from core.utils import register_heif_support
+from core.utils import open_image_compat, register_heif_support
 
 register_heif_support()
 
@@ -153,13 +153,13 @@ def thumbs_generate(*, media_id: int, force: bool = False) -> Dict[str, object]:
                 "skipped": [],
                 "notes": "source missing",
             }
-        img = Image.open(src_path)
-        img = ImageOps.exif_transpose(img)
-        has_alpha = img.mode in ("RGBA", "LA") or (
-            img.mode == "P" and "transparency" in img.info
-        )
+        with open_image_compat(src_path) as opened:
+            opened = ImageOps.exif_transpose(opened)
+            has_alpha = opened.mode in ("RGBA", "LA") or (
+                opened.mode == "P" and "transparency" in opened.info
+            )
+            img = opened.convert("RGBA" if has_alpha else "RGB")
         out_ext = ".png" if has_alpha else ".jpg"
-        img = img.convert("RGBA" if has_alpha else "RGB")
         rel_name = Path(m.local_rel_path).with_suffix(out_ext)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a helper context manager that opens HEIC images even when the Pillow plugin is not registered
- update the local import and thumbnail generation flows to use the new helper for resilient HEIC handling
- cover the fallback behaviour with an additional HEIC support test

## Testing
- pytest tests/test_heic_support.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d5aeabf6e483239ce708e3ae638873