### PR TITLE
Add CLI utility for inspecting Celery task statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ celery -A cli.src.celery.tasks worker --loglevel=info
 celery -A cli.src.celery.tasks beat --loglevel=info
 ```
 
+### 📊 Celeryタスクの状況確認
+アプリケーションのデータベースに保存されたCeleryタスクの状態は、次のヘルパースクリプトで一覧できます。
+
+```bash
+# 直近50件（デフォルト）のタスクをテーブル表示
+python -m cli.src.celery.inspect_tasks
+
+# 実行中・待機中タスクだけを確認
+python -m cli.src.celery.inspect_tasks --pending
+
+# JSON形式で全タスクを取得
+python -m cli.src.celery.inspect_tasks --json --limit 0
+```
+
+`--include-payload` や `--include-result` を付与すると、各レコードに保存されている詳細情報も確認できます。
+
 ### 初期ユーザー
 マスタデータ投入後、以下でログイン可能：
 - **Email**: `admin@example.com`

--- a/cli/src/celery/inspect_tasks.py
+++ b/cli/src/celery/inspect_tasks.py
@@ -1,0 +1,351 @@
+"""Utilities for inspecting Celery task records stored in the database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from datetime import datetime, timezone
+
+from sqlalchemy import func
+
+from core.db import db
+from core.models import CeleryTaskRecord, CeleryTaskStatus
+
+# Statuses that represent work that has not been finalized yet.
+PENDING_STATUSES: Tuple[CeleryTaskStatus, ...] = (
+    CeleryTaskStatus.SCHEDULED,
+    CeleryTaskStatus.QUEUED,
+    CeleryTaskStatus.RUNNING,
+)
+
+
+def _normalize_datetime(value: Optional[datetime]) -> Optional[str]:
+    """Return a human readable UTC timestamp string."""
+
+    if value is None:
+        return None
+
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.strftime("%Y-%m-%d %H:%M:%SZ")
+
+
+def _truncate(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1] + "…"
+
+
+def _json_snippet(data: Optional[Mapping[str, object]], *, max_length: int = 60) -> str:
+    if not data:
+        return "-"
+    text = json.dumps(data, ensure_ascii=False, sort_keys=True)
+    return _truncate(text, max_length)
+
+
+def _format_object_identity(object_type: Optional[str], object_id: Optional[str]) -> str:
+    if not object_type and not object_id:
+        return "-"
+    if not object_type:
+        return f"?:{object_id}"
+    if not object_id:
+        return f"{object_type}:?"
+    return f"{object_type}:{object_id}"
+
+
+def parse_status_filters(
+    status_values: Optional[Sequence[str]] = None,
+    *,
+    include_pending: bool = False,
+) -> List[CeleryTaskStatus]:
+    """Convert CLI status filters into :class:`CeleryTaskStatus` values."""
+
+    statuses: List[CeleryTaskStatus] = []
+
+    def _append(status: CeleryTaskStatus) -> None:
+        if status not in statuses:
+            statuses.append(status)
+
+    if status_values:
+        for raw in status_values:
+            if raw is None:
+                continue
+            text = raw.strip()
+            if not text:
+                continue
+            normalized = text.replace("-", "_").replace(" ", "_")
+            try:
+                status = CeleryTaskStatus[normalized.upper()]
+            except KeyError as exc:
+                for item in CeleryTaskStatus:
+                    if normalized.lower() == item.value.lower():
+                        status = item
+                        break
+                else:
+                    valid = ", ".join(s.value for s in CeleryTaskStatus)
+                    raise ValueError(
+                        f"Unknown status '{raw}'. Valid values are: {valid}."
+                    ) from exc
+            _append(status)
+
+    if include_pending:
+        for status in PENDING_STATUSES:
+            _append(status)
+
+    return statuses
+
+
+def _query_tasks(
+    statuses: Optional[Sequence[CeleryTaskStatus]] = None,
+    *,
+    limit: Optional[int] = None,
+) -> List[CeleryTaskRecord]:
+    query = CeleryTaskRecord.query.order_by(
+        CeleryTaskRecord.created_at.desc(),
+        CeleryTaskRecord.id.desc(),
+    )
+    if statuses:
+        query = query.filter(CeleryTaskRecord.status.in_(tuple(statuses)))
+    if limit and limit > 0:
+        query = query.limit(limit)
+    return list(query)
+
+
+def summarize_task_statuses() -> MutableMapping[str, int]:
+    """Return a mapping of ``status -> count`` including totals."""
+
+    results = (
+        db.session.query(CeleryTaskRecord.status, func.count(CeleryTaskRecord.id))
+        .group_by(CeleryTaskRecord.status)
+        .all()
+    )
+    summary: MutableMapping[str, int] = {status.value: count for status, count in results}
+    total = sum(summary.values())
+    for status in CeleryTaskStatus:
+        summary.setdefault(status.value, 0)
+    summary["total"] = total
+    return summary
+
+
+def _record_to_dict(
+    record: CeleryTaskRecord,
+    *,
+    include_payload: bool = False,
+    include_result: bool = False,
+) -> MutableMapping[str, object]:
+    data: MutableMapping[str, object] = {
+        "id": record.id,
+        "task_name": record.task_name,
+        "status": record.status.value,
+        "object_type": record.object_type,
+        "object_id": record.object_id,
+        "celery_task_id": record.celery_task_id,
+        "scheduled_for": _normalize_datetime(record.scheduled_for),
+        "created_at": _normalize_datetime(record.created_at),
+        "started_at": _normalize_datetime(record.started_at),
+        "finished_at": _normalize_datetime(record.finished_at),
+        "updated_at": _normalize_datetime(record.updated_at),
+        "error_message": record.error_message,
+    }
+    if include_payload:
+        data["payload"] = record.payload
+    if include_result:
+        data["result"] = record.result
+    return data
+
+
+def get_task_overview(
+    statuses: Optional[Sequence[CeleryTaskStatus]] = None,
+    *,
+    limit: Optional[int] = None,
+    include_payload: bool = False,
+    include_result: bool = False,
+) -> Tuple[MutableMapping[str, int], List[MutableMapping[str, object]]]:
+    """Return summary information and serialized task rows."""
+
+    records = _query_tasks(statuses, limit=limit)
+    serialized = [
+        _record_to_dict(
+            record,
+            include_payload=include_payload,
+            include_result=include_result,
+        )
+        for record in records
+    ]
+    summary = summarize_task_statuses()
+    return summary, serialized
+
+
+def format_tasks_table(
+    tasks: Sequence[Mapping[str, object]],
+    *,
+    include_payload: bool = False,
+    include_result: bool = False,
+) -> str:
+    """Render task information as a text table suitable for terminals."""
+
+    if not tasks:
+        return "No Celery task records found for the specified filters."
+
+    columns: List[Tuple[str, str]] = [
+        ("id", "ID"),
+        ("task_name", "Task"),
+        ("status", "Status"),
+        ("object", "Object"),
+        ("celery_task_id", "Celery ID"),
+        ("created_at", "Created"),
+        ("scheduled_for", "Scheduled"),
+        ("started_at", "Started"),
+        ("finished_at", "Finished"),
+        ("error_message", "Error"),
+    ]
+    if include_payload:
+        columns.append(("payload", "Payload"))
+    if include_result:
+        columns.append(("result", "Result"))
+
+    rows: List[List[str]] = []
+
+    for task in tasks:
+        row: List[str] = []
+        for key, _header in columns:
+            if key == "object":
+                value = _format_object_identity(
+                    task.get("object_type") if isinstance(task, Mapping) else None,
+                    task.get("object_id") if isinstance(task, Mapping) else None,
+                )
+            elif key == "payload":
+                value = _json_snippet(task.get("payload") if isinstance(task, Mapping) else None)
+            elif key == "result":
+                value = _json_snippet(task.get("result") if isinstance(task, Mapping) else None)
+            else:
+                raw = task.get(key) if isinstance(task, Mapping) else None
+                if raw is None:
+                    value = "-"
+                else:
+                    value = str(raw)
+                    if key == "error_message":
+                        value = _truncate(value, 80)
+            row.append(value)
+        rows.append(row)
+
+    widths = [
+        max(len(header), *(len(row[idx]) for row in rows)) for idx, (_key, header) in enumerate(columns)
+    ]
+
+    header_line = " | ".join(header.ljust(widths[idx]) for idx, (_key, header) in enumerate(columns))
+    separator_line = "-+-".join("-" * widths[idx] for idx in range(len(columns)))
+    data_lines = [
+        " | ".join(row[idx].ljust(widths[idx]) for idx in range(len(columns))) for row in rows
+    ]
+
+    return "\n".join([header_line, separator_line, *data_lines])
+
+
+def format_summary(summary: Mapping[str, int]) -> str:
+    """Render a textual summary of task counts."""
+
+    lines = ["Status summary:"]
+    for status in CeleryTaskStatus:
+        value = summary.get(status.value, 0)
+        lines.append(f"  {status.value:>8}: {value}")
+    total = summary.get("total", sum(summary.get(status.value, 0) for status in CeleryTaskStatus))
+    lines.append(f"  {'total':>8}: {total}")
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="List Celery task records stored in the application database.",
+    )
+    parser.add_argument(
+        "-s",
+        "--status",
+        dest="statuses",
+        action="append",
+        help=(
+            "Filter by task status. Can be provided multiple times. "
+            "Accepts names like 'queued', 'running', 'success', etc."
+        ),
+    )
+    parser.add_argument(
+        "--pending",
+        action="store_true",
+        help="Include pending statuses (scheduled, queued, running).",
+    )
+    parser.add_argument(
+        "-n",
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of task rows to include (default: 50). Use 0 for no limit.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of a formatted table.",
+    )
+    parser.add_argument(
+        "--include-payload",
+        action="store_true",
+        help="Include payload details in the output.",
+    )
+    parser.add_argument(
+        "--include-result",
+        action="store_true",
+        help="Include result details in the output.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        statuses = parse_status_filters(args.statuses, include_pending=args.pending)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    limit = args.limit if args.limit and args.limit > 0 else None
+
+    from webapp import create_app
+
+    app = create_app()
+
+    with app.app_context():
+        summary, tasks = get_task_overview(
+            statuses,
+            limit=limit,
+            include_payload=args.include_payload,
+            include_result=args.include_result,
+        )
+
+    if args.json:
+        payload = {
+            "summary": summary,
+            "tasks": tasks,
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(format_summary(summary))
+        print()
+        print(format_tasks_table(
+            tasks,
+            include_payload=args.include_payload,
+            include_result=args.include_result,
+        ))
+        if args.limit and args.limit > 0 and len(tasks) == args.limit:
+            print(
+                "\n(showing the most recent "
+                f"{args.limit} tasks; use --limit to adjust or 0 for all records)"
+            )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -389,6 +389,22 @@ redis-cli ping
 redis-cli llen celery
 ```
 
