### PR TITLE
Log duplicate import destinations

### DIFF
--- a/tests/test_local_import_duplicate_refresh.py
+++ b/tests/test_local_import_duplicate_refresh.py
@@ -103,6 +103,9 @@ def test_duplicate_import_refreshes_metadata(monkeypatch, tmp_path, app_context)
     assert media.height == 720
     assert media.orientation == 6
     stored_original = originals_dir / media.local_rel_path
+    assert second["imported_path"] == str(stored_original)
+    assert second["relative_path"] == media.local_rel_path
+    assert second["imported_filename"] == media.filename
     assert stored_original.exists()
     assert media.hash_sha256 == local_import.calculate_file_hash(str(stored_original))
     assert media.bytes == stored_original.stat().st_size


### PR DESCRIPTION
## Summary
- include destination path details when logging duplicate local import entries
- expose stored file information in duplicate import results for easier diagnostics
- extend the duplicate refresh test to cover the new metadata fields

## Testing
- pytest tests/test_local_import_duplicate_refresh.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e07a1011b48323aba050edc8e13dee