### PR TITLE
Log generated thumbnail paths during duplicate video regeneration

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -763,6 +763,12 @@ def _regenerate_duplicate_video_thumbnails(
         return
 
     if result.get("ok"):
+        paths = result.get("paths") or {}
+        generated_paths = {
+            size: paths[size]
+            for size in result.get("generated", [])
+            if size in paths
+        }
         _log_info(
             "local_import.duplicate_video.thumbnail_regenerated",
             "重複動画のサムネイルを再生成",
@@ -771,6 +777,7 @@ def _regenerate_duplicate_video_thumbnails(
             generated=result.get("generated"),
             skipped=result.get("skipped"),
             notes=result.get("notes"),
+            generated_paths=generated_paths,
             status="thumbs_regenerated",
         )
     else:


### PR DESCRIPTION
## Summary
- return thumbnail file paths from `thumbs_generate` so callers know where assets were written
- log the generated thumbnail paths when reprocessing duplicate videos
- update the thumbnail generation tests to assert the new metadata

## Testing
- pytest tests/test_thumbs_generate.py
- pytest tests/test_video_import.py::test_duplicate_video_regenerates_thumbnails -q

------
https://chatgpt.com/codex/tasks/task_e_68d718b344c0832397f729b544a4749e