+#### 5.4.3 データベースに保存されたタスク一覧
+Celeryタスクの永続化テーブルに記録された内容を確認するには、次のスクリプトを使用します。
+
+```bash
+# 直近のタスク一覧を表形式で確認
+python -m cli.src.celery.inspect_tasks
+
+# 実行中・待機中タスクのみを抽出
+python -m cli.src.celery.inspect_tasks --pending
+
+# JSON形式で全件取得（監視ツール連携など）
+python -m cli.src.celery.inspect_tasks --json --limit 0
+```
+
+`--include-payload` や `--include-result` を付けると、レコードに保存された詳細JSONも出力されます。
+
 ### 5.5 Redis の起動確認（開発環境）
 
 CeleryのブローカーとしてRedisが必要です。

--- a/tests/test_task_inspector.py
+++ b/tests/test_task_inspector.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.db import db
+from core.models import CeleryTaskRecord, CeleryTaskStatus
+
+from cli.src.celery.inspect_tasks import (
+    PENDING_STATUSES,
+    format_summary,
+    format_tasks_table,
+    get_task_overview,
+    parse_status_filters,
+)
+
+
+class TestStatusParsing:
+    def test_parse_status_filters_accepts_values(self):
+        statuses = parse_status_filters(["queued", "SUCCESS"])
+        assert statuses == [CeleryTaskStatus.QUEUED, CeleryTaskStatus.SUCCESS]
+
+    def test_parse_status_filters_includes_pending_shortcut(self):
+        statuses = parse_status_filters(["success"], include_pending=True)
+        for status in PENDING_STATUSES:
+            assert status in statuses
+        assert CeleryTaskStatus.SUCCESS in statuses
+
+    def test_parse_status_filters_rejects_unknown_value(self):
+        with pytest.raises(ValueError):
+            parse_status_filters(["not-a-status"])
+
+
+class TestTaskOverview:
+    def _create_task(
+        self,
+        *,
+        name: str,
+        status: CeleryTaskStatus,
+        created_at: datetime,
+        object_type: str | None = None,
+        object_id: str | None = None,
+        celery_id: str | None = None,
+        scheduled_for: datetime | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+        error_message: str | None = None,
+    ) -> CeleryTaskRecord:
+        record = CeleryTaskRecord(
+            task_name=name,
+            status=status,
+            object_type=object_type,
+            object_id=object_id,
+            celery_task_id=celery_id,
+            scheduled_for=scheduled_for,
+            started_at=started_at,
+            finished_at=finished_at,
+            error_message=error_message,
+        )
+        record.created_at = created_at
+        record.updated_at = created_at
+        return record
+
+    def test_get_task_overview_filters_and_serializes(self, app_context):
+        now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        with app_context.app_context():
+            queued = self._create_task(
+                name="task.alpha",
+                status=CeleryTaskStatus.QUEUED,
+                created_at=now,
+                object_type="media",
+                object_id="42",
+                celery_id="celery-1",
+                scheduled_for=now + timedelta(minutes=5),
+                started_at=now + timedelta(minutes=1),
+            )
+            queued.set_payload({"foo": "bar"})
+
+            success = self._create_task(
+                name="task.beta",
+                status=CeleryTaskStatus.SUCCESS,
+                created_at=now - timedelta(minutes=1),
+                celery_id="celery-2",
+            )
+            success.set_result({"ok": True})
+
+            failed = self._create_task(
+                name="task.gamma",
+                status=CeleryTaskStatus.FAILED,
+                created_at=now - timedelta(minutes=2),
+                error_message="boom",
+            )
+
+            db.session.add_all([queued, success, failed])
+            db.session.commit()
+
+            summary, tasks = get_task_overview(
+                [CeleryTaskStatus.QUEUED, CeleryTaskStatus.SUCCESS],
+                include_payload=True,
+                include_result=True,
+            )
+
+            assert [task["task_name"] for task in tasks] == ["task.alpha", "task.beta"]
+            assert tasks[0]["payload"] == {"foo": "bar"}
+            assert tasks[1]["result"] == {"ok": True}
+            assert summary["queued"] == 1
+            assert summary["failed"] == 1
+            assert summary["total"] == 3
+
+            limited_summary, limited_tasks = get_task_overview(limit=1)
+            assert len(limited_tasks) == 1
+            assert limited_tasks[0]["task_name"] == "task.alpha"
+            assert "payload" not in limited_tasks[0]
+            assert limited_summary["total"] == 3
+
+    def test_format_tasks_table_output(self):
+        task = {
+            "id": 1,
+            "task_name": "task.alpha",
+            "status": "queued",
+            "object_type": "media",
+            "object_id": "42",
+            "celery_task_id": "celery-1",
+            "created_at": "2024-01-01 12:00:00Z",
+            "scheduled_for": "2024-01-01 12:05:00Z",
+            "started_at": "2024-01-01 12:01:00Z",
+            "finished_at": None,
+            "error_message": "this is a very long error message that should be truncated" + "!" * 80,
+            "payload": {"foo": "bar"},
+            "result": {"ok": True},
+        }
+
+        table = format_tasks_table([task], include_payload=True, include_result=True)
+        lines = table.splitlines()
+        assert lines[0].startswith("ID")
+        assert "task.alpha" in table
+        assert "media:42" in table
+        assert "foo" in table
+        assert "…" in table  # truncated error
+
+        empty = format_tasks_table([], include_payload=False, include_result=False)
+        assert "No Celery task records" in empty
+
+    def test_format_summary_lists_all_statuses(self):
+        summary = {"queued": 2, "success": 5, "total": 10}
+        text = format_summary(summary)
+        for status in CeleryTaskStatus:
+            assert status.value in text
+        assert text.strip().splitlines()[-1].endswith("total: 10")


### PR DESCRIPTION
## Summary
- add a CLI helper (`python -m cli.src.celery.inspect_tasks`) that reads Celery task records, prints summaries, and supports JSON output
- cover the helper with focused unit tests for status parsing, serialization, and formatting
- document the new inspection workflow in README.md and docs/DEVELOPMENT.md

## Testing
- pytest tests/test_task_inspector.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e057afa47883238b9017b8412faa68