### PR TITLE
Add confirmation before canceling local import

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -196,6 +196,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportStopStartingNotice = '{{ _("Canceling local import...") }}';
   const localImportStopSuccessNotice = '{{ _("Local import was canceled.") }}';
   const localImportStopErrorNotice = '{{ _("Failed to stop local import.") }}';
+  const localImportCancelConfirmMessage = '{{ _("Are you sure you want to cancel the local import?") }}';
   const stopLocalImportLabel = '{{ _("Stop Local Import") }}';
   const localImportRunningMessage = '{{ _("Local import is running. You can stop it if needed.") }}';
 
@@ -408,6 +409,10 @@ document.addEventListener('DOMContentLoaded', () => {
   window.stopLocalImport = async function(sessionId) {
     if (!isAdmin) {
       showErrorToast(localImportStopErrorNotice);
+      return;
+    }
+
+    if (!window.confirm(localImportCancelConfirmMessage)) {
       return;
     }
 

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -181,6 +181,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportCancelingMessage = '{{ _("Canceling local import...") }}';
   const localImportCanceledMessage = '{{ _("Local import was canceled.") }}';
   const localImportStopFailedMessage = '{{ _("Failed to stop local import.") }}';
+  const localImportCancelConfirmMessage = '{{ _("Are you sure you want to cancel the local import?") }}';
 
   function getStatusBadgeClass(status) {
     switch (status) {
@@ -825,6 +826,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (stopLocalImportBtn) {
     stopLocalImportBtn.addEventListener('click', () => {
+      if (!window.confirm(localImportCancelConfirmMessage)) {
+        return;
+      }
+
       stopLocalImportSession();
     });
   }

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -321,3 +321,6 @@ msgstr "Sub Pages"
 
 msgid "Parent Page"
 msgstr "Parent Page"
+
+msgid "Are you sure you want to cancel the local import?"
+msgstr "Are you sure you want to cancel the local import?"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1201,6 +1201,11 @@ msgstr "ローカルインポートを停止しました。"
 msgid "Failed to stop local import."
 msgstr "ローカルインポートの停止に失敗しました。"
 
+#: webapp/photo_view/templates/photo_view/home.html:199
+#: webapp/photo_view/templates/photo_view/session_detail.html:184
+msgid "Are you sure you want to cancel the local import?"
+msgstr "ローカルインポートをキャンセルしますか？"
+
 #: webapp/photo_view/templates/photo_view/session_detail.html:94
 msgid "Local import session runs automatically."
 msgstr "ローカルインポートセッションは自動で実行されます。"

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -1253,6 +1253,11 @@ msgstr ""
 msgid "Deleting..."
 msgstr ""
 
+#: webapp/photo_view/templates/photo_view/home.html:199
+#: webapp/photo_view/templates/photo_view/session_detail.html:184
+msgid "Are you sure you want to cancel the local import?"
+msgstr ""
+
 #: webapp/admin/templates/admin/role_edit.html:???
 msgid "Define role basics and choose the permissions it should include."
 msgstr ""


### PR DESCRIPTION
## Summary
- add a confirmation dialog before stopping local import sessions from the session detail and home views
- add translation strings for the new confirmation message and recompile message catalogs
- remove compiled message catalogs from the change set so they can be generated downstream

## Testing
- pytest tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68d5b13f2a2c83238f203196a821f4a8