### PR TITLE
Add UI and API support for media recovery

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -744,6 +744,30 @@ def _refresh_existing_media_metadata(
     return True
 
 
+def refresh_media_metadata_from_original(
+    media: Media,
+    *,
+    originals_dir: str,
+    fallback_path: str,
+    file_extension: str,
+    session_id: Optional[str] = None,
+) -> bool:
+    """Public wrapper for :func:`_refresh_existing_media_metadata`.
+
+    The helper is reused outside of the local import task (for example from UI
+    triggered recovery flows) while keeping the implementation centralised in a
+    single location.
+    """
+
+    return _refresh_existing_media_metadata(
+        media,
+        originals_dir=originals_dir,
+        fallback_path=fallback_path,
+        file_extension=file_extension,
+        session_id=session_id,
+    )
+
+
 def _regenerate_duplicate_video_thumbnails(
     media: Media,
     *,

--- a/migrations/versions/31b1901dba43_base.py
+++ b/migrations/versions/31b1901dba43_base.py
@@ -347,13 +347,15 @@ def upgrade():
     "INSERT INTO permission (id, code) VALUES " \
     "(1, 'admin:photo-settings'), (2, 'admin:job-settings'), (3, 'user:manage'), (4, 'album:create'), (5, 'album:edit'), " \
     "(6, 'album:view'), (7, 'media:view'), (8, 'permission:manage'), (9, 'role:manage'), (10, 'system:manage'), " \
-    "(11, 'wiki:admin'), (12, 'wiki:read'), (13, 'wiki:write'), (14, 'media:tag-manage'), (15, 'media:delete')")
+    "(11, 'wiki:admin'), (12, 'wiki:read'), (13, 'wiki:write'), (14, 'media:tag-manage'), (15, 'media:delete'), " \
+    "(16, 'media:recover')")
     op.execute(
     "INSERT INTO role_permissions (role_id, perm_id) VALUES " \
     "(1, 1), (1, 2), (1, 3), (1, 4), (1, 5)," \
     "(1, 6), (1, 7), (1, 8), (1, 9), (1, 10)," \
-    "(1, 11), (1, 12), (1, 13), (1, 14), (1, 15)," \
-    "(2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (3, 6), (3, 7)")
+    "(1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16)," \
+    "(2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15), (2, 16)," \
+    "(3, 6), (3, 7)")
     from datetime import datetime, timezone
     op.get_bind().execute(
     sa.text(

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -52,6 +52,7 @@ def seed_permissions():
         {'id': 13, 'code': 'wiki:write'},
         {'id': 14, 'code': 'media:tag-manage'},
         {'id': 15, 'code': 'media:delete'},
+        {'id': 16, 'code': 'media:recover'},
     ]
     
     for perm_data in permissions_data:
@@ -70,9 +71,9 @@ def seed_role_permissions():
         # admin (role_id=1) - all permissions
         (1, 1), (1, 2), (1, 3), (1, 4), (1, 5),
         (1, 6), (1, 7), (1, 8), (1, 9), (1, 10),
-        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15),
+        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16),
         # manager (role_id=2) - limited permissions
-        (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15),
+        (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15), (2, 16),
         # member (role_id=3) - view only
         (3, 6), (3, 7)
     ]

--- a/webapp/photo_view/templates/photo_view/media_detail.html
+++ b/webapp/photo_view/templates/photo_view/media_detail.html
@@ -283,6 +283,11 @@
             <li><a class="dropdown-item download-option" href="#" data-download-type="thumbnail">{{ _("Download thumbnail (2048px)") }}</a></li>
           </ul>
         </div>
+        {% if current_user.can('media:recover') %}
+        <button class="btn btn-outline-warning" id="recover-btn">
+          <i class="fas fa-undo"></i> {{ _("Recover metadata") }}
+        </button>
+        {% endif %}
         {% if current_user.can('media:delete') %}
         <button class="btn btn-outline-danger" id="delete-btn">
           <i class="fas fa-trash-alt"></i> {{ _("Delete") }}
@@ -376,6 +381,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const fullscreenBtn = document.getElementById('fullscreen-btn');
   const zoomBtn = document.getElementById('zoom-btn');
   const deleteBtn = document.getElementById('delete-btn');
