### PR TITLE
Add JWT auth check endpoint and tests

### DIFF
--- a/tests/test_api_auth_check.py
+++ b/tests/test_api_auth_check.py
@@ -1,0 +1,54 @@
+import pytest
+
+from webapp.services.token_service import TokenService
+from webapp.extensions import db
+from core.models.user import User
+
+
+@pytest.fixture
+def client(app_context):
+    return app_context.test_client()
+
+
+@pytest.fixture
+def user(app_context):
+    account = User(email="jwt-user@example.com")
+    account.set_password("secret")
+    db.session.add(account)
+    db.session.commit()
+    return account
+
+
+def test_auth_check_requires_token(client):
+    response = client.get("/api/auth/check")
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "authentication_required"}
+
+
+def test_auth_check_accepts_bearer_token(client, user):
+    access_token = TokenService.generate_access_token(user)
+
+    response = client.get(
+        "/api/auth/check",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+    assert data["active"] is True
+
+
+def test_auth_check_accepts_cookie_token(client, user):
+    access_token = TokenService.generate_access_token(user)
+
+    client.set_cookie("access_token", access_token)
+
+    response = client.get("/api/auth/check")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+    assert data["active"] is True

--- a/webapp/api/openapi.py
+++ b/webapp/api/openapi.py
@@ -22,6 +22,13 @@ def openapi_spec():
                     "responses": {"200": {"description": "OK"}},
                 }
             },
+            "/api/auth/check": {
+                "get": {
+                    "summary": "JWTまたはCookieでの認証状態チェック",
+                    "security": [{"cookieAuth": []}, {"bearerAuth": []}],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            },
         },
         "components": {
             "securitySchemes": {

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -412,6 +412,21 @@ def get_current_user():
     return getattr(g, 'current_user', None)
 
 
+@bp.get("/auth/check")
+@login_or_jwt_required
+def api_auth_check():
+    """APIクライアントがJWT認証できているか確認するためのシンプルなエンドポイント"""
+    user = get_current_user()
+    if not user:
+        return jsonify({"error": "authentication_required"}), 401
+
+    return jsonify({
+        "id": user.id,
+        "email": user.email,
+        "active": bool(user.is_active),
+    })
+
+
 def require_api_perms(*perm_codes):
     """APIエンドポイント向けの権限チェックデコレータ"""
 


### PR DESCRIPTION
## Summary
- add /api/auth/check endpoint protected by login_or_jwt_required to confirm JWT authentication
- document the new endpoint in the generated OpenAPI schema
- add tests covering bearer header and cookie based JWT access to the endpoint

## Testing
- pytest tests/test_api_auth_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fa91eb988323b6e80887c267fd07