### PR TITLE
Fail local video import when playback assets are missing

### DIFF
--- a/tests/test_video_import.py
+++ b/tests/test_video_import.py
@@ -7,8 +7,10 @@ from pathlib import Path
 
 import pytest
 
-from core.models.photo_models import Media, MediaItem, VideoMetadata
+from core.db import db
+from core.models.photo_models import Media, MediaItem, MediaPlayback, VideoMetadata
 from core.tasks import local_import as local_import_module
+from core.tasks import media_post_processing
 from core.tasks.local_import import import_single_file
 
 
@@ -20,7 +22,75 @@ def create_test_video(path: Path) -> None:
     path.write_bytes(mp4_header + (b"\x00" * 2000))
 
 
-def _import_video(import_path: Path, import_dir: Path, originals_dir: Path) -> tuple[Media, MediaItem, VideoMetadata]:
+def _stub_playback_success(monkeypatch: pytest.MonkeyPatch, playback_dir: Path) -> None:
+    """動画再生生成処理をスタブ化し、ダミーファイルを作成する。"""
+
+    def fake_enqueue(
+        media_id: int,
+        *,
+        logger_override=None,
+        operation_id=None,
+        request_context=None,
+    ) -> dict:
+        media = Media.query.get(media_id)
+        if media:
+            media.has_playback = True
+        playback = MediaPlayback.query.filter_by(media_id=media_id, preset="std1080p").first()
+        if not playback:
+            rel_path = "2024/01/01/test.mp4"
+            playback = MediaPlayback(
+                media_id=media_id,
+                preset="std1080p",
+                rel_path=rel_path,
+                status="done",
+            )
+            db.session.add(playback)
+        else:
+            playback.status = "done"
+            playback.rel_path = playback.rel_path or "2024/01/01/test.mp4"
+
+        playback.poster_rel_path = playback.poster_rel_path or "2024/01/01/test.jpg"
+        playback.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+
+        dest = playback_dir / playback.rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"stub playback")
+
+        poster = playback_dir / (playback.poster_rel_path or "2024/01/01/test.jpg")
+        poster.parent.mkdir(parents=True, exist_ok=True)
+        poster.write_bytes(b"stub poster")
+
+        return {
+            "ok": True,
+            "note": "stub",
+            "output_path": str(dest),
+            "poster_path": str(poster),
+        }
+
+    monkeypatch.setattr(media_post_processing, "enqueue_media_playback", fake_enqueue)
+
+
+def _stub_playback_failure(monkeypatch: pytest.MonkeyPatch, note: str = "stub_failure") -> None:
+    """動画再生生成処理を失敗させるスタブを設定する。"""
+
+    def fake_enqueue(
+        media_id: int,
+        *,
+        logger_override=None,
+        operation_id=None,
+        request_context=None,
+    ) -> dict:
+        return {"ok": False, "note": note}
+
+    monkeypatch.setattr(media_post_processing, "enqueue_media_playback", fake_enqueue)
+
+
+def _import_video(
+    import_path: Path,
+    import_dir: Path,
+    originals_dir: Path,
+) -> tuple[Media, MediaItem, VideoMetadata]:
     """ローカルインポートを実行し、生成されたモデルを返す。"""
 
     result = import_single_file(str(import_path), str(import_dir), str(originals_dir))
@@ -45,8 +115,20 @@ def _import_video(import_path: Path, import_dir: Path, originals_dir: Path) -> t
     return media, media_item, video_meta
 
 
+@pytest.fixture
+def playback_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """テスト用の再生ファイルディレクトリを用意する。"""
+
+    play_dir = tmp_path / "playback"
+    play_dir.mkdir()
+    monkeypatch.setenv("FPV_NAS_PLAY_DIR", str(play_dir))
+    return play_dir
+
+
 @pytest.mark.usefixtures("app_context")
-def test_local_import_mp4_video(tmp_path: Path) -> None:
+def test_local_import_mp4_video(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, playback_dir: Path
+) -> None:
     """MP4ファイルがローカルインポート経由で正しく登録されることを検証する。"""
 
     import_dir = tmp_path / "import"
@@ -57,6 +139,7 @@ def test_local_import_mp4_video(tmp_path: Path) -> None:
     test_video = import_dir / "test_video.mp4"
     create_test_video(test_video)
 
+    _stub_playback_success(monkeypatch, playback_dir)
     media, media_item, _ = _import_video(test_video, import_dir, originals_dir)
 
     assert media.is_video is True
@@ -67,7 +150,9 @@ def test_local_import_mp4_video(tmp_path: Path) -> None:
 
 
 @pytest.mark.usefixtures("app_context")
-def test_local_import_mov_video(tmp_path: Path) -> None:
+def test_local_import_mov_video(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, playback_dir: Path
+) -> None:
     """QuickTime(MOV)ファイルもローカルインポートで処理できることを確認する。"""
 
     import_dir = tmp_path / "import"
@@ -78,6 +163,7 @@ def test_local_import_mov_video(tmp_path: Path) -> None:
     test_video = import_dir / "TestClip.MOV"
     create_test_video(test_video)
 
+    _stub_playback_success(monkeypatch, playback_dir)
     media, media_item, _ = _import_video(test_video, import_dir, originals_dir)
 
     assert media.is_video is True
@@ -88,7 +174,11 @@ def test_local_import_mov_video(tmp_path: Path) -> None:
 
 
 @pytest.mark.usefixtures("app_context")
-def test_video_shot_at_from_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_video_shot_at_from_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    playback_dir: Path,
+) -> None:
     """動画メタデータから shot_at が設定されることを確認する。"""
 
     import_dir = tmp_path / "import"
@@ -111,7 +201,32 @@ def test_video_shot_at_from_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyP
         }
 
     monkeypatch.setattr(local_import_module, "extract_video_metadata", fake_extract)
+    _stub_playback_success(monkeypatch, playback_dir)
 
     media, _, _ = _import_video(test_video, import_dir, originals_dir)
 
     assert media.shot_at == expected_shot_at.replace(tzinfo=None)
+
+
+@pytest.mark.usefixtures("app_context")
+def test_local_import_video_playback_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, playback_dir: Path
+) -> None:
+    """再生ファイル生成に失敗した場合にエラーになることを検証する。"""
+
+    import_dir = tmp_path / "import"
+    originals_dir = tmp_path / "originals"
+    import_dir.mkdir()
+    originals_dir.mkdir()
+
+    test_video = import_dir / "FailVideo.mp4"
+    create_test_video(test_video)
+
+    _stub_playback_failure(monkeypatch, note="ffmpeg_missing")
+
+    result = import_single_file(str(test_video), str(import_dir), str(originals_dir))
+
+    assert result["success"] is False
+    assert "ffmpeg_missing" in result["reason"]
+    # 元ファイルは削除されず残っていることを確認
+    assert test_video.exists()


### PR DESCRIPTION
## Summary
- ensure local video imports raise a structured error when playback generation fails and verify that playback files exist
- return detailed results from the media post-processing helpers so callers can inspect playback/thumbnail outcomes
- extend the video import tests with playback stubs and a failure scenario covering the new error handling

## Testing
- pytest tests/test_video_import.py


------
https://chatgpt.com/codex/tasks/task_e_68d64a6343d0832383323c85a34864d5