### PR TITLE
Fix session detail pagination refresh

### DIFF
--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -822,7 +822,25 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      const loadedPagesBeforeRefresh = paginationClient
+        ? Math.max(0, paginationClient.currentPage - 1)
+        : 0;
+
       await paginationClient.loadFirst();
+
+      if (paginationClient && loadedPagesBeforeRefresh > 1) {
+        const additionalPagesToReload = loadedPagesBeforeRefresh - 1;
+        for (let pageIndex = 0; pageIndex < additionalPagesToReload; pageIndex += 1) {
+          if (!paginationClient.hasNext) {
+            break;
+          }
+          // 既に読み込んでいるページ数を維持するため、順次再取得する
+          // setIntervalによる定期リフレッシュ時に「さらに読み込む」で追加表示した行が
+          // 消えてしまう問題を防ぐ。
+          // eslint-disable-next-line no-await-in-loop
+          await paginationClient.loadNext();
+        }
+      }
     } catch (err) {
       console.error(err);
     } finally {


### PR DESCRIPTION
## Summary
- keep track of the number of pages already loaded on the session detail page
- reload the same number of pages during auto refresh so that manually loaded rows stay visible

## Testing
- pytest tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ceb5af548323b26beebaadbd8ba9