### PR TITLE
Improve thumbnail generation logging for video media

### DIFF
--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -112,16 +112,31 @@ def enqueue_thumbs_generate(
         return {"ok": False, "note": "exception", "error": str(exc)}
 
     generated = result.get("generated", [])
+    skipped = result.get("skipped", [])
+    notes = result.get("notes")
     if result.get("ok"):
+        if generated:
+            event = "thumbnail_generation.complete"
+            message = "Thumbnails generated successfully."
+        else:
+            event = "thumbnail_generation.skipped"
+            # Provide a clear reason in the log message when nothing was generated
+            if notes:
+                message = f"Thumbnail generation skipped: {notes}."
+            else:
+                message = "Thumbnail generation skipped with no thumbnails produced."
+
         _structured_task_log(
             logger,
             level="info",
-            event="thumbnail_generation.complete",
-            message="Thumbnails generated successfully.",
+            event=event,
+            message=message,
             operation_id=op_id,
             media_id=media_id,
             request_context=request_context,
             generated=generated,
+            skipped=skipped,
+            notes=notes,
         )
     else:
         _structured_task_log(


### PR DESCRIPTION
## Summary
- log skipped thumbnail generations with details when no thumbnails are produced
- include reasons such as playback not ready in structured task logs so video thumbnail issues are visible

## Testing
- pytest tests/test_transcode.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d70e5f80f883238c297c477d8a2827