### PR TITLE
Restrict data files listing to system manage permission

### DIFF
--- a/tests/test_admin_data_files.py
+++ b/tests/test_admin_data_files.py
@@ -1,0 +1,83 @@
+import pytest
+
+from core.models.user import User, Role, Permission
+from webapp.extensions import db
+
+
+@pytest.fixture
+def client(app_context):
+    return app_context.test_client()
+
+
+def _login(client, user):
+    with client.session_transaction() as session:
+        session["_user_id"] = str(user.id)
+        session["_fresh"] = True
+
+
+def test_data_files_page_lists_current_files(client, tmp_path):
+    app = client.application
+
+    originals_dir = tmp_path / "media"
+    thumbs_dir = tmp_path / "thumbs"
+    playback_dir = tmp_path / "playback"
+    import_dir = tmp_path / "import"
+
+    for directory in (originals_dir, thumbs_dir, playback_dir, import_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (originals_dir / "2024" / "holiday").mkdir(parents=True)
+    original_file = originals_dir / "2024" / "holiday" / "photo1.jpg"
+    original_file.write_bytes(b"a" * 2048)
+
+    thumb_file = thumbs_dir / "256" / "2024" / "holiday" / "photo1.jpg"
+    thumb_file.parent.mkdir(parents=True, exist_ok=True)
+    thumb_file.write_bytes(b"b" * 512)
+
+    playback_file = playback_dir / "2024" / "holiday" / "photo1.mp4"
+    playback_file.parent.mkdir(parents=True, exist_ok=True)
+    playback_file.write_bytes(b"c" * 4096)
+
+    import_file = import_dir / "incoming" / "photo2.jpg"
+    import_file.parent.mkdir(parents=True, exist_ok=True)
+    import_file.write_bytes(b"d" * 256)
+
+    app.config["FPV_NAS_ORIGINALS_DIR"] = str(originals_dir)
+    app.config["FPV_NAS_THUMBS_DIR"] = str(thumbs_dir)
+    app.config["FPV_NAS_PLAY_DIR"] = str(playback_dir)
+    app.config["LOCAL_IMPORT_DIR"] = str(import_dir)
+
+    admin_role = Role(name="admin")
+    system_manage = Permission(code="system:manage")
+    db.session.add_all([admin_role, system_manage])
+    admin_role.permissions.append(system_manage)
+    admin_user = User(email="admin@example.com")
+    admin_user.set_password("secret")
+    admin_user.roles.append(admin_role)
+    db.session.add(admin_user)
+    db.session.commit()
+
+    _login(client, admin_user)
+
+    response = client.get("/admin/data-files")
+    assert response.status_code == 200
+
+    html = response.data.decode("utf-8")
+    assert "photo1.jpg" in html
+    assert "photo1.mp4" in html
+    assert "incoming/photo2.jpg" in html
+    assert str(originals_dir) in html
+    assert "2.0 KB" in html
+    assert "Data Files" in html
+
+
+def test_data_files_requires_system_manage_permission(client):
+    user = User(email="user@example.com")
+    user.set_password("secret")
+    db.session.add(user)
+    db.session.commit()
+
+    _login(client, user)
+
+    response = client.get("/admin/data-files")
+    assert response.status_code == 403

--- a/webapp/admin/templates/admin/data_files.html
+++ b/webapp/admin/templates/admin/data_files.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+
+{% block title %}{{ _('Data Files') }} - {{ _('AppName') }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">
+          <i class="bi bi-hdd-stack me-2"></i>
+          {{ _('Data Files in Use') }}
+        </h1>
+      </div>
+
+      {% if directories %}
+      <p class="text-muted">{{ _('Up to %(limit)d files are shown for each directory.', limit=directories[0].limit) }}</p>
+      {% endif %}
+
+      {% for directory in directories %}
+      <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <div>
+            <h2 class="h5 mb-0">{{ directory.label }}</h2>
+            <div class="small text-muted">{{ _('Config key: %(key)s', key=directory.config_key) }}</div>
+          </div>
+          {% if directory.exists %}
+          <span class="badge bg-success">{{ _('Found') }}</span>
+          {% else %}
+          <span class="badge bg-danger">{{ _('Missing') }}</span>
+          {% endif %}
+        </div>
+        <div class="card-body">
+          <p class="mb-2">
+            <strong>{{ _('Base path') }}:</strong>
+            {% if directory.base_path %}
+              <code>{{ directory.base_path }}</code>
+            {% else %}
+              <span class="text-muted">{{ _('Not configured') }}</span>
+            {% endif %}
+          </p>
+
+          {% if directory.candidates %}
+          <p class="mb-2">
+            <strong>{{ _('Candidate paths') }}:</strong>
+            {% for candidate in directory.candidates %}
+              <code class="me-2">{{ candidate }}</code>
+            {% endfor %}
+          </p>
+          {% endif %}
+
+          <p class="mb-3">
+            <span class="me-3">
+              <strong>{{ _('File count') }}:</strong>
+              {{ directory.total_files }}
+            </span>
+            <span>
+              <strong>{{ _('Total size') }}:</strong>
+              {{ directory.total_size_display }}
+            </span>
+          </p>
+
+          {% if not directory.exists %}
+          <div class="alert alert-warning mb-0">
+            {{ _('The directory does not exist. Please check the NAS mount or configuration.') }}
+          </div>
+          {% elif directory.total_files == 0 %}
+          <div class="alert alert-info mb-0">
+            {{ _('No files found in this directory.') }}
+          </div>
+          {% else %}
+          <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle">
+              <thead class="table-light">
+                <tr>
+                  <th scope="col">{{ _('Relative path') }}</th>
+                  <th scope="col" class="text-end">{{ _('Size') }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for file in directory.files %}
+                <tr>
+                  <td><code>{{ file.name }}</code></td>
+                  <td class="text-end"><span class="badge bg-secondary">{{ file.size_display }}</span></td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% if directory.truncated %}
+          <div class="alert alert-secondary mt-3 mb-0">
+            {{ _('Showing the first %(limit)d files. %(remaining)d additional files are not displayed.', limit=directory.limit, remaining=directory.remaining_count) }}
+          </div>
+          {% endif %}
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+
+      {% if not directories %}
+      <div class="alert alert-info">{{ _('No directory information is available.') }}</div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -57,12 +57,14 @@
       </ul>
       <ul class="navbar-nav">
         {% if current_user.is_authenticated %}
+          {% set show_system_manage = current_user.can('system:manage') %}
+          {% set show_admin_only = current_user.has_role('admin') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
             </a>
           </li>
-          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or current_user.has_role('admin') %}
+          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_system_manage or show_admin_only %}
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               {{ _('Management') }}
@@ -81,8 +83,18 @@
               {% if current_user.can('permission:manage') %}
               <li><a class="dropdown-item" href="{{ url_for('admin.permissions') }}">{{ _('Permissions') }}</a></li>
               {% endif %}
-              {% if current_user.has_role('admin') %}
+              {% if show_system_manage %}
               <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item" href="{{ url_for('admin.show_data_files') }}">
+                  <i class="bi bi-hdd-stack me-2"></i>{{ _('Data Files') }}
+                </a>
+              </li>
+              {% endif %}
+              {% if show_admin_only %}
+              {% if not show_system_manage %}
+              <li><hr class="dropdown-divider"></li>
+              {% endif %}
               <li><a class="dropdown-item" href="{{ url_for('photo_view.settings') }}">{{ _('Photo View Settings') }}</a></li>
               <li><a class="dropdown-item" href="{{ url_for('photo_view.admin_exports') }}">{{ _('Photo Exports') }}</a></li>
               {% endif %}


### PR DESCRIPTION
## Summary
- gate the admin data files route and navigation link behind the `system:manage` permission instead of only checking the admin role
- expose the management menu for users with the required permission and avoid duplicate dividers in the dropdown
- extend the admin data files test fixture to seed the permission and add a regression test covering the forbidden case

## Testing
- pytest tests/test_admin_data_files.py

------
https://chatgpt.com/codex/tasks/task_e_68df38c43cfc8323be9209473bda5517