### PR TITLE
Handle alternate thumbnail filenames

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -32,6 +32,7 @@ class Media(db.Model):
     
     # ファイル情報
     local_rel_path = db.Column(db.String(255), nullable=True)  # ローカルファイルパス
+    thumbnail_rel_path = db.Column(db.String(255), nullable=True)  # サムネイル用パス
     filename = db.Column(db.String(255), nullable=True)  # 元のファイル名
     hash_sha256 = db.Column(db.CHAR(64), nullable=True)
     bytes = db.Column(BigInt, nullable=True)
@@ -86,6 +87,12 @@ class Media(db.Model):
     @property
     def is_google_photos(self):
         return self.source_type == 'google_photos'
+
+    @property
+    def resolved_thumbnail_rel_path(self) -> str | None:
+        """サムネイル用の相対パスを返す。"""
+
+        return self.thumbnail_rel_path or self.local_rel_path
 
 class MediaSidecar(db.Model):
     id = db.Column(BigInt, primary_key=True, autoincrement=True)

--- a/migrations/versions/b2d5c3f6ad1a_add_thumbnail_rel_path_to_media.py
+++ b/migrations/versions/b2d5c3f6ad1a_add_thumbnail_rel_path_to_media.py
@@ -1,0 +1,22 @@
+"""Add thumbnail_rel_path column to media table."""
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision = "b2d5c3f6ad1a"
+down_revision = "a8b078766f1e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "media",
+        sa.Column("thumbnail_rel_path", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("media", "thumbnail_rel_path")


### PR DESCRIPTION
## Summary
- add a dedicated `thumbnail_rel_path` column to persist the generated thumbnail name
- update thumbnail generation and media API routes to resolve converted thumbnail extensions and clean up all candidates
- cover HEIC/JPG scenarios with new tests and provide a migration for the schema change

## Testing
- pytest tests/test_media_api.py -k thumbnail

------
https://chatgpt.com/codex/tasks/task_e_68d5f0e2e6e4832383748cd433111876