### PR TITLE
Add error detail view for failed picker selections

### DIFF
--- a/webapp/photo_view/templates/photo_view/selection_error_detail.html
+++ b/webapp/photo_view/templates/photo_view/selection_error_detail.html
@@ -1,0 +1,150 @@
+{% extends 'base.html' %}
+{% block title %}{{ _("Selection Error Details") }}{% endblock %}
+
+{% block content %}
+<div class="d-flex flex-column flex-lg-row gap-2 align-items-lg-center justify-content-lg-between mb-3">
+  <div>
+    <h1 class="mb-1">{{ _("Selection Error Details") }}</h1>
+    <p class="text-muted small mb-0">{{ _('Review why this media failed to import.') }}</p>
+  </div>
+  <a href="{{ session_detail_url }}" class="btn btn-outline-secondary btn-sm">
+    <i class="bi bi-arrow-left"></i> {{ _("Back to Session") }}
+  </a>
+</div>
+
+{% set selection = payload.get('selection', {}) %}
+{% set session = payload.get('session', {}) %}
+{% set logs = payload.get('logs', []) %}
+{% set status_value = (selection.get('status') or '').lower() %}
+{% if status_value == 'failed' %}
+  {% set status_badge_class = 'danger' %}
+{% elif status_value == 'expired' %}
+  {% set status_badge_class = 'warning' %}
+{% else %}
+  {% set status_badge_class = 'secondary' %}
+{% endif %}
+
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5 mb-3">{{ _("Selection Summary") }}</h2>
+    {% if selection.get('error') %}
+    <div class="alert alert-danger" role="alert">
+      <strong>{{ _("Error Message:") }}</strong> {{ selection.get('error') }}
+    </div>
+    {% else %}
+    <div class="alert alert-secondary" role="alert">
+      {{ _("No error message was recorded for this selection.") }}
+    </div>
+    {% endif %}
+    <div class="row row-cols-1 row-cols-md-2 g-3">
+      <div class="col">
+        <dl class="mb-0">
+          <dt class="text-muted small">{{ _("Session ID") }}</dt>
+          <dd class="mb-2"><code>{{ session.get('sessionId') or '-' }}</code></dd>
+          <dt class="text-muted small">{{ _("Selection ID") }}</dt>
+          <dd class="mb-2">{{ selection.get('id') }}</dd>
+          <dt class="text-muted small">{{ _("Status") }}</dt>
+          <dd class="mb-2"><span class="badge bg-{{ status_badge_class }}">{{ selection.get('status') or '-' }}</span></dd>
+          <dt class="text-muted small">{{ _("Attempts") }}</dt>
+          <dd class="mb-0">{{ selection.get('attempts') }}</dd>
+        </dl>
+      </div>
+      <div class="col">
+        <dl class="mb-0">
+          <dt class="text-muted small">{{ _("Filename") }}</dt>
+          <dd class="mb-2">{{ selection.get('filename') or '-' }}</dd>
+          <dt class="text-muted small">{{ _("Google Media ID") }}</dt>
+          <dd class="mb-2"><code>{{ selection.get('googleMediaId') or '-' }}</code></dd>
+          <dt class="text-muted small">{{ _("Local File Path") }}</dt>
+          <dd class="mb-0"><code>{{ selection.get('localFilePath') or '-' }}</code></dd>
+        </dl>
+      </div>
+    </div>
+    <div class="row row-cols-1 row-cols-md-3 g-3 mt-2">
+      <div class="col">
+        <dl class="mb-0">
+          <dt class="text-muted small">{{ _("Enqueued At") }}</dt>
+          <dd class="mb-0">{{ selection.get('enqueuedAt') or '-' }}</dd>
+        </dl>
+      </div>
+      <div class="col">
+        <dl class="mb-0">
+          <dt class="text-muted small">{{ _("Started At") }}</dt>
+          <dd class="mb-0">{{ selection.get('startedAt') or '-' }}</dd>
+        </dl>
+      </div>
+      <div class="col">
+        <dl class="mb-0">
+          <dt class="text-muted small">{{ _("Finished At") }}</dt>
+          <dd class="mb-0">{{ selection.get('finishedAt') or '-' }}</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    <h2 class="h5 mb-3">{{ _("Related Logs") }}</h2>
+    {% if logs %}
+    <div class="table-responsive">
+      <table class="table table-sm align-middle">
+        <thead>
+          <tr>
+            <th scope="col">{{ _("Time") }}</th>
+            <th scope="col">{{ _("Level") }}</th>
+            <th scope="col">{{ _("Event") }}</th>
+            <th scope="col">{{ _("Message") }}</th>
+            <th scope="col">{{ _("Details") }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for log in logs %}
+          {% set level = (log.get('level') or '').upper() %}
+          {% if level in ['ERROR', 'CRITICAL'] %}
+            {% set level_class = 'danger' %}
+          {% elif level == 'WARNING' %}
+            {% set level_class = 'warning' %}
+          {% elif level == 'INFO' %}
+            {% set level_class = 'info' %}
+          {% else %}
+            {% set level_class = 'secondary' %}
+          {% endif %}
+          <tr>
+            <td class="small text-nowrap">{{ log.get('createdAt') or '-' }}</td>
+            <td class="small"><span class="badge bg-{{ level_class }}">{{ level or '-' }}</span></td>
+            <td class="small"><code>{{ log.get('event') or '-' }}</code></td>
+            <td class="small">{{ log.get('message') or '-' }}</td>
+            <td class="small">
+              {% if log.get('errorDetails') %}
+              <details class="mb-2">
+                <summary>{{ _("Error details") }}</summary>
+                <pre class="small bg-body-secondary border rounded p-2 mb-0">{{ log.get('errorDetails')|tojson(indent=2, sort_keys=True) }}</pre>
+              </details>
+              {% endif %}
+              {% set extra = log.get('extra') or {} %}
+              {% if extra %}
+              <div class="text-muted small">
+                {% for key, value in extra.items() %}
+                  <div><strong>{{ key }}:</strong> {{ value }}</div>
+                {% endfor %}
+              </div>
+              {% endif %}
+              {% if log.get('trace') %}
+              <details class="mt-2">
+                <summary>{{ _("Traceback") }}</summary>
+                <pre class="small bg-body-secondary border rounded p-2 mb-0">{{ log.get('trace') }}</pre>
+              </details>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="text-muted mb-0">{{ _("No related logs were found for this selection.") }}</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -144,6 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectionPaginationStatusEl = document.getElementById('selection-pagination-status');
   const selectionPaginationButton = document.getElementById('selection-pagination-load');
   const selectionPaginationSpinner = document.getElementById('selection-pagination-spinner');