+  const recoverBtn = document.getElementById('recover-btn');
   const basicInfo = document.getElementById('basic-info');
   const technicalInfo = document.getElementById('technical-info');
   const exifInfo = document.getElementById('exif-info');
@@ -409,6 +415,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const deleteForbiddenText = '{{ _("You do not have permission to delete media.")|escapejs }}';
   const deleteMissingText = '{{ _("Media was not found or is already deleted.")|escapejs }}';
   const deleteInProgressText = '{{ _("Deleting...")|escapejs }}';
+  const recoverConfirmText = '{{ _("Reapply metadata from the original file?")|escapejs }}';
+  const recoverSuccessText = '{{ _("Media metadata was refreshed.")|escapejs }}';
+  const recoverErrorText = '{{ _("Failed to refresh media metadata.")|escapejs }}';
+  const recoverForbiddenText = '{{ _("You do not have permission to recover metadata.")|escapejs }}';
+  const recoverSourceMissingText = '{{ _("Original file for recovery could not be found.")|escapejs }}';
+  const recoverUnsupportedText = '{{ _("The original file type is not supported for recovery.")|escapejs }}';
+  const recoverInProgressText = '{{ _("Recovering...")|escapejs }}';
+  const recoverThumbnailTriggeredText = '{{ _("Thumbnail regeneration has been requested.")|escapejs }}';
   const redirectAfterDeleteUrl = '{{ url_for("photo_view.media_list")|escapejs }}';
   const downloadErrorText = '{{ _("Failed to download media.")|escapejs }}';
   const downloadPlaybackPendingText = '{{ _("Video playback is still being prepared. Please try again shortly.")|escapejs }}';
@@ -493,6 +507,64 @@ document.addEventListener('DOMContentLoaded', () => {
         mediaDisplay.innerHTML = '<div class="text-center text-danger p-5"><h4>Error loading media</h4><p>The requested media could not be found or loaded.</p></div>';
       }
     }
+  }
+
+  if (recoverBtn) {
+    recoverBtn.addEventListener('click', async () => {
+      if (!confirm(recoverConfirmText)) {
+        return;
+      }
+
+      const originalHtml = recoverBtn.innerHTML;
+      recoverBtn.disabled = true;
+      recoverBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>${recoverInProgressText}`;
+
+      try {
+        const response = await window.apiClient.post(`/api/media/${mediaId}/recover`);
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch (error) {
+          payload = null;
+        }
+
+        if (response.ok && payload && payload.media) {
+          currentMedia = payload.media;
+          displayMedia(currentMedia);
+          displayMediaInfo(currentMedia);
+          if (Array.isArray(currentMedia.tags)) {
+            currentTags = currentMedia.tags;
+          }
+          renderMediaTags();
+          updateDownloadControls(currentMedia);
+          showSuccessToast(recoverSuccessText);
+          if (payload.thumbnailJobTriggered) {
+            if (typeof showInfoToast === 'function') {
+              showInfoToast(recoverThumbnailTriggeredText, 4000);
+            } else {
+              showSuccessToast(recoverThumbnailTriggeredText);
+            }
+          }
+        } else {
+          const errorCode = payload && payload.error;
+          if (response.status === 403) {
+            showErrorToast(recoverForbiddenText);
+          } else if (errorCode === 'source_missing') {
+            showErrorToast(recoverSourceMissingText);
+          } else if (errorCode === 'unsupported_extension') {
+            showErrorToast(recoverUnsupportedText);
+          } else {
+            showErrorToast(recoverErrorText);
+          }
+        }
+      } catch (error) {
+        console.error('Recover request failed', error);
+        showErrorToast(recoverErrorText);
+      } finally {
+        recoverBtn.disabled = false;
+        recoverBtn.innerHTML = originalHtml;
+      }
+    });
   }
 
   if (deleteBtn) {


### PR DESCRIPTION
## Summary
- add a reusable helper to refresh media metadata from existing originals
- trigger thumbnail regeneration when a media thumbnail is missing and expose a media recovery API endpoint
- surface a metadata recovery button on the media detail screen guarded by the new permission and extend master data/seed fixtures
- cover the recovery workflow with API tests

## Testing
- pytest tests/test_media_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7267fda2c8323988fcb6d98f16db9