### PR TITLE
Ensure playback files use container storage path

### DIFF
--- a/core/storage_paths.py
+++ b/core/storage_paths.py
@@ -122,3 +122,20 @@ def ensure_directory(path: str | Path) -> Path:
     directory = Path(path)
     directory.mkdir(parents=True, exist_ok=True)
     return directory
+
+
+def ensure_preferred_storage_path(config_key: str) -> Path:
+    """Ensure and return the highest priority storage path for *config_key*."""
+
+    last_error: OSError | None = None
+    for candidate in storage_path_candidates(config_key):
+        try:
+            return ensure_directory(candidate)
+        except OSError as exc:  # pragma: no cover - defensive
+            last_error = exc
+            continue
+
+    if last_error:
+        raise last_error
+
+    raise RuntimeError(f"No storage directory candidates available for {config_key}")

--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 
 from core.db import db
 from core.models.photo_models import Media, MediaPlayback
-from core.storage_paths import ensure_directory, first_existing_storage_path
+from core.storage_paths import ensure_preferred_storage_path, first_existing_storage_path
 from .thumbs_generate import thumbs_generate
 
 # transcode専用ロガーを取得（両方のログハンドラーが設定済み）
@@ -49,10 +49,7 @@ def _orig_dir() -> Path:
 
 
 def _play_dir() -> Path:
-    base = first_existing_storage_path("FPV_NAS_PLAY_DIR")
-    if not base:
-        base = "/tmp/fpv_play"
-    return ensure_directory(base)
+    return ensure_preferred_storage_path("FPV_NAS_PLAY_DIR")
 
 
 def _tmp_dir() -> Path:

--- a/tests/test_storage_paths.py
+++ b/tests/test_storage_paths.py
@@ -1,0 +1,29 @@
+from core.storage_paths import ensure_preferred_storage_path
+
+
+def test_ensure_preferred_storage_path_prefers_first_candidate(tmp_path, monkeypatch):
+    preferred = tmp_path / "preferred"
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+
+    monkeypatch.setenv("FPV_NAS_PLAY_CONTAINER_DIR", str(preferred))
+    monkeypatch.setenv("FPV_NAS_PLAY_DIR", str(fallback))
+
+    resolved = ensure_preferred_storage_path("FPV_NAS_PLAY_DIR")
+
+    assert resolved == preferred
+    assert preferred.is_dir()
+
+
+def test_ensure_preferred_storage_path_uses_fallback_on_error(tmp_path, monkeypatch):
+    invalid = tmp_path / "invalid"
+    invalid.write_text("conflict")
+    fallback = tmp_path / "fallback"
+
+    monkeypatch.setenv("FPV_NAS_THUMBS_CONTAINER_DIR", str(invalid))
+    monkeypatch.setenv("FPV_NAS_THUMBS_DIR", str(fallback))
+
+    resolved = ensure_preferred_storage_path("FPV_NAS_THUMBS_DIR")
+
+    assert resolved == fallback
+    assert fallback.is_dir()


### PR DESCRIPTION
## Summary
- add a helper to ensure the highest priority storage directory is created
- update the transcoding worker to always write playback files into the preferred path
- cover the new helper with unit tests to exercise fallback handling

## Testing
- pytest tests/test_storage_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68e19b9136f083239c7156e3c0ac7967