### PR TITLE
Improve logging for delayed thumbnail retries

### DIFF
--- a/tests/test_thumbs_generate.py
+++ b/tests/test_thumbs_generate.py
@@ -6,6 +6,7 @@ import pytest
 from PIL import Image
 
 from core.tasks import thumbs_generate
+from core.tasks.thumbs_generate import PLAYBACK_NOT_READY_NOTES
 
 
 @pytest.fixture
@@ -186,6 +187,6 @@ def test_video_playback_not_ready(app):
         "ok": True,
         "generated": [],
         "skipped": [256, 512, 1024, 2048],
-        "notes": "playback not ready",
+        "notes": PLAYBACK_NOT_READY_NOTES,
         "paths": {},
     }


### PR DESCRIPTION
## Summary
- return detailed metadata when scheduling thumbnail retries and expose it via enqueue helpers
- log duplicate video thumbnail retries with countdown/task identifiers for easier monitoring
- extend the retry scheduling test to cover the propagated metadata

## Testing
- pytest tests/test_media_post_processing.py tests/test_thumbs_generate.py

------
https://chatgpt.com/codex/tasks/task_e_68d72189d0308323883c9260c8158c56