### PR TITLE
Refactor local import task into domain-oriented services

### DIFF
--- a/domain/local_import/entities.py
+++ b/domain/local_import/entities.py
@@ -1,0 +1,49 @@
+"""ローカルインポートで利用する値オブジェクトとエンティティ。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class ImportFile:
+    """取り込み対象ファイルを表現する値オブジェクト。"""
+
+    absolute_path: str
+
+    @property
+    def path(self) -> Path:
+        return Path(self.absolute_path)
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+    @property
+    def extension(self) -> str:
+        return self.path.suffix.lower()
+
+
+@dataclass
+class ImportOutcome:
+    """ファイル取り込み結果を保持するドメインエンティティ。"""
+
+    source: ImportFile
+    status: str = "pending"
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def mark(self, status: str, **fields: Any) -> None:
+        self.status = status
+        if fields:
+            self.details.update(fields)
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = dict(self.details)
+        payload.setdefault("status", self.status)
+        return payload
+
+
+__all__ = ["ImportFile", "ImportOutcome"]
+

--- a/domain/local_import/logging.py
+++ b/domain/local_import/logging.py
@@ -1,0 +1,110 @@
+"""ローカルインポート処理のための共通ロギングユーティリティ。"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+def serialize_details(details: Dict[str, Any]) -> str:
+    """詳細情報をJSON文字列へ変換。失敗時は文字列表現を返す。"""
+
+    if not details:
+        return ""
+
+    try:
+        return json.dumps(details, ensure_ascii=False, default=str)
+    except TypeError:
+        return str(details)
+
+
+def compose_message(
+    message: str,
+    details: Dict[str, Any],
+    status: Optional[str] = None,
+) -> str:
+    """メッセージと詳細を結合してログに出力する文字列を生成。"""
+
+    payload = details
+    if status is not None:
+        payload = dict(details)
+        payload.setdefault("status", status)
+
+    serialized = serialize_details(payload)
+    if not serialized:
+        return message
+    return f"{message} | details={serialized}"
+
+
+def with_session(details: Dict[str, Any], session_id: Optional[str]) -> Dict[str, Any]:
+    """ログ詳細に session_id を追加した辞書を返す。"""
+
+    merged = dict(details)
+    if session_id is not None and "session_id" not in merged:
+        merged["session_id"] = session_id
+    return merged
+
+
+def file_log_context(file_path: Optional[str], filename: Optional[str] = None) -> Dict[str, Any]:
+    """ファイル関連ログに共通のコンテキストを生成する。"""
+
+    context: Dict[str, Any] = {}
+    base_name = filename
+
+    if not base_name and file_path:
+        base_name = file_path.split("/")[-1]
+
+    display_value = file_path or base_name
+
+    if display_value:
+        context["file"] = display_value
+
+    if file_path:
+        context["file_path"] = file_path
+        if base_name and base_name != file_path:
+            context["basename"] = base_name
+    elif base_name:
+        context["basename"] = base_name
+
+    return context
+
+
+def existing_media_destination_context(media, originals_dir: Optional[str]) -> Dict[str, Any]:
+    """既存メディアの保存先情報をログ用に組み立てる。"""
+
+    details: Dict[str, Any] = {}
+
+    if media is None:
+        return details
+
+    relative_path = getattr(media, "local_rel_path", None)
+    if relative_path:
+        details["relative_path"] = relative_path
+
+        base_dir = originals_dir if originals_dir else None
+        if base_dir:
+            absolute_path = os.path.normpath(os.path.join(base_dir, relative_path))
+        else:
+            absolute_path = relative_path
+
+        details["imported_path"] = absolute_path
+        details["destination"] = absolute_path
+
+    filename = getattr(media, "filename", None)
+    if filename:
+        details["imported_filename"] = filename
+
+    return details
+
+
+import os
+
+
+__all__ = [
+    "compose_message",
+    "existing_media_destination_context",
+    "file_log_context",
+    "serialize_details",
+    "with_session",
+]
+

