### PR TITLE
Log imported file path during local import

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -1159,6 +1159,7 @@ def import_single_file(
         new_filename = generate_filename(shot_at, file_extension, file_hash)
         rel_path = get_relative_path(shot_at, new_filename)
         dest_path = os.path.join(originals_dir, rel_path)
+        imported_filename = new_filename
         
         # ディレクトリ作成
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
@@ -1194,6 +1195,8 @@ def import_single_file(
             "ファイルを保存先にコピーしました",
             **file_context,
             destination=dest_path,
+            imported_path=dest_path,
+            imported_filename=imported_filename,
             session_id=session_id,
             status="copied",
         )
@@ -1318,6 +1321,8 @@ def import_single_file(
         result["media_id"] = media.id
         result["media_google_id"] = media.google_media_id
         result["reason"] = "取り込み成功"
+        result["imported_filename"] = imported_filename
+        result["imported_path"] = dest_path
 
         _log_info(
             "local_import.file.success",
@@ -1325,6 +1330,8 @@ def import_single_file(
             **file_context,
             media_id=media.id,
             relative_path=rel_path,
+            imported_path=dest_path,
+            imported_filename=imported_filename,
             session_id=session_id,
             status="success",
         )

--- a/tests/test_video_import.py
+++ b/tests/test_video_import.py
@@ -113,6 +113,8 @@ def _import_video(
     media = Media.query.get(result["media_id"])
     assert media is not None
     assert media.google_media_id == result["media_google_id"]
+    assert result["imported_filename"] == Path(media.local_rel_path).name
+    assert Path(result["imported_path"]) == originals_dir / media.local_rel_path
 
     media_item = MediaItem.query.get(media.google_media_id)
     assert media_item is not None


### PR DESCRIPTION
## Summary
- add imported file path and filename to local import logging and result payloads
- extend video import test to verify the new result fields

## Testing
- pytest tests/test_video_import.py::test_local_import_mp4_video -q

------
https://chatgpt.com/codex/tasks/task_e_68e06ddd95188323a943246507e4a4c0