### PR TITLE
Ensure Celery task logging uses worker_log table

### DIFF
--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -9,6 +9,7 @@ from flask import current_app, has_app_context
 
 
 _APPDB_HANDLER_ATTR = "_is_appdb_log_handler"
+_WORKER_HANDLER_ATTR = "_is_worker_db_log_handler"
 
 
 def _create_appdb_db_handler() -> logging.Handler:
@@ -42,8 +43,46 @@ def ensure_appdb_file_logging(logger: logging.Logger) -> None:
         logger.setLevel(logging.INFO)
 
 
+def _create_worker_db_handler() -> logging.Handler:
+    """Create a WorkerDBLogHandler configured for Celery worker logging."""
+
+    from core.db_log_handler import WorkerDBLogHandler
+
+    app_obj = current_app._get_current_object() if has_app_context() else None
+    handler = WorkerDBLogHandler(app=app_obj)
+    handler.setLevel(logging.INFO)
+    setattr(handler, _WORKER_HANDLER_ATTR, True)
+    return handler
+
+
+def ensure_worker_db_logging(logger: logging.Logger) -> None:
+    """Attach the worker-specific database log handler to *logger* if missing."""
+
+    from core.db_log_handler import DBLogHandler, WorkerDBLogHandler
+
+    has_worker_handler = False
+
+    for handler in list(logger.handlers):
+        if isinstance(handler, WorkerDBLogHandler):
+            has_worker_handler = True
+            setattr(handler, _WORKER_HANDLER_ATTR, True)
+        elif isinstance(handler, DBLogHandler) and getattr(handler, _APPDB_HANDLER_ATTR, False):
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+    if not has_worker_handler:
+        worker_handler = _create_worker_db_handler()
+        logger.addHandler(worker_handler)
+
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
+
+
 def setup_task_logging(logger_name: Optional[str] = None) -> logging.Logger:
-    """Setup logging for core tasks to use the database-backed appdb handler."""
+    """Setup logging for core tasks to use the worker database log handler."""
 
     # Get logger
     if logger_name:
@@ -51,7 +90,7 @@ def setup_task_logging(logger_name: Optional[str] = None) -> logging.Logger:
     else:
         logger = logging.getLogger()
 
-    ensure_appdb_file_logging(logger)
+    ensure_worker_db_logging(logger)
 
     return logger
 


### PR DESCRIPTION
## Summary
- update the task logging helper to bind Celery loggers to the worker_log database handler
- remove legacy app-db handlers when configuring task loggers so worker entries are not duplicated
- extend the logging configuration tests to cover the new worker handler behaviour

## Testing
- pytest tests/test_logging_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d857c8eb7483239767f1f9928b6cfe