--- a/domain/local_import/media_metadata.py
+++ b/domain/local_import/media_metadata.py
@@ -1,0 +1,257 @@
+"""ローカルインポートで利用するメディアメタデータ関連のユーティリティ。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from PIL import Image
+from PIL.ExifTags import TAGS
+
+from core.utils import open_image_compat, register_heif_support
+
+register_heif_support()
+
+
+def calculate_file_hash(file_path: str) -> str:
+    """ファイルのSHA-256ハッシュを計算"""
+
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()
+
+
+def get_image_dimensions(file_path: str) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    """画像の幅、高さ、向きを取得"""
+
+    try:
+        with open_image_compat(file_path) as img:
+            width, height = img.size
+
+            # EXIF orientationを取得
+            orientation = None
+            exif_dict = {}
+
+            getexif = getattr(img, "getexif", None)
+            if callable(getexif):
+                try:
+                    exif = getexif()
+                except Exception:
+                    exif = None
+                if exif:
+                    exif_dict = dict(exif.items())
+
+            if not exif_dict and hasattr(img, "_getexif"):
+                try:
+                    raw = img._getexif()
+                    if raw:
+                        exif_dict = raw
+                except Exception:
+                    exif_dict = {}
+
+            if not exif_dict:
+                exif_bytes = (getattr(img, "info", {}) or {}).get("exif")
+                if isinstance(exif_bytes, (bytes, bytearray)) and hasattr(Image, "Exif"):
+                    try:
+                        exif_reader = Image.Exif()
+                        exif_reader.load(exif_bytes)
+                        exif_dict = dict(exif_reader.items())
+                    except Exception:
+                        exif_dict = {}
+
+            for tag, value in exif_dict.items():
+                if TAGS.get(tag) == "Orientation":
+                    orientation = value
+                    break
+
+            return width, height, orientation
+    except Exception:
+        return None, None, None
+
+
+def extract_exif_data(file_path: str) -> Dict:
+    """EXIFデータを抽出"""
+
+    exif_data = {}
+    try:
+        with open_image_compat(file_path) as img:
+            exif_dict = {}
+
+            getexif = getattr(img, "getexif", None)
+            if callable(getexif):
+                try:
+                    exif = getexif()
+                except Exception:
+                    exif = None
+                if exif:
+                    exif_dict = dict(exif.items())
+
+            if not exif_dict and hasattr(img, "_getexif"):
+                try:
+                    raw = img._getexif()
+                    if raw:
+                        exif_dict = raw
+                except Exception:
+                    exif_dict = {}
+
+            if not exif_dict:
+                exif_bytes = (getattr(img, "info", {}) or {}).get("exif")
+                if isinstance(exif_bytes, (bytes, bytearray)) and hasattr(Image, "Exif"):
+                    try:
+                        exif_reader = Image.Exif()
+                        exif_reader.load(exif_bytes)
+                        exif_dict = dict(exif_reader.items())
+                    except Exception:
+                        exif_dict = {}
+
+            if exif_dict:
+                for tag, value in exif_dict.items():
+                    decoded_tag = TAGS.get(tag, tag)
+                    exif_data[decoded_tag] = value
+
+    except Exception:
+        return {}
+
+    return exif_data
+
+
+def _parse_ffprobe_datetime(raw: str) -> Optional[datetime]:
+    if not raw:
+        return None
+
+    normalized = raw.strip()
+
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+
+    if len(normalized) > 5 and normalized[-5] in {"+", "-"} and normalized[-3] != ":":
+        normalized = f"{normalized[:-2]}:{normalized[-2:]}"
+
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        try:
+            dt = datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return None
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+
+    return dt
+
+
+def parse_ffprobe_datetime(raw: str) -> Optional[datetime]:
+    """ffprobe文字列をUTCのdatetimeへ正規化する公開関数。"""
+
+    return _parse_ffprobe_datetime(raw)
+
+
+def extract_video_metadata(file_path: str) -> Dict:
+    """動画ファイルからメタデータを抽出（ffprobeを使用）"""
+
+    metadata: Dict[str, Any] = {}
+    try:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_streams",
+            "-show_format",
+            "-of",
+            "json",
+            str(file_path),
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode == 0:
+            info = json.loads(proc.stdout)
+
+            # ビデオストリーム情報を取得
+            streams = info.get("streams", [])
+            video_streams = [s for s in streams if s.get("codec_type") == "video"]
+            if video_streams:
+                v_stream = video_streams[0]
+                # FPSを取得
+                if "r_frame_rate" in v_stream:
+                    fps_str = v_stream["r_frame_rate"]
+                    if "/" in fps_str:
+                        num, den = fps_str.split("/")
+                        if den != "0":
+                            metadata["fps"] = float(num) / float(den)
+                    else:
+                        metadata["fps"] = float(fps_str)
+
+                # 幅・高さを取得
+                metadata["width"] = v_stream.get("width")
+                metadata["height"] = v_stream.get("height")
+
+                # ストリームタグから作成日時を確認
+                stream_tags = v_stream.get("tags") or {}
+                for key in ("creation_time", "com.apple.quicktime.creationdate", "date"):
+                    shot_at_candidate = stream_tags.get(key)
+                    if shot_at_candidate:
+                        parsed = _parse_ffprobe_datetime(str(shot_at_candidate))
+                        if parsed:
+                            metadata["shot_at"] = parsed
+                            break
+
+            # フォーマット情報から時間を取得
+            format_info = info.get("format", {})
+            if "duration" in format_info:
+                metadata["duration_ms"] = int(float(format_info["duration"]) * 1000)
+
+            # フォーマットタグに作成日時が含まれていれば利用
+            format_tags = format_info.get("tags") or {}
+            if "shot_at" not in metadata:
+                for key in ("creation_time", "com.apple.quicktime.creationdate", "date"):
+                    shot_at_candidate = format_tags.get(key)
+                    if shot_at_candidate:
+                        parsed = _parse_ffprobe_datetime(str(shot_at_candidate))
+                        if parsed:
+                            metadata["shot_at"] = parsed
+                            break
+
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError, ValueError):
+        # ffprobeが使えない場合やエラーの場合は空のメタデータを返す
+        pass
+
+    return metadata
+
+
+def generate_filename(shot_at: datetime, file_extension: str, file_hash: str) -> str:
+    """
+    ファイル名を生成
+    フォーマット: YYYYMMDD_HHMMSS_local_hash8.ext
+    """
+
+    date_str = shot_at.strftime("%Y%m%d_%H%M%S")
+    hash8 = file_hash[:8]
+    return f"{date_str}_local_{hash8}{file_extension}"
+
+
+def get_relative_path(shot_at: datetime, filename: str) -> str:
+    """相対パスを生成 (YYYY/MM/DD/filename)"""
+
+    year = shot_at.strftime("%Y")
+    month = shot_at.strftime("%m")
+    day = shot_at.strftime("%d")
+    return f"{year}/{month}/{day}/{filename}"
+
+
+__all__ = [
+    "calculate_file_hash",
+    "extract_exif_data",
+    "extract_video_metadata",
+    "generate_filename",
+    "get_image_dimensions",
+    "get_relative_path",
+    "parse_ffprobe_datetime",
+]
+

--- a/domain/local_import/session.py
+++ b/domain/local_import/session.py
@@ -1,0 +1,96 @@
+"""ローカルインポートにおけるセッション管理ロジック。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+class LocalImportSessionService:
+    """セッションの進捗管理やキャンセル判定を担うドメインサービス。"""
+
+    def __init__(self, db, log_error) -> None:  # type: ignore[no-untyped-def]
+        self._db = db
+        self._log_error = log_error
+
+    def set_progress(
+        self,
+        session,
+        *,
+        status: Optional[str] = None,
+        stage: Optional[str] = None,
+        celery_task_id: Optional[str] = None,
+        stats_updates: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """セッションの進捗と関連統計情報を更新する。"""
+
+        if not session:
+            return
+
+        now = datetime.now(timezone.utc)
+        if status:
+            session.status = status
+        session.last_progress_at = now
+        session.updated_at = now
+
+        stats = session.stats() if hasattr(session, "stats") else {}
+        if not isinstance(stats, dict):
+            stats = {}
+        if stage is not None:
+            stats["stage"] = stage
+        if celery_task_id is not None:
+            stats["celery_task_id"] = celery_task_id
+        if stats_updates:
+            stats.update(stats_updates)
+        session.set_stats(stats)
+
+        try:
+            self._db.session.commit()
+        except Exception as exc:  # pragma: no cover - unexpected path
+            self._db.session.rollback()
+            self._log_error(
+                "local_import.session.progress_update_failed",
+                "セッション状態の更新中にエラーが発生",
+                session_id=getattr(session, "session_id", None),
+                session_db_id=getattr(session, "id", None),
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=True,
+            )
+            raise
+
+    def cancel_requested(self, session, *, task_instance=None) -> bool:  # type: ignore[no-untyped-def]
+        """セッションに対してキャンセルが要求されているかを判定。"""
+
+        if not session:
+            return False
+
+        if task_instance and hasattr(task_instance, "is_aborted"):
+            try:
+                if task_instance.is_aborted():
+                    return True
+            except Exception:
+                pass
+
+        try:
+            self._db.session.refresh(session)
+        except Exception:
+            try:
+                self._db.session.rollback()
+            except Exception:
+                pass
+            fresh = session.__class__.query.get(session.id)
+            if not fresh:
+                return True
+            session.status = fresh.status
+            session.stats_json = fresh.stats_json
+
+        stats = session.stats() if hasattr(session, "stats") else {}
+        if isinstance(stats, dict) and stats.get("cancel_requested"):
+            return True
+
+        return session.status == "canceled"
+
+
+__all__ = ["LocalImportSessionService"]
+

--- a/domain/local_import/zip_archive.py
+++ b/domain/local_import/zip_archive.py
@@ -1,0 +1,171 @@
+"""ローカルインポートで利用するZIPアーカイブ関連処理。"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional
+
+
+class ZipExtractionError(Exception):
+    """ZIP展開処理で致命的なエラーが発生した場合に送出。"""
+
+
+class ZipArchiveService:
+    """ZIPアーカイブを取り扱うドメインサービス。"""
+
+    def __init__(
+        self,
+        log_info: Callable[..., None],
+        log_warning: Callable[..., None],
+        log_error: Callable[..., None],
+        supported_extensions: Iterable[str],
+    ) -> None:
+        self._log_info = log_info
+        self._log_warning = log_warning
+        self._log_error = log_error
+        self._supported_extensions = {ext.lower() for ext in supported_extensions}
+        self._extracted_directories: List[Path] = []
+
+    def _zip_extraction_base_dir(self) -> Path:
+        base_dir = Path(tempfile.gettempdir()) / "local_import_zip"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        return base_dir
+
+    def _register_extracted_directory(self, path: Path) -> None:
+        self._extracted_directories.append(path)
+
+    def cleanup(self) -> None:
+        while self._extracted_directories:
+            dir_path = self._extracted_directories.pop()
+            try:
+                shutil.rmtree(dir_path)
+            except FileNotFoundError:
+                continue
+            except Exception as exc:  # pragma: no cover - unexpected
+                self._log_warning(
+                    "local_import.zip.cleanup_failed",
+                    "ZIP展開ディレクトリの削除に失敗",
+                    directory=str(dir_path),
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                )
+
+    def extract(self, zip_path: str, *, session_id: Optional[str] = None) -> List[str]:
+        extracted_files: List[str] = []
+        archive_path = Path(zip_path)
+        extraction_dir = (
+            self._zip_extraction_base_dir() / f"{archive_path.stem}_{uuid.uuid4().hex}"
+        )
+        extraction_dir.mkdir(parents=True, exist_ok=True)
+        self._register_extracted_directory(extraction_dir)
+
+        should_remove_archive = False
+
+        try:
+            with zipfile.ZipFile(zip_path) as archive:
+                should_remove_archive = True
+                for member in archive.infolist():
+                    if member.is_dir():
+                        continue
+
+                    member_path = Path(member.filename)
+                    if member_path.is_absolute() or any(part == ".." for part in member_path.parts):
+                        self._log_warning(
+                            "local_import.zip.unsafe_member",
+                            "ZIP内の危険なパスをスキップ",
+                            zip_path=zip_path,
+                            member=member.filename,
+                            session_id=session_id,
+                        )
+                        continue
+
+                    if member_path.suffix.lower() not in self._supported_extensions:
+                        continue
+
+                    target_path = extraction_dir / member_path
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+                    with archive.open(member) as src, open(target_path, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+
+                    extracted_files.append(str(target_path))
+                    self._log_info(
+                        "local_import.zip.member_extracted",
+                        "ZIP内のファイルを抽出",
+                        session_id=session_id,
+                        status="extracted",
+                        zip_path=zip_path,
+                        member=member.filename,
+                        extracted_path=str(target_path),
+                    )
+
+        except zipfile.BadZipFile as exc:
+            self._log_error(
+                "local_import.zip.invalid",
+                "ZIPファイルの展開に失敗",
+                zip_path=zip_path,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                session_id=session_id,
+            )
+        except Exception as exc:
+            self._log_error(
+                "local_import.zip.extract_failed",
+                "ZIPファイル展開中にエラーが発生",
+                zip_path=zip_path,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=True,
+                session_id=session_id,
+            )
+        else:
+            if extracted_files:
+                self._log_info(
+                    "local_import.zip.extracted",
+                    "ZIPファイルを展開",
+                    zip_path=zip_path,
+                    extracted_count=len(extracted_files),
+                    extraction_dir=str(extraction_dir),
+                    session_id=session_id,
+                    status="extracted",
+                )
+            else:
+                self._log_warning(
+                    "local_import.zip.no_supported_files",
+                    "ZIPファイルに取り込み対象ファイルがありません",
+                    zip_path=zip_path,
+                    session_id=session_id,
+                    status="skipped",
+                )
+
+        if should_remove_archive:
+            try:
+                os.remove(zip_path)
+                self._log_info(
+                    "local_import.zip.removed",
+                    "ZIPファイルを削除",
+                    zip_path=zip_path,
+                    session_id=session_id,
+                    status="cleaned",
+                )
+            except OSError as exc:
+                self._log_warning(
+                    "local_import.zip.remove_failed",
+                    "ZIPファイルの削除に失敗",
+                    zip_path=zip_path,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    session_id=session_id,
+                    status="warning",
+                )
+
+        return extracted_files
+
+
+__all__ = ["ZipArchiveService", "ZipExtractionError"]
+


### PR DESCRIPTION
## Summary
- extract logging, metadata, zip handling, and session orchestration for local import into dedicated domain services
- refactor `import_single_file` to rely on `ImportOutcome` value objects for clearer control flow and reduced duplication
- keep the task orchestration intact while delegating persistence concerns through reusable helpers

## Testing
- `pytest tests/test_local_import_duplicate_refresh.py -k refresh -q`


------
https://chatgpt.com/codex/tasks/task_e_68e213f5dea08323bc40c6cf2d72ffdb