+  const viewErrorDetailsLabel = '{{ _("View error details") }}';
 
   const selectionStatusLabels = {
     pending: '{{ _("Pending") }}',
@@ -418,6 +419,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const fileCellContent = canDisplayLink
       ? `<a href="/photo-view/media/${selection.mediaId}" class="text-decoration-none">${safeDisplayName}</a>`
       : safeDisplayName;
+    const errorMessageHtml = selection.error
+      ? `<div class="text-danger small">${escapeHtml(selection.error)}</div>`
+      : '<span class="text-muted small">-</span>';
+    const errorLinkHtml = selection.errorDetailsUrl
+      ? `<div><a href="${escapeHtml(selection.errorDetailsUrl)}" class="small link-danger link-offset-2">${escapeHtml(viewErrorDetailsLabel)}</a></div>`
+      : '';
     tr.innerHTML = `
       <td>${fileCellContent}</td>
       <td>
@@ -426,7 +433,7 @@ document.addEventListener('DOMContentLoaded', () => {
         </span>
       </td>
       <td>${selection.attempts}</td>
-      <td><small class="text-danger">${selection.error || ''}</small></td>
+      <td>${errorMessageHtml}${errorLinkHtml}</td>
     `;
     return tr;
   }


### PR DESCRIPTION
## Summary
- expose error detail URLs in the picker selection API and add an endpoint to surface failure diagnostics
- collect related log records for failed selections and render them on a new selection error detail page
- link failed selections from the session detail table and cover the new behavior with API/UI tests

## Testing
- pytest tests/test_local_import_ui.py tests/test_picker_session_service_local_import.py


------
https://chatgpt.com/codex/tasks/task_e_68d5b15d922c83238df4026403e201d4