### PR TITLE
Delete photo metadata with media

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -160,7 +160,13 @@ class MediaItem(db.Model):
     camera_model = db.Column(db.String(255))
     photo_metadata_id = db.Column(BigInt, db.ForeignKey('photo_metadata.id'))
     video_metadata_id = db.Column(BigInt, db.ForeignKey('video_metadata.id'))
-    photo_metadata = db.relationship('PhotoMetadata', backref='media_item', uselist=False)
+    photo_metadata = db.relationship(
+        'PhotoMetadata',
+        backref='media_item',
+        uselist=False,
+        cascade='all, delete-orphan',
+        single_parent=True,
+    )
     video_metadata = db.relationship('VideoMetadata', backref='media_item', uselist=False)
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)

--- a/tests/test_media_item_deletion.py
+++ b/tests/test_media_item_deletion.py
@@ -1,0 +1,34 @@
+"""MediaItem削除時のPhotoMetadataの削除をテスト"""
+
+from core.models.photo_models import MediaItem, PhotoMetadata
+from webapp.extensions import db
+
+
+def test_photo_metadata_deleted_with_media_item(app_context):
+    """MediaItemを削除した際に関連PhotoMetadataも削除されることを確認"""
+    photo_metadata = PhotoMetadata(
+        focal_length=50.0,
+        aperture_f_number=1.8,
+        iso_equivalent=100,
+        exposure_time="1/125",
+    )
+    media_item = MediaItem(
+        id="test-media",
+        type="PHOTO",
+        mime_type="image/jpeg",
+        filename="test.jpg",
+        width=1920,
+        height=1080,
+        photo_metadata=photo_metadata,
+    )
+
+    db.session.add(media_item)
+    db.session.commit()
+
+    metadata_id = photo_metadata.id
+    assert PhotoMetadata.query.get(metadata_id) is not None
+
+    db.session.delete(media_item)
+    db.session.commit()
+
+    assert PhotoMetadata.query.get(metadata_id) is None


### PR DESCRIPTION
## Summary
- add delete-orphan cascade to the MediaItem.photo_metadata relationship so metadata is removed with the parent
- add a regression test covering MediaItem deletion cascading to PhotoMetadata

## Testing
- pytest tests/test_media_item_deletion.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ebdd706c83238cf43b036315e561