### PR TITLE
Add filtering controls to session detail and precise log timestamps

### DIFF
--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -239,8 +239,31 @@ def api_picker_session_selections_by_session_id(session_id: str):
     
     # ページングパラメータの取得
     params = PaginationParams.from_request(default_page_size=200)
-    
-    payload = PickerSessionService.selection_details(ps, params)
+
+    raw_status_filters = request.args.getlist("status")
+    normalized_status_filters = []
+    seen_status = set()
+    for raw_status in raw_status_filters:
+        if not raw_status:
+            continue
+        normalized = raw_status.strip().lower()
+        if not normalized or normalized in seen_status:
+            continue
+        seen_status.add(normalized)
+        normalized_status_filters.append(normalized)
+
+    search_query = request.args.get("search", type=str)
+    if search_query is not None:
+        search_query = search_query.strip()
+        if not search_query:
+            search_query = None
+
+    payload = PickerSessionService.selection_details(
+        ps,
+        params,
+        status_filters=normalized_status_filters,
+        search_query=search_query,
+    )
 
     selections = payload.get("selections", [])
     for item in selections:

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -39,6 +39,40 @@
     <i class="bi bi-info-circle"></i> {{ _("Failed files will be retried up to three times.") }}
   </p>
   <div id="selection-counts" class="mb-2 text-muted">{{ _("Loading...") }}</div>
+  <form id="selection-filter-form" class="row gy-2 gx-2 gx-md-3 align-items-end mb-3">
+    <div class="col-12 col-md-4 col-lg-3">
+      <label for="selection-status-filter" class="form-label small mb-1">{{ _("Status") }}</label>
+      <select id="selection-status-filter" class="form-select form-select-sm">
+        <option value="">{{ _("All statuses") }}</option>
+        <option value="pending">{{ _("Pending") }}</option>
+        <option value="enqueued">{{ _("Enqueued") }}</option>
+        <option value="running">{{ _("Running") }}</option>
+        <option value="imported">{{ _("Imported") }}</option>
+        <option value="failed">{{ _("Failed") }}</option>
+        <option value="dup">{{ _("Duplicate") }}</option>
+        <option value="skipped">{{ _("Skipped") }}</option>
+      </select>
+    </div>
+    <div class="col-12 col-md-5 col-lg-4">
+      <label for="selection-search-input" class="form-label small mb-1">{{ _("Search") }}</label>
+      <div class="input-group input-group-sm">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
+        <input type="search"
+               id="selection-search-input"
+               class="form-control"
+               placeholder="{{ _("Search selected files") }}"
+               autocomplete="off">
+      </div>
+    </div>
+    <div class="col-12 col-md-3 col-lg-auto d-flex gap-2">
+      <button id="selection-filter-apply" class="btn btn-primary btn-sm flex-grow-1 flex-lg-grow-0" type="submit">
+        <i class="bi bi-funnel me-1"></i>{{ _("Apply filters") }}
+      </button>
+      <button id="selection-filter-reset" class="btn btn-outline-secondary btn-sm flex-grow-1 flex-lg-grow-0" type="button">
+        {{ _("Reset filters") }}
+      </button>
+    </div>
+  </form>
   <div class="table-responsive">
     <table class="table table-sm">
       <thead>
@@ -140,6 +174,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportStatusEl = document.getElementById('local-import-status');
   const logSection = document.getElementById('local-import-logs-section');
   const logBody = document.getElementById('local-import-log-body');
+  const selectionFilterForm = document.getElementById('selection-filter-form');
+  const selectionStatusFilter = document.getElementById('selection-status-filter');
+  const selectionSearchInput = document.getElementById('selection-search-input');
+  const selectionFilterApplyBtn = document.getElementById('selection-filter-apply');
+  const selectionFilterResetBtn = document.getElementById('selection-filter-reset');
   const selectionPaginationEl = document.getElementById('selection-pagination');
   const selectionPaginationStatusEl = document.getElementById('selection-pagination-status');
   const selectionPaginationButton = document.getElementById('selection-pagination-load');
