### PR TITLE
Add Celery retry for delayed video thumbnails

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -38,8 +38,10 @@ from core.models.job_sync import JobSync
 from core.models.picker_session import PickerSession
 from core.utils import get_file_date_from_name, get_file_date_from_exif
 from core.logging_config import setup_task_logging, log_task_error, log_task_info
-from core.tasks.media_post_processing import process_media_post_import
-from core.tasks.thumbs_generate import thumbs_generate
+from core.tasks.media_post_processing import (
+    enqueue_thumbs_generate,
+    process_media_post_import,
+)
 from core.storage_paths import first_existing_storage_path, storage_path_candidates
 from webapp.config import Config
 
@@ -749,8 +751,16 @@ def _regenerate_duplicate_video_thumbnails(
 ) -> None:
     """重複動画のサムネイル生成を再実行する。"""
 
+    request_context = {"sessionId": session_id} if session_id else None
+
     try:
-        result = thumbs_generate(media_id=media.id, force=True)
+        result = enqueue_thumbs_generate(
+            media.id,
+            force=True,
+            logger_override=logger,
+            operation_id=f"duplicate-video-{media.id}",
+            request_context=request_context,
+        )
     except Exception as exc:  # pragma: no cover - unexpected failure path
         _log_error(
             "local_import.duplicate_video.thumbnail_regen_failed",
@@ -766,6 +776,7 @@ def _regenerate_duplicate_video_thumbnails(
         paths = result.get("paths") or {}
         generated = result.get("generated", [])
         skipped = result.get("skipped", [])
+        retry_scheduled = result.get("retry_scheduled", False)
         generated_paths = {
             size: paths[size]
             for size in generated
@@ -788,6 +799,7 @@ def _regenerate_duplicate_video_thumbnails(
             generated_paths=generated_paths,
             skipped_paths=skipped_paths,
             paths=paths,
+            retry_scheduled=retry_scheduled,
             status=status,
         )
     else:
@@ -797,6 +809,7 @@ def _regenerate_duplicate_video_thumbnails(
             session_id=session_id,
             media_id=media.id,
             notes=result.get("notes"),
+            retry_scheduled=result.get("retry_scheduled"),
             status="thumbs_skipped",
         )
 

--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -22,11 +22,68 @@ from core.models.photo_models import Media, MediaPlayback
 
 # These imports are intentionally placed after SQLAlchemy models to avoid
 # circular import issues.
-from .thumbs_generate import thumbs_generate
+from .thumbs_generate import PLAYBACK_NOT_READY_NOTES, thumbs_generate
 from .transcode import transcode_worker
 
 
 _logger = setup_task_logging(__name__)
+
+_THUMBNAIL_RETRY_COUNTDOWN = 300
+
+
+def _schedule_thumbnail_retry(
+    *,
+    media_id: int,
+    force: bool,
+    countdown: int,
+    logger: logging.Logger,
+    operation_id: str,
+    request_context: Optional[Dict[str, Any]],
+) -> bool:
+    """Schedule a Celery retry for thumbnail generation.
+
+    Returns ``True`` when a retry job could be enqueued.  When Celery is not
+    available the function simply returns ``False`` without logging to avoid
+    noisy warnings in test environments.
+    """
+
+    try:
+        from cli.src.celery.tasks import thumbs_generate_task
+    except ImportError:
+        return False
+
+    try:
+        async_result = thumbs_generate_task.apply_async(
+            kwargs={"media_id": media_id, "force": force},
+            countdown=countdown,
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        _structured_task_log(
+            logger,
+            level="warning",
+            event="thumbnail_generation.retry_failed",
+            message="Failed to schedule thumbnail retry.",
+            operation_id=operation_id,
+            media_id=media_id,
+            request_context=request_context,
+            countdown=countdown,
+            error=str(exc),
+        )
+        return False
+
+    _structured_task_log(
+        logger,
+        level="info",
+        event="thumbnail_generation.retry_scheduled",
+        message=f"Playback not ready; retry scheduled in {countdown} seconds.",
+        operation_id=operation_id,
+        media_id=media_id,
+        request_context=request_context,
+        countdown=countdown,
+        celery_task_id=getattr(async_result, "id", None),
+        force=force,
+    )
+    return True
 
 
 def _structured_task_log(
@@ -86,18 +143,24 @@ def enqueue_thumbs_generate(
     logger_override: Optional[logging.Logger] = None,
     operation_id: Optional[str] = None,
     request_context: Optional[Dict[str, Any]] = None,
+    force: bool = False,
 ) -> Dict[str, Any]:
     """Synchronously generate thumbnails for *media_id* with structured logging.
 
+    When the underlying worker reports that playback assets are not yet ready,
+    the helper schedules a Celery retry (if available) using a 5 minute delay.
+
     Returns the raw result dictionary from :func:`thumbs_generate` (or a
-    synthesized error response when the worker raises an exception).
+    synthesized error response when the worker raises an exception).  When a
+    retry is scheduled the returned dictionary includes ``retry_scheduled`` set
+    to ``True``.
     """
 
     logger = logger_override or _logger
     op_id = operation_id or str(uuid4())
 
     try:
-        result = thumbs_generate(media_id=media_id)
+        result = thumbs_generate(media_id=media_id, force=force)
     except Exception as exc:  # pragma: no cover - unexpected failure path
         _structured_task_log(
             logger,
@@ -114,6 +177,8 @@ def enqueue_thumbs_generate(
     generated = result.get("generated", [])
     skipped = result.get("skipped", [])
     notes = result.get("notes")
+    retry_scheduled = False
+
     if result.get("ok"):
         if generated:
             event = "thumbnail_generation.complete"
@@ -138,6 +203,16 @@ def enqueue_thumbs_generate(
             skipped=skipped,
             notes=notes,
         )
+
+        if notes == PLAYBACK_NOT_READY_NOTES:
+            retry_scheduled = _schedule_thumbnail_retry(
+                media_id=media_id,
+                force=force,
+                countdown=_THUMBNAIL_RETRY_COUNTDOWN,
+                logger=logger,
+                operation_id=op_id,
+                request_context=request_context,
+            )
     else:
         _structured_task_log(
             logger,
@@ -149,6 +224,10 @@ def enqueue_thumbs_generate(
             request_context=request_context,
             notes=result.get("notes"),
         )
+
+    if retry_scheduled:
+        result = dict(result)
+        result["retry_scheduled"] = True
 
     return result
 

--- a/tests/test_media_post_processing.py
+++ b/tests/test_media_post_processing.py
@@ -133,3 +133,53 @@ def test_enqueue_media_playback_generates_thumbnails_for_completed_playback(app,
     thumb_path = thumbs_dir / "256" / "2025/09/27/video.jpg"
     assert thumb_path.exists()
 
+
+def test_enqueue_thumbs_generate_schedules_retry(monkeypatch):
+    """サムネイル生成が保留の場合にCeleryリトライをスケジュールすることを確認。"""
+
+    from core.tasks import media_post_processing
+
+    monkeypatch.setattr(
+        media_post_processing,
+        "thumbs_generate",
+        lambda media_id, force=False: {
+            "ok": True,
+            "generated": [],
+            "skipped": [256, 512, 1024, 2048],
+            "notes": media_post_processing.PLAYBACK_NOT_READY_NOTES,
+            "paths": {},
+        },
+    )
+
+    scheduled: dict = {}
+
+    def fake_schedule(
+        *,
+        media_id: int,
+        force: bool,
+        countdown: int,
+        logger,
+        operation_id: str,
+        request_context,
+    ) -> bool:
+        scheduled.update(
+            media_id=media_id,
+            force=force,
+            countdown=countdown,
+            operation_id=operation_id,
+            request_context=request_context,
+        )
+        return True
+
+    monkeypatch.setattr(media_post_processing, "_schedule_thumbnail_retry", fake_schedule)
+
+    result = media_post_processing.enqueue_thumbs_generate(123, force=True)
+
+    assert result["retry_scheduled"] is True
+    assert scheduled["media_id"] == 123
+    assert scheduled["force"] is True
+    assert (
+        scheduled["countdown"]
+        == media_post_processing._THUMBNAIL_RETRY_COUNTDOWN
+    )
+

--- a/tests/test_thumbs_generate.py
+++ b/tests/test_thumbs_generate.py
@@ -6,6 +6,7 @@ import pytest
 from PIL import Image
 
 from core.tasks import thumbs_generate
+from core.tasks.thumbs_generate import PLAYBACK_NOT_READY_NOTES
 
 
 @pytest.fixture
@@ -186,6 +187,6 @@ def test_video_playback_not_ready(app):
         "ok": True,
         "generated": [],
         "skipped": [256, 512, 1024, 2048],
-        "notes": "playback not ready",
+        "notes": PLAYBACK_NOT_READY_NOTES,
         "paths": {},
     }


### PR DESCRIPTION
## Summary
- add a Celery task for thumbnail generation that retries when playback assets are not ready
- extend the thumbnail helper to schedule retry jobs and update duplicate video handling to use it
- refresh unit tests to cover the new retry scheduling behaviour

## Testing
- pytest tests/test_thumbs_generate.py tests/test_media_post_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d72189d0308323883c9260c8158c56