### PR TITLE
Refactor local import flow into domain services

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -13,11 +14,8 @@ from flask import current_app
 from core.db import db
 from core.models.photo_models import (
     Media,
-    Exif,
     PickerSelection,
     MediaItem,
-    PhotoMetadata,
-    VideoMetadata,
     MediaPlayback,
 )
 from core.models.job_sync import JobSync
@@ -30,7 +28,6 @@ from core.tasks.media_post_processing import (
     process_media_post_import,
 )
 from core.tasks.thumbs_generate import thumbs_generate as _thumbs_generate
-from core.utils import get_file_date_from_exif, get_file_date_from_name
 from webapp.config import Config
 
 from domain.local_import.logging import (
@@ -41,15 +38,15 @@ from domain.local_import.logging import (
     with_session as _with_session,
 )
 from domain.local_import.entities import ImportFile, ImportOutcome
-from domain.local_import.media_metadata import (
-    calculate_file_hash,
-    extract_exif_data,
-    extract_video_metadata,
-    generate_filename,
-    get_image_dimensions,
-    get_relative_path,
-    parse_ffprobe_datetime,
+from domain.local_import.media_entities import (
+    apply_analysis_to_media_entity,
+    build_media_from_analysis,
+    build_media_item_from_analysis,
+    ensure_exif_for_media,
+    update_media_item_from_analysis,
 )
+from domain.local_import.media_file import analyze_media_file
+from domain.local_import.policies import SUPPORTED_EXTENSIONS
 from domain.local_import.zip_archive import ZipArchiveService
 from domain.local_import.session import LocalImportSessionService
 
@@ -206,12 +203,6 @@ def _commit_with_error_logging(
         raise
 
 
-# サポートするファイル拡張子
-SUPPORTED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.tiff', '.tif', '.bmp', '.heic', '.heif'}
-SUPPORTED_VIDEO_EXTENSIONS = {'.mp4', '.mov', '.avi', '.mkv', '.m4v', '.3gp', '.webm'}
-SUPPORTED_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS | SUPPORTED_VIDEO_EXTENSIONS
-
-
 _session_service = LocalImportSessionService(db, _log_error)
 
 
@@ -273,102 +264,27 @@ def _refresh_existing_media_metadata(
         )
         return False
 
-    file_size = os.path.getsize(source_path)
-    file_hash = calculate_file_hash(source_path)
+    analysis = analyze_media_file(source_path)
 
-    is_video = file_extension in SUPPORTED_VIDEO_EXTENSIONS
-    width, height, orientation = None, None, None
-    duration_ms = None
-    exif_data: Dict[str, Any] = {}
-    video_metadata: Dict[str, Any] = {}
-
-    if not is_video and file_extension in SUPPORTED_IMAGE_EXTENSIONS:
-        width, height, orientation = get_image_dimensions(source_path)
-        exif_data = extract_exif_data(source_path)
-    elif is_video:
-        video_metadata = extract_video_metadata(source_path)
-        if video_metadata:
-            width = video_metadata.get("width") or width
-            height = video_metadata.get("height") or height
-            duration_ms = video_metadata.get("duration_ms") or duration_ms
-
-    shot_at = None
-    if exif_data:
-        shot_at = get_file_date_from_exif(exif_data)
-    if not shot_at:
-        shot_at = get_file_date_from_name(os.path.basename(source_path))
-    if not shot_at:
-        shot_at = datetime.fromtimestamp(os.path.getmtime(source_path), tz=timezone.utc)
-
-    mime_type_map = {
-        '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
-        '.png': 'image/png', '.tiff': 'image/tiff', '.tif': 'image/tiff',
-        '.bmp': 'image/bmp', '.heic': 'image/heic', '.heif': 'image/heif',
-        '.mp4': 'video/mp4', '.mov': 'video/quicktime',
-        '.avi': 'video/x-msvideo', '.mkv': 'video/x-matroska',
-        '.m4v': 'video/mp4', '.3gp': 'video/3gpp', '.webm': 'video/webm'
-    }
-    mime_type = mime_type_map.get(file_extension, 'application/octet-stream')
-
-    media.mime_type = mime_type
-    media.hash_sha256 = file_hash
-    media.bytes = file_size
-    if width is not None:
-        media.width = width
-    if height is not None:
-        media.height = height
-    if duration_ms is not None:
-        media.duration_ms = duration_ms
-    if orientation is not None:
-        media.orientation = orientation
-    if shot_at:
-        media.shot_at = shot_at
-    media.is_video = is_video
-
-    if exif_data:
-        media.camera_make = exif_data.get('Make') or media.camera_make
-        media.camera_model = exif_data.get('Model') or media.camera_model
+    apply_analysis_to_media_entity(media, analysis)
 
     media_item = None
     if media.google_media_id:
         media_item = MediaItem.query.get(media.google_media_id)
         if media_item:
-            media_item.mime_type = mime_type
-            media_item.filename = os.path.basename(media.filename or source_path)
-            if width is not None:
-                media_item.width = width
-            if height is not None:
-                media_item.height = height
-            if exif_data:
-                media_item.camera_make = exif_data.get('Make') or media_item.camera_make
-                media_item.camera_model = exif_data.get('Model') or media_item.camera_model
-            media_item.type = "VIDEO" if is_video else "PHOTO"
-
-            if not is_video and exif_data:
-                photo_meta = media_item.photo_metadata or PhotoMetadata()
-                if 'FocalLength' in exif_data:
-                    photo_meta.focal_length = exif_data.get('FocalLength')
-                if 'FNumber' in exif_data:
-                    photo_meta.aperture_f_number = exif_data.get('FNumber')
-                if 'ISOSpeedRatings' in exif_data:
-                    photo_meta.iso_equivalent = exif_data.get('ISOSpeedRatings')
-                exposure_value = exif_data.get('ExposureTime') if 'ExposureTime' in exif_data else None
-                photo_meta.exposure_time = str(exposure_value) if exposure_value not in (None, '') else None
-                media_item.photo_metadata = photo_meta
-                db.session.add(photo_meta)
+            metadata_obj = update_media_item_from_analysis(media_item, analysis)
+            if metadata_obj is not None:
+                db.session.add(metadata_obj)
                 db.session.flush()
-            elif is_video:
-                video_meta = media_item.video_metadata or VideoMetadata(processing_status='UNSPECIFIED')
-                if video_metadata:
-                    if 'fps' in video_metadata:
-                        video_meta.fps = video_metadata.get('fps')
-                    if 'processing_status' in video_metadata:
-                        video_meta.processing_status = video_metadata.get('processing_status')
-                if video_meta.processing_status is None:
-                    video_meta.processing_status = 'UNSPECIFIED'
-                media_item.video_metadata = video_meta
-                db.session.add(video_meta)
-                db.session.flush()
+        else:
+            _log_warning(
+                "local_import.file.duplicate_media_item_missing",
+                "既存メディアに対応するMediaItemが見つかりません",
+                media_id=media.id,
+                media_google_id=media.google_media_id,
+                session_id=session_id,
+                status="warning",
+            )
     else:
         _log_warning(
             "local_import.file.duplicate_media_item_missing",
@@ -379,20 +295,9 @@ def _refresh_existing_media_metadata(
             status="warning",
         )
 
-    if exif_data:
-        exif = media.exif or Exif(media_id=media.id)
-        exif.camera_make = exif_data.get('Make')
-        exif.camera_model = exif_data.get('Model')
-        exif.lens = exif_data.get('LensModel')
-        exif.iso = exif_data.get('ISOSpeedRatings')
-        shutter_value = exif_data.get('ExposureTime') if 'ExposureTime' in exif_data else None
-        exif.shutter = str(shutter_value) if shutter_value not in (None, '') else None
-        exif.f_number = exif_data.get('FNumber')
-        exif.focal_len = exif_data.get('FocalLength')
-        exif.gps_lat = exif_data.get('GPSLatitude')
-        exif.gps_lng = exif_data.get('GPSLongitude')
-        exif.raw_json = json.dumps(exif_data, ensure_ascii=False, default=str)
-        db.session.add(exif)
+    exif_model = ensure_exif_for_media(media, analysis)
+    if exif_model is not None:
+        db.session.add(exif_model)
 
     _commit_with_error_logging(
         "local_import.file.duplicate_refresh_commit",
@@ -528,55 +433,6 @@ def _regenerate_duplicate_video_thumbnails(
         )
         return False, result.get("notes")
 
-
-def create_media_item_for_local(filename: str, mime_type: str, width: Optional[int], height: Optional[int],
-                               is_video: bool, exif_data: Optional[Dict] = None, video_metadata: Optional[Dict] = None) -> MediaItem:
-    """ローカルファイル用のMediaItemを作成"""
-    import uuid
-    
-    # ファイル名からユニークなIDを生成
-    media_item_id = f"local_{uuid.uuid4().hex[:16]}"
-    
-    # MediaItemタイプの決定
-    item_type = "VIDEO" if is_video else "PHOTO"
-    
-    media_item = MediaItem(
-        id=media_item_id,
-        type=item_type,
-        mime_type=mime_type,
-        filename=filename,
-        width=width,
-        height=height,
-        camera_make=exif_data.get('Make') if exif_data else None,
-        camera_model=exif_data.get('Model') if exif_data else None
-    )
-    
-    # メタデータの作成
-    if is_video:
-        # ビデオメタデータ（ffprobeから取得、取れない場合はNULL）
-        video_meta = VideoMetadata(
-            fps=video_metadata.get('fps') if video_metadata else None,
-            processing_status='UNSPECIFIED'
-        )
-        db.session.add(video_meta)
-        db.session.flush()  # IDを取得
-        media_item.video_metadata_id = video_meta.id
-    else:
-        # フォトメタデータ（EXIFから取得、取れない場合はNULL）
-        photo_meta = PhotoMetadata(
-            focal_length=exif_data.get('FocalLength') if exif_data else None,
-            aperture_f_number=exif_data.get('FNumber') if exif_data else None,
-            iso_equivalent=exif_data.get('ISOSpeedRatings') if exif_data else None,
-            exposure_time=str(exif_data.get('ExposureTime', '')) if exif_data and exif_data.get('ExposureTime') else None
-        )
-        db.session.add(photo_meta)
-        db.session.flush()  # IDを取得
-        media_item.photo_metadata_id = photo_meta.id
-    
-    db.session.add(media_item)
-    return media_item
-
-
 def import_single_file(
     file_path: str,
     import_dir: str,
@@ -658,10 +514,10 @@ def import_single_file(
             )
             return outcome.as_dict()
 
-        file_hash = calculate_file_hash(file_path)
+        analysis = analyze_media_file(file_path)
 
         # 重複チェック
-        existing_media = check_duplicate_media(file_hash, file_size)
+        existing_media = check_duplicate_media(analysis.file_hash, analysis.file_size)
         if existing_media:
             outcome.details.update(
                 {
@@ -766,68 +622,14 @@ def import_single_file(
 
             return outcome.as_dict()
 
-        is_video = file_extension in SUPPORTED_VIDEO_EXTENSIONS
+        is_video = analysis.is_video
 
-        # 撮影日時とメタデータの取得
-        shot_at = None
-        exif_data: Optional[Dict[str, Any]] = None
-        video_meta: Optional[Dict[str, Any]] = None
-
-        if is_video:
-            video_meta = extract_video_metadata(file_path)
-            if video_meta:
-                candidate = video_meta.get("shot_at")
-                if isinstance(candidate, datetime):
-                    shot_at = candidate
-                elif isinstance(candidate, str):
-                    shot_at = parse_ffprobe_datetime(candidate)
-        elif file_extension in SUPPORTED_IMAGE_EXTENSIONS:
-            exif_data = extract_exif_data(file_path)
-            shot_at = get_file_date_from_exif(exif_data)
-
-        # EXIF/動画メタデータから取得できない場合は、ファイル名から取得
-        if not shot_at:
-            shot_at = get_file_date_from_name(os.path.basename(file_path))
-
-        # それでも取得できない場合は、ファイルの更新日時を使用
-        if not shot_at:
-            mtime = os.path.getmtime(file_path)
-            shot_at = datetime.fromtimestamp(mtime, tz=timezone.utc)
-        
-        # ファイル名とパスの生成
-        new_filename = generate_filename(shot_at, file_extension, file_hash)
-        rel_path = get_relative_path(shot_at, new_filename)
+        imported_filename = analysis.destination_filename
+        rel_path = analysis.relative_path
         dest_path = os.path.join(originals_dir, rel_path)
-        imported_filename = new_filename
-        
-        # ディレクトリ作成
+
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-        
-        # メディア情報の取得
-        width, height, orientation = None, None, None
-        duration_ms = None
 
-        if not is_video:
-            width, height, orientation = get_image_dimensions(file_path)
-        else:
-            # 動画の場合はffprobeで取得済みのメタデータから値を利用
-            if video_meta:
-                width = video_meta.get('width') or width
-                height = video_meta.get('height') or height
-                duration_ms = video_meta.get('duration_ms') or duration_ms
-
-        # MIMEタイプの決定
-        mime_type_map = {
-            '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
-            '.png': 'image/png', '.tiff': 'image/tiff', '.tif': 'image/tiff',
-            '.bmp': 'image/bmp', '.heic': 'image/heic', '.heif': 'image/heif',
-            '.mp4': 'video/mp4', '.mov': 'video/quicktime',
-            '.avi': 'video/x-msvideo', '.mkv': 'video/x-matroska',
-            '.m4v': 'video/mp4', '.3gp': 'video/3gpp', '.webm': 'video/webm'
-        }
-        mime_type = mime_type_map.get(file_extension, 'application/octet-stream')
-        
-        # ファイルコピー
         shutil.copy2(file_path, dest_path)
         _log_info(
             "local_import.file.copied",
@@ -839,58 +641,26 @@ def import_single_file(
             session_id=session_id,
             status="copied",
         )
-        
-        # MediaItemとメタデータの作成
-        media_item = create_media_item_for_local(
-            filename=os.path.basename(file_path),
-            mime_type=mime_type,
-            width=width,
-            height=height,
-            is_video=is_video,
-            exif_data=exif_data,
-            video_metadata=video_meta
-        )
-        
-        # DBへの登録
-        media = Media(
-            google_media_id=media_item.id,  # ローカルファイルの場合はmedia_item.idを使用
-            account_id=None,                # ローカルファイルの場合はNone
-            local_rel_path=rel_path,
-            filename=os.path.basename(file_path),
-            hash_sha256=file_hash,
-            bytes=file_size,
-            mime_type=mime_type,
-            width=width,
-            height=height,
-            duration_ms=duration_ms,
-            shot_at=shot_at,
-            imported_at=datetime.now(timezone.utc),
-            orientation=orientation,
-            is_video=is_video,
-            live_group_id=None,
-            is_deleted=False,
-            has_playback=False
-        )
-        
-        db.session.add(media)
-        db.session.flush()  # IDを取得
 
-        # EXIFデータの保存（画像の場合、すでに取得済みのデータを使用）
-        if not is_video and file_extension in SUPPORTED_IMAGE_EXTENSIONS and exif_data:
-            exif = Exif(
-                media_id=media.id,
-                camera_make=exif_data.get('Make'),
-                camera_model=exif_data.get('Model'),
-                lens=exif_data.get('LensModel'),
-                iso=exif_data.get('ISOSpeedRatings'),
-                shutter=str(exif_data.get('ExposureTime', '')),
-                f_number=exif_data.get('FNumber'),
-                focal_len=exif_data.get('FocalLength'),
-                gps_lat=exif_data.get('GPSLatitude'),
-                gps_lng=exif_data.get('GPSLongitude'),
-                raw_json=str(exif_data) if exif_data else None
-            )
-            db.session.add(exif)
+        aggregate = build_media_item_from_analysis(analysis)
+        db.session.add(aggregate.media_item)
+        if aggregate.photo_metadata is not None:
+            db.session.add(aggregate.photo_metadata)
+        if aggregate.video_metadata is not None:
+            db.session.add(aggregate.video_metadata)
+        db.session.flush()
+
+        media = build_media_from_analysis(
+            analysis,
+            google_media_id=aggregate.media_item.id,
+            relative_path=rel_path,
+        )
+        db.session.add(media)
+        db.session.flush()
+
+        exif_model = ensure_exif_for_media(media, analysis)
+        if exif_model is not None:
+            db.session.add(exif_model)
         
         db.session.commit()
 
@@ -2003,8 +1773,10 @@ def local_import_task(task_instance=None, session_id=None) -> Dict:
             elif pending_remaining > 0 or thumbnails_pending:
                 final_status = "processing"
             else:
-                if (not result["ok"]) or result["failed"] > 0 or thumbnails_failed:
+                if (not result["ok"]) or result["failed"] > 0:
                     final_status = "error"
+                elif thumbnails_failed:
+                    final_status = "imported"
                 elif result["success"] > 0 or result["skipped"] > 0 or result["processed"] > 0:
                     final_status = "imported"
                 else:

--- a/domain/local_import/media_entities.py
+++ b/domain/local_import/media_entities.py
@@ -1,0 +1,196 @@
+"""ドメインエンティティの生成・更新ロジック."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from core.models.photo_models import Exif, Media, MediaItem, PhotoMetadata, VideoMetadata
+
+from .media_file import MediaFileAnalysis
+
+
+@dataclass(frozen=True)
+class MediaItemAggregate:
+    """MediaItem と関連メタデータの集約."""
+
+    media_item: MediaItem
+    photo_metadata: Optional[PhotoMetadata]
+    video_metadata: Optional[VideoMetadata]
+
+
+def build_media_item_from_analysis(analysis: MediaFileAnalysis) -> MediaItemAggregate:
+    """解析結果から MediaItem を生成する。"""
+
+    item_type = "VIDEO" if analysis.is_video else "PHOTO"
+    media_item = MediaItem(
+        id=f"local_{uuid.uuid4().hex[:16]}",
+        type=item_type,
+        mime_type=analysis.mime_type,
+        filename=analysis.source.name,
+        width=analysis.width,
+        height=analysis.height,
+        camera_make=analysis.exif_data.get("Make"),
+        camera_model=analysis.exif_data.get("Model"),
+    )
+
+    if analysis.is_video:
+        video_metadata = VideoMetadata(
+            fps=analysis.video_metadata.get("fps"),
+            processing_status=_resolve_processing_status(
+                analysis.video_metadata.get("processing_status")
+            ),
+        )
+        media_item.video_metadata = video_metadata
+        return MediaItemAggregate(media_item, None, video_metadata)
+
+    photo_metadata = None
+    if analysis.exif_data:
+        photo_metadata = PhotoMetadata(
+            focal_length=analysis.exif_data.get("FocalLength"),
+            aperture_f_number=analysis.exif_data.get("FNumber"),
+            iso_equivalent=analysis.exif_data.get("ISOSpeedRatings"),
+            exposure_time=_normalize_exposure_time(analysis.exif_data.get("ExposureTime")),
+        )
+        media_item.photo_metadata = photo_metadata
+
+    return MediaItemAggregate(media_item, photo_metadata, None)
+
+
+def update_media_item_from_analysis(media_item: MediaItem, analysis: MediaFileAnalysis):
+    """解析結果を既存の MediaItem に適用する。"""
+
+    media_item.mime_type = analysis.mime_type
+    media_item.filename = analysis.source.name
+    media_item.width = analysis.width
+    media_item.height = analysis.height
+    media_item.type = "VIDEO" if analysis.is_video else "PHOTO"
+    if analysis.exif_data:
+        media_item.camera_make = analysis.exif_data.get("Make") or media_item.camera_make
+        media_item.camera_model = analysis.exif_data.get("Model") or media_item.camera_model
+
+    if analysis.is_video:
+        video_metadata = media_item.video_metadata or VideoMetadata(
+            processing_status="UNSPECIFIED"
+        )
+        video_metadata.fps = analysis.video_metadata.get("fps")
+        video_metadata.processing_status = _resolve_processing_status(
+            analysis.video_metadata.get("processing_status")
+        )
+        media_item.video_metadata = video_metadata
+        return video_metadata
+
+    if not analysis.exif_data:
+        return None
+
+    photo_metadata = media_item.photo_metadata or PhotoMetadata()
+    photo_metadata.focal_length = analysis.exif_data.get("FocalLength")
+    photo_metadata.aperture_f_number = analysis.exif_data.get("FNumber")
+    photo_metadata.iso_equivalent = analysis.exif_data.get("ISOSpeedRatings")
+    photo_metadata.exposure_time = _normalize_exposure_time(
+        analysis.exif_data.get("ExposureTime")
+    )
+    media_item.photo_metadata = photo_metadata
+    return photo_metadata
+
+
+def build_media_from_analysis(
+    analysis: MediaFileAnalysis,
+    *,
+    google_media_id: str,
+    relative_path: str,
+) -> Media:
+    """解析結果から Media エンティティを生成する。"""
+
+    media = Media(
+        google_media_id=google_media_id,
+        account_id=None,
+        local_rel_path=relative_path,
+        filename=analysis.source.name,
+        hash_sha256=analysis.file_hash,
+        bytes=analysis.file_size,
+        mime_type=analysis.mime_type,
+        width=analysis.width,
+        height=analysis.height,
+        duration_ms=analysis.duration_ms,
+        shot_at=analysis.shot_at,
+        imported_at=datetime.now(timezone.utc),
+        orientation=analysis.orientation,
+        is_video=analysis.is_video,
+        live_group_id=None,
+        is_deleted=False,
+        has_playback=False,
+    )
+
+    if analysis.exif_data:
+        media.camera_make = analysis.exif_data.get("Make") or media.camera_make
+        media.camera_model = analysis.exif_data.get("Model") or media.camera_model
+
+    return media
+
+
+def apply_analysis_to_media_entity(media: Media, analysis: MediaFileAnalysis) -> None:
+    """既存 Media に解析結果を適用する。"""
+
+    media.mime_type = analysis.mime_type
+    media.hash_sha256 = analysis.file_hash
+    media.bytes = analysis.file_size
+    if analysis.width is not None:
+        media.width = analysis.width
+    if analysis.height is not None:
+        media.height = analysis.height
+    media.duration_ms = analysis.duration_ms
+    media.orientation = analysis.orientation
+    media.shot_at = analysis.shot_at
+    media.is_video = analysis.is_video
+
+    if analysis.exif_data:
+        media.camera_make = analysis.exif_data.get("Make") or media.camera_make
+        media.camera_model = analysis.exif_data.get("Model") or media.camera_model
+
+
+def ensure_exif_for_media(media: Media, analysis: MediaFileAnalysis) -> Optional[Exif]:
+    """解析結果から EXIF 情報を更新・生成する。"""
+
+    if not analysis.exif_data:
+        return None
+
+    exif = media.exif or Exif(media_id=media.id)
+    exif.camera_make = analysis.exif_data.get("Make")
+    exif.camera_model = analysis.exif_data.get("Model")
+    exif.lens = analysis.exif_data.get("LensModel")
+    exif.iso = analysis.exif_data.get("ISOSpeedRatings")
+    exif.shutter = _normalize_exposure_time(analysis.exif_data.get("ExposureTime"))
+    exif.f_number = analysis.exif_data.get("FNumber")
+    exif.focal_len = analysis.exif_data.get("FocalLength")
+    exif.gps_lat = analysis.exif_data.get("GPSLatitude")
+    exif.gps_lng = analysis.exif_data.get("GPSLongitude")
+    exif.raw_json = json.dumps(analysis.exif_data, ensure_ascii=False, default=str)
+    exif.media_id = media.id
+    return exif
+
+
+def _normalize_exposure_time(value) -> Optional[str]:  # type: ignore[no-untyped-def]
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _resolve_processing_status(value: Optional[str]) -> str:
+    if not value:
+        return "UNSPECIFIED"
+    return value
+
+
+__all__ = [
+    "MediaItemAggregate",
+    "apply_analysis_to_media_entity",
+    "build_media_from_analysis",
+    "build_media_item_from_analysis",
+    "ensure_exif_for_media",
+    "update_media_item_from_analysis",
+]
+

--- a/domain/local_import/media_file.py
+++ b/domain/local_import/media_file.py
@@ -1,0 +1,118 @@
+"""メディアファイルの解析ロジック."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from core.utils import get_file_date_from_exif, get_file_date_from_name
+
+from .entities import ImportFile
+from .media_metadata import (
+    calculate_file_hash,
+    extract_exif_data,
+    extract_video_metadata,
+    generate_filename,
+    get_image_dimensions,
+    get_relative_path,
+)
+from .policies import (
+    DEFAULT_MIME_TYPE,
+    MIME_TYPE_BY_EXTENSION,
+    SUPPORTED_VIDEO_EXTENSIONS,
+)
+
+
+@dataclass(frozen=True)
+class MediaFileAnalysis:
+    """メディアファイルの解析結果."""
+
+    source: ImportFile
+    extension: str
+    file_size: int
+    file_hash: str
+    mime_type: str
+    is_video: bool
+    width: Optional[int]
+    height: Optional[int]
+    duration_ms: Optional[int]
+    orientation: Optional[int]
+    shot_at: datetime
+    exif_data: Dict[str, Any]
+    video_metadata: Dict[str, Any]
+    destination_filename: str
+    relative_path: str
+
+
+def analyze_media_file(file_path: str) -> MediaFileAnalysis:
+    """ファイルを解析して :class:`MediaFileAnalysis` を返す。"""
+
+    source = ImportFile(file_path)
+    extension = source.extension
+    file_size = os.path.getsize(file_path)
+    file_hash = calculate_file_hash(file_path)
+    is_video = extension in SUPPORTED_VIDEO_EXTENSIONS
+    mime_type = MIME_TYPE_BY_EXTENSION.get(extension, DEFAULT_MIME_TYPE)
+
+    width: Optional[int] = None
+    height: Optional[int] = None
+    orientation: Optional[int] = None
+    duration_ms: Optional[int] = None
+    exif_data: Dict[str, Any] = {}
+    video_metadata: Dict[str, Any] = {}
+
+    if is_video:
+        video_metadata = extract_video_metadata(file_path)
+        width = video_metadata.get("width")
+        height = video_metadata.get("height")
+        duration_ms = video_metadata.get("duration_ms")
+    else:
+        width, height, orientation = get_image_dimensions(file_path)
+        exif_data = extract_exif_data(file_path)
+
+    shot_at = _resolve_shot_at(source, exif_data, video_metadata)
+    destination_filename = generate_filename(shot_at, extension, file_hash)
+    relative_path = get_relative_path(shot_at, destination_filename)
+
+    return MediaFileAnalysis(
+        source=source,
+        extension=extension,
+        file_size=file_size,
+        file_hash=file_hash,
+        mime_type=mime_type,
+        is_video=is_video,
+        width=width,
+        height=height,
+        duration_ms=duration_ms,
+        orientation=orientation,
+        shot_at=shot_at,
+        exif_data=exif_data,
+        video_metadata=video_metadata,
+        destination_filename=destination_filename,
+        relative_path=relative_path,
+    )
+
+
+def _resolve_shot_at(
+    source: ImportFile,
+    exif_data: Dict[str, Any],
+    video_metadata: Dict[str, Any],
+) -> datetime:
+    """撮影日時を解析する。"""
+
+    shot_at = get_file_date_from_exif(exif_data)
+    if not shot_at:
+        metadata_shot_at = video_metadata.get("shot_at") if video_metadata else None
+        if isinstance(metadata_shot_at, datetime):
+            shot_at = metadata_shot_at
+    if not shot_at:
+        shot_at = get_file_date_from_name(source.name)
+    if not shot_at:
+        shot_at = datetime.fromtimestamp(source.path.stat().st_mtime, tz=timezone.utc)
+    return shot_at
+
+
+__all__ = ["MediaFileAnalysis", "analyze_media_file"]
+

--- a/domain/local_import/policies.py
+++ b/domain/local_import/policies.py
@@ -1,0 +1,56 @@
+"""ローカルインポートのポリシー定義."""
+
+from __future__ import annotations
+
+SUPPORTED_IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".tiff",
+    ".tif",
+    ".bmp",
+    ".heic",
+    ".heif",
+}
+
+SUPPORTED_VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".mkv",
+    ".m4v",
+    ".3gp",
+    ".webm",
+}
+
+SUPPORTED_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS | SUPPORTED_VIDEO_EXTENSIONS
+
+MIME_TYPE_BY_EXTENSION = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".bmp": "image/bmp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+    ".m4v": "video/mp4",
+    ".3gp": "video/3gpp",
+    ".webm": "video/webm",
+}
+
+DEFAULT_MIME_TYPE = "application/octet-stream"
+
+
+__all__ = [
+    "SUPPORTED_IMAGE_EXTENSIONS",
+    "SUPPORTED_VIDEO_EXTENSIONS",
+    "SUPPORTED_EXTENSIONS",
+    "MIME_TYPE_BY_EXTENSION",
+    "DEFAULT_MIME_TYPE",
+]
+


### PR DESCRIPTION
## Summary
- centralize supported extension and MIME rules for local imports in a dedicated domain policy module
- add media file analysis and entity-builder helpers to the domain layer for reuse across duplicate handling and new imports
- refactor the local import task to use the new domain services and adjust final status handling when only thumbnail generation fails

## Testing
- pytest tests/test_local_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e21d987ddc8323b5cb2417e5c86045