### PR TITLE
Ensure relative path is exposed for local imports

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -1240,6 +1240,7 @@ def import_single_file(
             destination=dest_path,
             imported_path=dest_path,
             imported_filename=imported_filename,
+            relative_path=rel_path,
             session_id=session_id,
             status="copied",
         )
@@ -1366,6 +1367,7 @@ def import_single_file(
         result["reason"] = "取り込み成功"
         result["imported_filename"] = imported_filename
         result["imported_path"] = dest_path
+        result["relative_path"] = rel_path
 
         _log_info(
             "local_import.file.success",

--- a/tests/test_local_import_duplicate_refresh.py
+++ b/tests/test_local_import_duplicate_refresh.py
@@ -73,6 +73,7 @@ def test_duplicate_import_refreshes_metadata(monkeypatch, tmp_path, app_context)
     assert media.width == 640
     assert media.height == 480
     assert media.orientation == 1
+    assert first["relative_path"] == media.local_rel_path
 
     exif = Exif.query.get(media.id)
     assert exif.camera_make == "BugCam"

--- a/tests/test_video_import.py
+++ b/tests/test_video_import.py
@@ -115,6 +115,7 @@ def _import_video(
     assert media.google_media_id == result["media_google_id"]
     assert result["imported_filename"] == Path(media.local_rel_path).name
     assert Path(result["imported_path"]) == originals_dir / media.local_rel_path
+    assert result["relative_path"] == media.local_rel_path
 
     media_item = MediaItem.query.get(media.google_media_id)
     assert media_item is not None


### PR DESCRIPTION
## Summary
- include the relative_path value in the local import copy log payload
- store the relative_path in the per-file import result so callers always receive it
- extend local import tests to assert the relative path is returned for new imports

## Testing
- pytest tests/test_video_import.py tests/test_local_import_duplicate_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68e0dd23a1848323a4c96e734780bc07