### PR TITLE
Verify playback file placement and improve logging

### DIFF
--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -197,6 +197,7 @@ def enqueue_media_playback(
             return
 
         result = transcode_worker(media_playback_id=pb.id)
+        db.session.refresh(pb)
         if result.get("ok"):
             _structured_task_log(
                 logger,
@@ -210,6 +211,10 @@ def enqueue_media_playback(
                 height=result.get("height"),
                 duration_ms=result.get("duration_ms"),
                 note=result.get("note"),
+                playback_rel_path=pb.rel_path,
+                playback_output_path=result.get("output_path"),
+                poster_rel_path=pb.poster_rel_path,
+                poster_output_path=result.get("poster_path"),
             )
         else:
             _structured_task_log(
@@ -224,6 +229,10 @@ def enqueue_media_playback(
                 height=result.get("height"),
                 duration_ms=result.get("duration_ms"),
                 note=result.get("note"),
+                playback_rel_path=pb.rel_path,
+                playback_output_path=result.get("output_path"),
+                poster_rel_path=pb.poster_rel_path,
+                poster_output_path=result.get("poster_path"),
             )
     except Exception as exc:  # pragma: no cover - unexpected failure path
         _structured_task_log(

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -246,7 +246,7 @@ def jwt_required(f):
 def _normalize_rel_path(value: str | None) -> Path | None:
     if not value:
         return None
-    normalized = value.lstrip("/\\")
+    normalized = value.replace("\\", "/").lstrip("/")
     if not normalized:
         return None
     return Path(normalized)
@@ -1623,12 +1623,29 @@ def serialize_tag(tag: Tag) -> dict:
     }
 
 
+def _path_to_posix(rel_path: str | None) -> str | None:
+    """Convert a stored relative path into POSIX-style notation."""
+
+    if not rel_path:
+        return None
+
+    normalized = _normalize_rel_path(rel_path)
+    if not normalized:
+        return None
+    return normalized.as_posix()
+
+
 def build_playback_dict(playback: MediaPlayback | None) -> dict:
     """Return playback information dictionary."""
+
+    rel_path = _path_to_posix(playback.rel_path) if playback else None
+    poster_rel_path = _path_to_posix(playback.poster_rel_path) if playback else None
+
     return {
         "available": bool(playback and playback.status == "done"),
         "preset": playback.preset if playback else None,
-        "rel_path": playback.rel_path if playback else None,
+        "rel_path": rel_path,
+        "poster_rel_path": poster_rel_path,
         "status": playback.status if playback else None,
     }
 


### PR DESCRIPTION
## Summary
- verify playback outputs exist after moving and emit detailed placement logs
- expose playback/poster paths from `transcode_worker` and include them in structured task logs
- add regression coverage for missing playback output detection

## Testing
- pytest tests/test_transcode.py::test_worker_transcode_basic -q *(skipped: ffmpeg not installed)*
- pytest tests/test_transcode.py::test_worker_transcode_detects_missing_output -q *(skipped: ffmpeg not installed)*
- pytest tests/test_transcode.py::test_worker_transcode_passthrough_mp4 -q *(skipped: ffmpeg not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d63b363bfc832397a060124d8aeb0e