### PR TITLE
Clamp negative page numbers in media pagination

### DIFF
--- a/tests/test_media_api.py
+++ b/tests/test_media_api.py
@@ -541,6 +541,18 @@ def test_list_second_page(client, seed_media_bulk):
     assert data.get("nextCursor") is None
 
 
+def test_list_negative_page_falls_back_to_first(client, seed_media_bulk):
+    _ = seed_media_bulk
+    login(client)
+
+    res = client.get("/api/media?page=-5&pageSize=10")
+    assert res.status_code == 200
+    data = res.get_json()
+    # page=-5 は自動的に1ページ目扱いとなる
+    assert data.get("currentPage") == 1
+    assert len(data["items"]) == 10
+
+
 def test_list_cursor_falls_back_to_id(client, seed_media_without_shot_at):
     _ = seed_media_without_shot_at
     login(client)

--- a/webapp/api/pagination.py
+++ b/webapp/api/pagination.py
@@ -24,7 +24,17 @@ class PaginationParams:
                  cursor: Optional[str] = None,
                  order: str = "desc",
                  use_cursor: Optional[bool] = None):
-        self.page = page or 1
+        # pageは1以上の整数に丸める
+        if page is None:
+            self.page = 1
+        else:
+            try:
+                self.page = int(page)
+            except (TypeError, ValueError):
+                self.page = 1
+            else:
+                if self.page < 1:
+                    self.page = 1
         if page_size is None:
             page_size = 200
         self.page_size = min(max(page_size, 1), 500)


### PR DESCRIPTION
## Summary
- clamp the requested page number to a minimum of 1 so negative values cannot produce invalid SQL offsets
- add a regression test confirming /api/media gracefully handles negative page inputs

## Testing
- pytest tests/test_media_api.py::test_list_negative_page_falls_back_to_first -q
- pytest tests/test_media_api.py::test_list_first_page -q

------
https://chatgpt.com/codex/tasks/task_e_68d644cddf4c8323928246e587030d93