### PR TITLE
Log missing ffmpeg during video poster generation

### DIFF
--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -178,6 +178,18 @@ def _generate_poster(playback: MediaPlayback, video_path: Path) -> Optional[str]
     poster_dest = _play_dir() / poster_rel
     poster_dest.parent.mkdir(parents=True, exist_ok=True)
 
+    if shutil.which("ffmpeg") is None:
+        logger.error(
+            "ffmpeg not found; skipping poster generation for playback %s",
+            playback.id,
+            extra={
+                "event": "transcode.poster.ffmpeg_missing",
+                "playback_id": playback.id,
+                "media_id": playback.media_id,
+            },
+        )
+        return None
+
     commands = [
         [
             "ffmpeg",


### PR DESCRIPTION
## Summary
- detect missing ffmpeg before attempting to generate video posters
- emit an error log with event metadata so worker-log captures the failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84fd61ff88323a24af40161ed4503