### PR TITLE
Log retry scheduling for duplicate video thumbnails

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -802,6 +802,18 @@ def _regenerate_duplicate_video_thumbnails(
             retry_scheduled=retry_scheduled,
             status=status,
         )
+        if retry_scheduled:
+            retry_details = result.get("retry_details") or {}
+            _log_info(
+                "local_import.duplicate_video.thumbnail_retry_scheduled",
+                "重複動画のサムネイル再生成を後で再試行",
+                session_id=session_id,
+                media_id=media.id,
+                retry_delay_seconds=retry_details.get("countdown"),
+                celery_task_id=retry_details.get("celery_task_id"),
+                notes=result.get("notes"),
+                status="retry_scheduled",
+            )
     else:
         _log_warning(
             "local_import.duplicate_video.thumbnail_regen_skipped",


### PR DESCRIPTION
## Summary
- include retry metadata when scheduling thumbnail regeneration retries
- log duplicate video thumbnail retry scheduling within the local import task
- update retry scheduling tests to cover the additional metadata

## Testing
- pytest tests/test_media_post_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d72cf1714c8323873260f089f6f706