@@ -324,7 +363,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ].join('');
 
       row.innerHTML = `
-        <td>${escapeHtml(formatDateTime(log.createdAt))}</td>
+        <td>${escapeHtml(formatPreciseDateTime(log.createdAt))}</td>
         <td>${log.event ? `<code>${escapeHtml(log.event)}</code>` : '-'}</td>
         <td>${statusText ? `<span class="badge bg-${statusBadgeClass}">${escapeHtml(statusText)}</span>` : '-'}</td>
         <td>${level ? `<span class="badge bg-${badgeClass}">${escapeHtml(level)}</span>` : '-'}</td>
@@ -341,6 +380,84 @@ document.addEventListener('DOMContentLoaded', () => {
   let isRefreshing = false;
   let currentCounts = {};
   let displayedSelectionCount = 0;
+  const selectionFilterState = {
+    status: '',
+    search: '',
+  };
+
+  function sleep(ms) {
+    return new Promise((resolve) => {
+      window.setTimeout(resolve, ms);
+    });
+  }
+
+  function buildSelectionRequestParams() {
+    const params = {};
+    if (selectionFilterState.status) {
+      params.status = selectionFilterState.status;
+    }
+    if (selectionFilterState.search) {
+      params.search = selectionFilterState.search;
+    }
+    return params;
+  }
+
+  function updateSelectionFilterStateFromInputs() {
+    const rawStatus = selectionStatusFilter ? selectionStatusFilter.value : '';
+    selectionFilterState.status = (rawStatus || '').trim().toLowerCase();
+
+    if (selectionSearchInput) {
+      selectionFilterState.search = selectionSearchInput.value.trim();
+    } else {
+      selectionFilterState.search = '';
+    }
+  }
+
+  function resetSelectionFilterInputs() {
+    if (selectionStatusFilter) {
+      selectionStatusFilter.value = '';
+    }
+    if (selectionSearchInput) {
+      selectionSearchInput.value = '';
+    }
+    selectionFilterState.status = '';
+    selectionFilterState.search = '';
+  }
+
+  async function reloadSelectionsWithFilters() {
+    updateSelectionFilterStateFromInputs();
+    if (paginationClient) {
+      paginationClient.defaultParams = buildSelectionRequestParams();
+    }
+
+    if (selectionFilterApplyBtn) {
+      selectionFilterApplyBtn.disabled = true;
+      selectionFilterApplyBtn.setAttribute('aria-busy', 'true');
+    }
+
+    try {
+      let attempts = 0;
+      while (isRefreshing && attempts < 40) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(50);
+        attempts += 1;
+      }
+
+      if (isRefreshing) {
+        window.setTimeout(() => {
+          refreshSelections();
+        }, 0);
+        return;
+      }
+
+      await refreshSelections();
+    } finally {
+      if (selectionFilterApplyBtn) {
+        selectionFilterApplyBtn.disabled = false;
+        selectionFilterApplyBtn.removeAttribute('aria-busy');
+      }
+    }
+  }
 
   function formatDateTime(isoString) {
     if (!isoString) return '-';
@@ -355,6 +472,52 @@ document.addEventListener('DOMContentLoaded', () => {
       const date = new Date(isoString);
       return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
     } catch (e) {
+      return isoString;
+    }
+  }
+
+  function formatPreciseDateTime(isoString) {
+    if (!isoString) {
+      return '-';
+    }
+
+    const options = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      fractionalSecondDigits: 3,
+      hour12: false,
+    };
+
+    const helper = window.appTime;
+    if (helper && typeof helper.formatDateTime === 'function') {
+      try {
+        const formatted = helper.formatDateTime(isoString, options);
+        if (formatted) {
+          return formatted;
+        }
+      } catch (error) {
+        console.warn('Failed to format precise datetime via appTime', error);
+      }
+    }
+
+    try {
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) {
+        return '-';
+      }
+      if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+        try {
+          return new Intl.DateTimeFormat(undefined, options).format(date);
+        } catch (error) {
+          console.warn('Intl precise formatting failed', error);
+        }
+      }
+      return date.toISOString();
+    } catch (error) {
       return isoString;
     }
   }
@@ -761,6 +924,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     isRefreshing = true;
+    const currentFilterParams = buildSelectionRequestParams();
     try {
       const sessionData = await fetchSessionStatus();
       latestStatus = sessionData?.status || latestStatus;
@@ -778,6 +942,7 @@ document.addEventListener('DOMContentLoaded', () => {
           baseUrl: `/api/picker/session/${encodeURIComponent(pickerSessionId)}/selections`,
           pageSize: 200,
           autoLoad: false,
+          parameters: currentFilterParams,
           onItemsLoaded: (items, meta) => {
             if (meta.currentPage === 1) {
               selectionBody.innerHTML = '';
@@ -814,6 +979,7 @@ document.addEventListener('DOMContentLoaded', () => {
             setSelectionPaginationLoading(state);
           },
         });
+        paginationClient.defaultParams = currentFilterParams;
         if (selectionPaginationButton) {
           selectionPaginationButton.addEventListener('click', () => {
             if (paginationClient) {
@@ -821,6 +987,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
           });
         }
+      } else {
+        paginationClient.defaultParams = currentFilterParams;
       }
 
       const loadedPagesBeforeRefresh = paginationClient
@@ -856,6 +1024,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       stopLocalImportSession();
+    });
+  }
+
+  if (selectionFilterForm) {
+    selectionFilterForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await reloadSelectionsWithFilters();
+    });
+  }
+
+  if (selectionFilterResetBtn) {
+    selectionFilterResetBtn.addEventListener('click', async () => {
+      resetSelectionFilterInputs();
+      await reloadSelectionsWithFilters();
     });
   }
 

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -324,3 +324,15 @@ msgstr "Parent Page"
 
 msgid "Are you sure you want to cancel the local import?"
 msgstr "Are you sure you want to cancel the local import?"
+
+msgid "All statuses"
+msgstr "All statuses"
+
+msgid "Search selected files"
+msgstr "Search selected files"
+
+msgid "Apply filters"
+msgstr "Apply filters"
+
+msgid "Reset filters"
+msgstr "Reset filters"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1320,9 +1320,25 @@ msgstr "選択ファイル数"
 msgid "Failed files will be retried up to three times."
 msgstr "失敗したファイルは最大3回まで再試行されます。"
 
+#: webapp/photo_view/templates/photo_view/session_detail.html:46
+msgid "All statuses"
+msgstr "すべてのステータス"
+
 #: webapp/photo_view/templates/photo_view/session_detail.html:32
 msgid "File"
 msgstr "ファイル"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:63
+msgid "Search selected files"
+msgstr "選択されたファイルを検索"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:69
+msgid "Apply filters"
+msgstr "絞り込みを適用"
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:72
+msgid "Reset filters"
+msgstr "絞り込みをリセット"
 
 #: webapp/photo_view/templates/photo_view/session_detail.html:34
 msgid "Attempts"

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -1172,8 +1172,24 @@ msgstr ""
 msgid "Failed files will be retried up to three times."
 msgstr ""
 
+#: webapp/photo_view/templates/photo_view/session_detail.html:46
+msgid "All statuses"
+msgstr ""
+
 #: webapp/photo_view/templates/photo_view/session_detail.html:32
 msgid "File"
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:63
+msgid "Search selected files"
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:69
+msgid "Apply filters"
+msgstr ""
+
+#: webapp/photo_view/templates/photo_view/session_detail.html:72
+msgid "Reset filters"
 msgstr ""
 
 #: webapp/photo_view/templates/photo_view/session_detail.html:34


### PR DESCRIPTION
## Summary
- add status/search filtering controls to the session detail Selected Files table and wire them into the frontend pagination client
- support the new status and search query parameters in the picker session selections API/service
- render import log timestamps down to milliseconds and update translations/tests accordingly

## Testing
- pytest tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d85e9d1c8323bb31bb6349ff878c