### PR TITLE
Align transcode storage resolution with storage_paths

### DIFF
--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 
 from core.db import db
 from core.models.photo_models import Media, MediaPlayback
+from core.storage_paths import ensure_directory, first_existing_storage_path
 from .thumbs_generate import thumbs_generate
 
 # transcode専用ロガーを取得（両方のログハンドラーが設定済み）
@@ -41,14 +42,17 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _orig_dir() -> Path:
-    return Path(os.environ.get("FPV_NAS_ORIGINALS_DIR", "/tmp/fpv_orig"))
+    base = first_existing_storage_path("FPV_NAS_ORIGINALS_DIR")
+    if not base:
+        base = "/tmp/fpv_orig"
+    return Path(base)
 
 
 def _play_dir() -> Path:
-    return Path(
-        os.environ.get("FPV_NAS_PLAY_CONTAINER_DIR")
-        or os.environ.get("FPV_NAS_PLAY_DIR", "/tmp/fpv_play")
-    )
+    base = first_existing_storage_path("FPV_NAS_PLAY_DIR")
+    if not base:
+        base = "/tmp/fpv_play"
+    return ensure_directory(base)
 
 
 def _tmp_dir() -> Path:


### PR DESCRIPTION
## Summary
- update the transcode helper directories to reuse `core.storage_paths`
- ensure playback output directories are created under the resolved base path

## Testing
- pytest tests/test_transcode.py

------
https://chatgpt.com/codex/tasks/task_e_68d650af69c88323baf1321991713077