### PR TITLE
Use worker_log table for Celery worker logs

### DIFF
--- a/core/models/worker_log.py
+++ b/core/models/worker_log.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from ..db import db
+
+
+BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+class WorkerLog(db.Model):
+    __tablename__ = "worker_log"
+
+    id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    created_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    level = db.Column(db.String(20), nullable=False)
+    event = db.Column(db.String(50), nullable=False)
+    logger_name = db.Column(db.String(120))
+    task_name = db.Column(db.String(255))
+    task_uuid = db.Column(db.String(36))
+    worker_hostname = db.Column(db.String(255))
+    queue_name = db.Column(db.String(120))
+    status = db.Column(db.String(40))
+    message = db.Column(db.Text, nullable=False)
+    trace = db.Column(db.Text)
+    meta_json = db.Column(db.JSON)
+    extra_json = db.Column(db.JSON)
+
+
+__all__ = ["WorkerLog"]


### PR DESCRIPTION
## Summary
- add a dedicated WorkerDBLogHandler that persists Celery worker records into the worker_log table
- update the Celery logging bootstrap to swap legacy log handlers for the worker-specific handler
- define a WorkerLog ORM model that matches the worker_log schema

## Testing
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b95fb0a483238f162c5425c3b6ea