### PR TITLE
Include stored file paths in local import logs

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -128,6 +128,23 @@ def _with_session(details: Dict[str, Any], session_id: Optional[str]) -> Dict[st
     return merged
 
 
+def _file_log_context(file_path: Optional[str], filename: Optional[str] = None) -> Dict[str, Any]:
+    """ファイル関連ログに共通のコンテキストを生成する。"""
+
+    context: Dict[str, Any] = {}
+
+    if file_path:
+        context["file"] = file_path
+        context["file_path"] = file_path
+        if filename and filename != os.path.basename(file_path):
+            context["source_filename"] = filename
+    elif filename:
+        context["file"] = filename
+        context["source_filename"] = filename
+
+    return context
+
+
 def _log_info(
     event: str,
     message: str,
@@ -966,11 +983,13 @@ def import_single_file(
         "media_google_id": None,
         "metadata_refreshed": False,
     }
-    
+
+    file_context = _file_log_context(file_path)
+
     _log_info(
         "local_import.file.begin",
         "ローカルファイルの取り込みを開始",
-        file_path=file_path,
+        **file_context,
         import_dir=import_dir,
         originals_dir=originals_dir,
         session_id=session_id,
@@ -984,7 +1003,7 @@ def import_single_file(
             _log_warning(
                 "local_import.file.missing",
                 "取り込み対象ファイルが見つかりません",
-                file_path=file_path,
+                **file_context,
                 session_id=session_id,
                 status="missing",
             )
@@ -997,7 +1016,7 @@ def import_single_file(
             _log_warning(
                 "local_import.file.unsupported",
                 "サポート対象外拡張子のためスキップ",
-                file_path=file_path,
+                **file_context,
                 extension=file_extension,
                 session_id=session_id,
                 status="unsupported",
@@ -1011,7 +1030,7 @@ def import_single_file(
             _log_warning(
                 "local_import.file.empty",
                 "ファイルサイズが0のためスキップ",
-                file_path=file_path,
+                **file_context,
                 session_id=session_id,
                 status="skipped",
             )
@@ -1039,7 +1058,7 @@ def import_single_file(
                 _log_error(
                     "local_import.file.duplicate_refresh_failed",
                     "重複ファイルのメタデータ更新中にエラーが発生",
-                    file_path=file_path,
+                    **file_context,
                     media_id=existing_media.id,
                     error_type=type(refresh_exc).__name__,
                     error_message=str(refresh_exc),
@@ -1055,7 +1074,7 @@ def import_single_file(
                     _log_info(
                         "local_import.file.duplicate_refreshed",
                         "重複ファイルから既存メディアのメタデータを更新",
-                        file_path=file_path,
+                        **file_context,
                         media_id=existing_media.id,
                         session_id=session_id,
                         status="duplicate_refreshed",
@@ -1065,7 +1084,7 @@ def import_single_file(
                         _log_info(
                             "local_import.file.duplicate_source_removed",
                             "重複ファイルのソースを削除",
-                            file_path=file_path,
+                            **file_context,
                             media_id=existing_media.id,
                             session_id=session_id,
                             status="cleaned",
@@ -1076,7 +1095,7 @@ def import_single_file(
                         _log_warning(
                             "local_import.file.duplicate_source_remove_failed",
                             "重複ファイル削除に失敗",
-                            file_path=file_path,
+                            **file_context,
                             media_id=existing_media.id,
                             error_type=type(cleanup_exc).__name__,
                             error_message=str(cleanup_exc),
@@ -1087,7 +1106,7 @@ def import_single_file(
                     _log_info(
                         "local_import.file.duplicate",
                         "重複ファイルを検出したためスキップ",
-                        file_path=file_path,
+                        **file_context,
                         media_id=existing_media.id,
                         session_id=session_id,
                         status="duplicate",
@@ -1133,6 +1152,9 @@ def import_single_file(
         new_filename = generate_filename(shot_at, file_extension, file_hash)
         rel_path = get_relative_path(shot_at, new_filename)
         dest_path = os.path.join(originals_dir, rel_path)
+        result["stored_relative_path"] = rel_path
+        result["stored_file_path"] = dest_path
+        result["stored_filename"] = new_filename
         
         # ディレクトリ作成
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
@@ -1166,8 +1188,11 @@ def import_single_file(
         _log_info(
             "local_import.file.copied",
             "ファイルを保存先にコピーしました",
-            file_path=file_path,
+            **file_context,
             destination=dest_path,
+            stored_file_path=dest_path,
+            stored_filename=new_filename,
+            stored_relative_path=rel_path,
             session_id=session_id,
             status="copied",
         )
@@ -1243,7 +1268,7 @@ def import_single_file(
                     _log_warning(
                         "local_import.file.playback_skipped",
                         "動画の再生ファイル生成をスキップ",
-                        file_path=file_path,
+                        **file_context,
                         media_id=media.id,
                         note=note,
                         session_id=session_id,
@@ -1283,7 +1308,7 @@ def import_single_file(
         _log_info(
             "local_import.file.source_removed",
             "取り込み完了後に元ファイルを削除",
-            file_path=file_path,
+            **file_context,
             session_id=session_id,
             status="cleaned",
         )
@@ -1296,9 +1321,12 @@ def import_single_file(
         _log_info(
             "local_import.file.success",
             "ローカルファイルの取り込みが完了",
-            file_path=file_path,
+            **file_context,
             media_id=media.id,
             relative_path=rel_path,
+            stored_file_path=dest_path,
+            stored_filename=new_filename,
+            stored_relative_path=rel_path,
             session_id=session_id,
             status="success",
         )
@@ -1308,7 +1336,7 @@ def import_single_file(
         _log_error(
             "local_import.file.failed",
             "ローカルファイル取り込み中にエラーが発生",
-            file_path=file_path,
+            **file_context,
             error_type=type(e).__name__,
             error_message=str(e),
             exc_info=True,
@@ -1353,6 +1381,7 @@ def scan_import_directory(import_dir: str, *, session_id: Optional[str] = None) 
         for filename in filenames:
             file_path = os.path.join(root, filename)
             file_extension = Path(filename).suffix.lower()
+            file_context = _file_log_context(file_path, filename)
 
             if file_extension in SUPPORTED_EXTENSIONS:
                 files.append(file_path)
@@ -1361,7 +1390,7 @@ def scan_import_directory(import_dir: str, *, session_id: Optional[str] = None) 
                     "取り込み対象ファイルを検出",
                     session_id=session_id,
                     status="scanning",
-                    file_path=file_path,
+                    **file_context,
                     extension=file_extension,
                 )
             elif file_extension == ".zip":
@@ -1380,7 +1409,7 @@ def scan_import_directory(import_dir: str, *, session_id: Optional[str] = None) 
                     "サポート対象外のファイルをスキップ",
                     session_id=session_id,
                     status="skipped",
-                    file_path=file_path,
+                    **file_context,
                     extension=file_extension,
                 )
 
@@ -1511,6 +1540,7 @@ def _enqueue_local_import_selections(
     enqueued = 0
     for file_path in file_paths:
         filename = os.path.basename(file_path)
+        file_context = _file_log_context(file_path, filename)
         selection = existing.get(file_path)
         if selection is None:
             selection = PickerSelection(
@@ -1529,7 +1559,7 @@ def _enqueue_local_import_selections(
                 "local_import.selection.created",
                 "取り込み対象ファイルのSelectionを作成",
                 session_db_id=session.id,
-                file_path=file_path,
+                **file_context,
                 selection_id=selection.id,
                 session_id=active_session_id,
                 celery_task_id=celery_task_id,
@@ -1546,7 +1576,7 @@ def _enqueue_local_import_selections(
                 "local_import.selection.requeued",
                 "既存Selectionを再キュー",
                 session_db_id=session.id,
-                file_path=file_path,
+                **file_context,
                 selection_id=selection.id,
                 session_id=active_session_id,
                 celery_task_id=celery_task_id,
@@ -1619,6 +1649,8 @@ def _process_local_import_queue(
     for index, selection in enumerate(selections, 1):
         file_path = selection.local_file_path
         filename = selection.local_filename or (os.path.basename(file_path) if file_path else f"selection_{selection.id}")
+        file_context = _file_log_context(file_path, filename)
+        display_file = file_context.get("file") or filename
 
         if _session_cancel_requested(session, task_instance=task_instance):
             _log_info(
@@ -1654,7 +1686,7 @@ def _process_local_import_queue(
                 "local_import.selection.running",
                 "Selectionを処理中に更新",
                 selection_id=selection.id,
-                file_path=file_path,
+                **file_context,
                 session_id=active_session_id,
                 celery_task_id=celery_task_id,
             )
@@ -1664,7 +1696,7 @@ def _process_local_import_queue(
                 "local_import.selection.running_update_failed",
                 "Selectionを処理中に更新できませんでした",
                 selection_id=getattr(selection, "id", None),
-                file_path=file_path,
+                **file_context,
                 error_type=type(exc).__name__,
                 error_message=str(exc),
                 session_id=active_session_id,
@@ -1679,11 +1711,20 @@ def _process_local_import_queue(
         )
 
         detail = {
-            "file": filename,
+            "file": display_file,
             "status": "success" if file_result["success"] else "failed",
             "reason": file_result["reason"],
             "media_id": file_result.get("media_id"),
         }
+        stored_path = file_result.get("stored_file_path")
+        stored_relative_path = file_result.get("stored_relative_path")
+        stored_filename = file_result.get("stored_filename")
+        if stored_path:
+            detail["stored_file_path"] = stored_path
+        if stored_relative_path:
+            detail["stored_relative_path"] = stored_relative_path
+        if stored_filename:
+            detail["stored_filename"] = stored_filename
         result["details"].append(detail)
 
         try:
@@ -1698,8 +1739,11 @@ def _process_local_import_queue(
                 _log_info(
                     "local_import.file.processed_success",
                     "ファイルの取り込みに成功",
-                    file_path=file_path,
+                    **file_context,
                     media_id=file_result.get("media_id"),
+                    stored_file_path=stored_path,
+                    stored_relative_path=stored_relative_path,
+                    stored_filename=stored_filename,
                     session_id=active_session_id,
                     celery_task_id=celery_task_id,
                 )
@@ -1716,7 +1760,7 @@ def _process_local_import_queue(
                             _log_info(
                                 "local_import.file.duplicate_cleanup",
                                 "重複ファイルの元ファイルを削除",
-                                file_path=file_path,
+                                **file_context,
                                 session_id=active_session_id,
                                 celery_task_id=celery_task_id,
                             )
@@ -1724,7 +1768,7 @@ def _process_local_import_queue(
                         _log_warning(
                             "local_import.file.duplicate_cleanup_failed",
                             "重複ファイルの削除に失敗",
-                            file_path=file_path,
+                            **file_context,
                             session_id=active_session_id,
                             celery_task_id=celery_task_id,
                         )
@@ -1734,11 +1778,11 @@ def _process_local_import_queue(
                     selection.finished_at = datetime.now(timezone.utc)
                     selection.attempts = (selection.attempts or 0) + 1
                     result["failed"] += 1
-                    result["errors"].append(f"{file_path}: {reason}")
+                    result["errors"].append(f"{display_file}: {reason}")
                     _log_warning(
                         "local_import.file.processed_failed",
                         "ファイルの取り込みに失敗",
-                        file_path=file_path,
+                        **file_context,
                         reason=reason,
                         session_id=active_session_id,
                         celery_task_id=celery_task_id,
@@ -1749,7 +1793,7 @@ def _process_local_import_queue(
                 "local_import.selection.updated",
                 "Selectionの状態を更新",
                 selection_id=selection.id,
-                file_path=file_path,
+                **file_context,
                 status=selection.status,
                 session_id=active_session_id,
                 celery_task_id=celery_task_id,
@@ -1759,7 +1803,7 @@ def _process_local_import_queue(
             _log_error(
                 "local_import.selection.update_failed",
                 "Selectionの状態更新に失敗",
-                file_path=file_path,
+                **file_context,
                 selection_id=getattr(selection, "id", None),
                 error_type=type(e).__name__,
                 error_message=str(e),
@@ -1772,7 +1816,7 @@ def _process_local_import_queue(
             task_instance.update_state(
                 state="PROGRESS",
                 meta={
-                    "status": f"ファイル処理中: {filename}",
+                    "status": f"ファイル処理中: {display_file}",
                     "progress": progress,
                     "current": index,
                     "total": total_files,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ ALWAYS_RUN = {
     "tests/test_picker_session_service_local_import.py",
     "tests/test_local_import_duplicate_refresh.py",
     "tests/test_local_import.py",
+    "tests/test_local_import_ui.py",
 }
 
 

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -2,8 +2,10 @@
 ローカルインポートのSession Detail UI テスト
 """
 
+import importlib
 import json
 import os
+import shutil
 import tempfile
 import zipfile
 from datetime import datetime, timezone
@@ -12,12 +14,13 @@ from unittest.mock import patch
 
 import pytest
 
+import webapp.config as config_module
 from webapp import create_app
 from webapp.extensions import db
 from core.models.picker_session import PickerSession
 from core.models.photo_models import PickerSelection
 from core.models.log import Log
-from core.tasks.local_import import local_import_task
+from core.tasks import local_import as local_import_module
 
 
 @pytest.fixture
@@ -50,15 +53,23 @@ def app():
         for key, value in test_config.items():
             old_env[key] = os.environ.get(key)
             os.environ[key] = str(value)
-        
+
         try:
+            importlib.reload(config_module)
+            importlib.reload(local_import_module)
             app = create_app()
             app.config.update(test_config)
-            
+
             with app.app_context():
+                logger_obj = getattr(local_import_module, "logger", None)
+                if logger_obj is not None:
+                    for handler in getattr(logger_obj, "handlers", []):
+                        bind = getattr(handler, "bind_to_app", None)
+                        if callable(bind):
+                            bind(app)
                 db.create_all()
                 yield app
-                
+
         finally:
             # 環境変数を復元
             for key, old_value in old_env.items():
@@ -81,7 +92,7 @@ class TestSessionDetailAPI:
         
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
         
         # セッション一覧API呼び出し
@@ -113,7 +124,7 @@ class TestSessionDetailAPI:
         
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
         
         # セッション状態API呼び出し
@@ -140,7 +151,7 @@ class TestSessionDetailAPI:
 
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
 
         # セッション選択一覧API呼び出し
@@ -178,7 +189,7 @@ class TestSessionDetailAPI:
             sess['_fresh'] = True
 
         with app.app_context():
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
             picker_session = PickerSession.query.filter_by(session_id=session_id).first()
             selection = PickerSelection.query.filter_by(session_id=picker_session.id).first()
@@ -231,7 +242,7 @@ class TestSessionDetailAPI:
             sess['_fresh'] = True
 
         with app.app_context():
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
 
         response = client.get(f'/api/picker/session/{session_id}/logs?limit=50')
@@ -243,6 +254,72 @@ class TestSessionDetailAPI:
         assert logs, '少なくとも1件のログが返されること'
         assert all('status' in entry for entry in logs)
         assert any(entry.get('status') for entry in logs)
+
+    def test_session_logs_include_full_file_path(self, app):
+        """ログにフルパスのファイル情報が含まれることを確認"""
+
+        client = app.test_client()
+
+        with client.session_transaction() as sess:
+            sess['_user_id'] = '1'
+            sess['_fresh'] = True
+
+        import_dir = Path(app.config['LOCAL_IMPORT_DIR'])
+
+        # 既存ファイルをクリーンアップ
+        for child in list(import_dir.iterdir()):
+            if child.is_file():
+                child.unlink()
+            elif child.is_dir():
+                shutil.rmtree(child)
+
+        nested_dir = import_dir / 'nested'
+        nested_dir.mkdir(parents=True, exist_ok=True)
+        target_file = nested_dir / 'full_path_test.jpg'
+        target_file.write_bytes(b'log-path-test')
+
+        with app.app_context():
+            result = local_import_module.local_import_task()
+            session_id = result['session_id']
+
+        target_path_str = str(target_file)
+
+        detail_entry = next(
+            (detail for detail in result['details'] if detail.get('file') == target_path_str),
+            None,
+        )
+        assert detail_entry is not None, '結果詳細に対象ファイルが含まれていること'
+
+        originals_dir = Path(app.config['FPV_NAS_ORIGINALS_DIR'])
+        stored_files = [p for p in originals_dir.rglob('*') if p.is_file()]
+        assert len(stored_files) == 1, '保存先に1件のファイルが存在すること'
+        stored_path = stored_files[0]
+
+        assert detail_entry.get('stored_file_path') == str(stored_path)
+        assert detail_entry.get('stored_filename') == stored_path.name
+        assert detail_entry.get('stored_relative_path') == str(stored_path.relative_to(originals_dir))
+
+        response = client.get(f'/api/picker/session/{session_id}/logs?limit=50')
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        logs = payload.get('logs', [])
+
+        success_entries = [
+            entry for entry in logs if entry.get('event') == 'local_import.file.processed_success'
+        ]
+        assert success_entries, '成功ログが少なくとも1件含まれていること'
+
+        matched_entry = next(
+            (entry for entry in success_entries if entry.get('details', {}).get('file') == target_path_str),
+            None,
+        )
+        assert matched_entry is not None, 'ログにフルパスが含まれていること'
+        log_details = matched_entry.get('details', {})
+        assert log_details.get('file_path') == target_path_str
+        assert log_details.get('stored_file_path') == str(stored_path)
+        assert log_details.get('stored_filename') == stored_path.name
+        assert log_details.get('stored_relative_path') == str(stored_path.relative_to(originals_dir))
     
     def test_session_import_api_blocked_for_local_import(self, app):
         """ローカルインポートセッションでインポートAPIがブロックされることをテスト"""
@@ -254,7 +331,7 @@ class TestSessionDetailAPI:
         
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
         
         # インポートAPI呼び出し（ローカルインポートセッションでは無効）
@@ -335,7 +412,7 @@ class TestSessionDetailAPI:
             archive.writestr("images/inside.jpg", b"fake image data")
 
         with app.app_context():
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
 
         response = client.get(f'/api/picker/session/{session_id}/logs?limit=20')
@@ -367,7 +444,7 @@ class TestSessionDetailUI:
         
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
         
         # セッション詳細ページ呼び出し
@@ -395,7 +472,7 @@ class TestSessionDetailUI:
         
         with app.app_context():
             # ローカルインポート実行
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
         
         # ホームページ呼び出し
@@ -430,7 +507,7 @@ class TestLocalImportIntegration:
         
         # 2. ローカルインポート実行
         with app.app_context():
-            result = local_import_task()
+            result = local_import_module.local_import_task()
             session_id = result['session_id']
             assert result['ok'] is True
             assert result['success'] == 1


### PR DESCRIPTION
## Summary
- add stored file path, filename, and relative path to local import results and logging instead of only returning the basename
- expose the original source filename separately in the shared file log context
- extend the local import UI test to validate the stored file metadata in task results and log API responses

## Testing
- pytest tests/test_local_import_ui.py::TestSessionDetailAPI::test_session_logs_include_status -q
- pytest tests/test_local_import_ui.py::TestSessionDetailAPI::test_session_logs_include_full_file_path -q
- pytest tests/test_picker_session_service_local_import.py::TestPickerSessionServiceLocalImport::test_selection_details_for_local_import -q

------
https://chatgpt.com/codex/tasks/task_e_68e057335a048323b9bd824347ca52d1