### PR TITLE
Refine local import analysis and strengthen service tests

### DIFF
--- a/application/local_import/file_importer.py
+++ b/application/local_import/file_importer.py
@@ -1,0 +1,527 @@
+"""ローカルファイル取り込みのアプリケーションサービス."""
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Protocol
+
+from core.models.photo_models import Media, MediaPlayback
+from domain.local_import.entities import ImportFile, ImportOutcome
+from domain.local_import.logging import existing_media_destination_context, file_log_context
+from domain.local_import.media_entities import (
+    build_media_from_analysis,
+    build_media_item_from_analysis,
+    ensure_exif_for_media,
+)
+
+
+class PlaybackError(RuntimeError):
+    """ローカルインポート時の再生資産準備に失敗したことを表す."""
+
+
+class AnalysisService(Protocol):
+    def __call__(self, file_path: str):
+        ...
+
+
+class PostProcessService(Protocol):
+    def __call__(self, media, *, logger_override, request_context: Dict[str, Any]):
+        ...
+
+
+class DuplicateChecker(Protocol):
+    def __call__(self, file_hash: str, file_size: int) -> Optional[Media]:
+        ...
+
+
+class MetadataRefresher(Protocol):
+    def __call__(
+        self,
+        media: Media,
+        *,
+        originals_dir: str,
+        fallback_path: str,
+        file_extension: str,
+        session_id: Optional[str] = None,
+    ) -> bool:
+        ...
+
+
+class DirectoryResolver(Protocol):
+    def __call__(self, config_key: str) -> str:
+        ...
+
+
+class ThumbnailRegenerator(Protocol):
+    def __call__(self, media: Media, *, session_id: Optional[str] = None) -> tuple[bool, Optional[str]]:
+        ...
+
+
+class Logger(Protocol):
+    def info(self, event: str, message: str, *, session_id: Optional[str] = None, status: Optional[str] = None, **details: Any) -> None:
+        ...
+
+    def warning(self, event: str, message: str, *, session_id: Optional[str] = None, status: Optional[str] = None, **details: Any) -> None:
+        ...
+
+    def error(self, event: str, message: str, *, session_id: Optional[str] = None, status: Optional[str] = None, exc_info: bool = False, **details: Any) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class PlaybackFailurePolicy:
+    recoverable_notes: Iterable[str] = ("ffmpeg_missing", "playback_skipped")
+
+    def is_recoverable(self, note: str) -> bool:
+        if not note:
+            return False
+
+        normalized = note.lower()
+        if normalized in {n.lower() for n in self.recoverable_notes}:
+            return True
+        return normalized.startswith("ffmpeg_")
+
+
+class LocalImportFileImporter:
+    """単一ファイル取り込みのユースケース."""
+
+    def __init__(
+        self,
+        *,
+        db,
+        logger: Logger,
+        duplicate_checker: DuplicateChecker,
+        metadata_refresher: MetadataRefresher,
+        post_process_service: PostProcessService,
+        post_process_logger,
+        directory_resolver: DirectoryResolver,
+        analysis_service: AnalysisService,
+        thumbnail_regenerator: ThumbnailRegenerator,
+        supported_extensions: Iterable[str],
+        playback_policy: Optional[PlaybackFailurePolicy] = None,
+    ) -> None:
+        self._db = db
+        self._logger = logger
+        self._duplicate_checker = duplicate_checker
+        self._metadata_refresher = metadata_refresher
+        self._post_process_service = post_process_service
+        self._post_process_logger = post_process_logger
+        self._directory_resolver = directory_resolver
+        self._analysis_service = analysis_service
+        self._thumbnail_regenerator = thumbnail_regenerator
+        self._supported_extensions = {ext.lower() for ext in supported_extensions}
+        self._playback_policy = playback_policy or PlaybackFailurePolicy()
+
+    def import_file(
+        self,
+        file_path: str,
+        import_dir: str,
+        originals_dir: str,
+        *,
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        source = ImportFile(file_path)
+        outcome = ImportOutcome(
+            source,
+            details={
+                "success": False,
+                "file_path": file_path,
+                "reason": "",
+                "media_id": None,
+                "media_google_id": None,
+                "metadata_refreshed": False,
+            },
+        )
+
+        file_context = file_log_context(file_path)
+
+        self._logger.info(
+            "local_import.file.begin",
+            "ローカルファイルの取り込みを開始",
+            **file_context,
+            import_dir=import_dir,
+            originals_dir=originals_dir,
+            session_id=session_id,
+            status="processing",
+        )
+
+        try:
+            if not os.path.exists(file_path):
+                outcome.mark("missing", reason="ファイルが存在しません")
+                self._logger.warning(
+                    "local_import.file.missing",
+                    "取り込み対象ファイルが見つかりません",
+                    **file_context,
+                    session_id=session_id,
+                    status="missing",
+                )
+                return outcome.as_dict()
+
+            file_extension = Path(file_path).suffix.lower()
+            if file_extension not in self._supported_extensions:
+                outcome.mark(
+                    "unsupported",
+                    reason=f"サポートされていない拡張子: {file_extension}",
+                )
+                self._logger.warning(
+                    "local_import.file.unsupported",
+                    "サポート対象外拡張子のためスキップ",
+                    **file_context,
+                    extension=file_extension,
+                    session_id=session_id,
+                    status="unsupported",
+                )
+                return outcome.as_dict()
+
+            file_size = os.path.getsize(file_path)
+            if file_size == 0:
+                outcome.mark("skipped", reason="ファイルサイズが0です")
+                self._logger.warning(
+                    "local_import.file.empty",
+                    "ファイルサイズが0のためスキップ",
+                    **file_context,
+                    session_id=session_id,
+                    status="skipped",
+                )
+                return outcome.as_dict()
+
+            analysis = self._analysis_service(file_path)
+            existing_media = self._duplicate_checker(
+                analysis.file_hash, analysis.file_size
+            )
+            if existing_media:
+                return self._handle_duplicate(
+                    outcome,
+                    existing_media,
+                    file_context,
+                    file_path,
+                    originals_dir,
+                    file_extension,
+                    session_id,
+                )
+
+            return self._store_new_media(
+                outcome,
+                analysis,
+                file_context,
+                file_path,
+                originals_dir,
+                session_id,
+            )
+        except Exception as exc:
+            self._db.session.rollback()
+            self._logger.error(
+                "local_import.file.failed",
+                "ローカルファイル取り込み中にエラーが発生",
+                **file_context,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=True,
+                session_id=session_id,
+                status="failed",
+            )
+            outcome.mark("failed", reason=f"エラー: {str(exc)}")
+            self._cleanup_destination(file_context, locals(), session_id)
+            return outcome.as_dict()
+
+    def _handle_duplicate(
+        self,
+        outcome: ImportOutcome,
+        existing_media: Media,
+        file_context: Dict[str, Any],
+        file_path: str,
+        originals_dir: str,
+        file_extension: str,
+        session_id: Optional[str],
+    ) -> Dict[str, Any]:
+        outcome.details.update(
+            {
+                "reason": f"重複ファイル (既存ID: {existing_media.id})",
+                "media_id": existing_media.id,
+                "media_google_id": existing_media.google_media_id,
+            }
+        )
+        outcome.mark("duplicate")
+
+        destination_details = existing_media_destination_context(
+            existing_media, originals_dir
+        )
+        for key in ("imported_path", "imported_filename", "relative_path"):
+            value = destination_details.get(key)
+            if value:
+                outcome.details[key] = value
+
+        refreshed = False
+        try:
+            refreshed = self._metadata_refresher(
+                existing_media,
+                originals_dir=originals_dir,
+                fallback_path=file_path,
+                file_extension=file_extension,
+                session_id=session_id,
+            )
+        except Exception as refresh_exc:
+            self._logger.error(
+                "local_import.file.duplicate_refresh_failed",
+                "重複ファイルのメタデータ更新中にエラーが発生",
+                **file_context,
+                media_id=existing_media.id,
+                **destination_details,
+                error_type=type(refresh_exc).__name__,
+                error_message=str(refresh_exc),
+                exc_info=True,
+                session_id=session_id,
+            )
+        else:
+            if refreshed:
+                outcome.details["metadata_refreshed"] = True
+                outcome.details["reason"] = (
+                    f"重複ファイル (既存ID: {existing_media.id}) - メタデータ更新"
+                )
+                outcome.mark("duplicate_refreshed")
+                self._logger.info(
+                    "local_import.file.duplicate_refreshed",
+                    "重複ファイルから既存メディアのメタデータを更新",
+                    **file_context,
+                    media_id=existing_media.id,
+                    **destination_details,
+                    session_id=session_id,
+                    status="duplicate_refreshed",
+                )
+                self._remove_source(file_context, file_path, existing_media, destination_details, session_id)
+            else:
+                self._logger.info(
+                    "local_import.file.duplicate",
+                    "重複ファイルを検出したためスキップ",
+                    **file_context,
+                    media_id=existing_media.id,
+                    **destination_details,
+                    session_id=session_id,
+                    status="duplicate",
+                )
+
+        if existing_media.is_video:
+            regen_success, regen_error = self._thumbnail_regenerator(
+                existing_media,
+                session_id=session_id,
+            )
+            if not regen_success:
+                outcome.details["thumbnail_regen_error"] = (
+                    regen_error or "重複動画のサムネイル再生成に失敗しました"
+                )
+
+        return outcome.as_dict()
+
+    def _remove_source(
+        self,
+        file_context: Dict[str, Any],
+        file_path: str,
+        existing_media: Media,
+        destination_details: Dict[str, Any],
+        session_id: Optional[str],
+    ) -> None:
+        try:
+            os.remove(file_path)
+            self._logger.info(
+                "local_import.file.duplicate_source_removed",
+                "重複ファイルのソースを削除",
+                **file_context,
+                media_id=existing_media.id,
+                **destination_details,
+                session_id=session_id,
+                status="cleaned",
+            )
+        except FileNotFoundError:
+            pass
+        except OSError as cleanup_exc:
+            self._logger.warning(
+                "local_import.file.duplicate_source_remove_failed",
+                "重複ファイル削除に失敗",
+                **file_context,
+                media_id=existing_media.id,
+                **destination_details,
+                error_type=type(cleanup_exc).__name__,
+                error_message=str(cleanup_exc),
+                session_id=session_id,
+                status="warning",
+            )
+
+    def _store_new_media(
+        self,
+        outcome: ImportOutcome,
+        analysis,
+        file_context: Dict[str, Any],
+        file_path: str,
+        originals_dir: str,
+        session_id: Optional[str],
+    ) -> Dict[str, Any]:
+        is_video = analysis.is_video
+        imported_filename = analysis.destination_filename
+        rel_path = analysis.relative_path
+        dest_path = os.path.join(originals_dir, rel_path)
+
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        shutil.copy2(file_path, dest_path)
+        self._logger.info(
+            "local_import.file.copied",
+            "ファイルを保存先にコピーしました",
+            **file_context,
+            destination=dest_path,
+            imported_path=dest_path,
+            imported_filename=imported_filename,
+            session_id=session_id,
+            status="copied",
+        )
+
+        aggregate = build_media_item_from_analysis(analysis)
+        self._db.session.add(aggregate.media_item)
+        if aggregate.photo_metadata is not None:
+            self._db.session.add(aggregate.photo_metadata)
+        if aggregate.video_metadata is not None:
+            self._db.session.add(aggregate.video_metadata)
+        self._db.session.flush()
+
+        media = build_media_from_analysis(
+            analysis,
+            google_media_id=aggregate.media_item.id,
+            relative_path=rel_path,
+        )
+        self._db.session.add(media)
+        self._db.session.flush()
+
+        exif_model = ensure_exif_for_media(media, analysis)
+        if exif_model is not None:
+            self._db.session.add(exif_model)
+
+        self._db.session.commit()
+
+        post_process_result = self._post_process_service(
+            media,
+            logger_override=self._post_process_logger,
+            request_context={
+                "session_id": session_id,
+                "source": "local_import",
+            },
+        )
+        if post_process_result is not None:
+            outcome.details["post_process"] = post_process_result
+
+        if is_video:
+            self._validate_playback(
+                media, post_process_result or {}, outcome, file_context, session_id
+            )
+
+        os.remove(file_path)
+        self._logger.info(
+            "local_import.file.source_removed",
+            "取り込み完了後に元ファイルを削除",
+            **file_context,
+            session_id=session_id,
+            status="cleaned",
+        )
+
+        outcome.details.update(
+            {
+                "success": True,
+                "media_id": media.id,
+                "media_google_id": media.google_media_id,
+                "reason": "取り込み成功",
+                "imported_filename": imported_filename,
+                "imported_path": dest_path,
+            }
+        )
+        outcome.mark("success")
+
+        self._logger.info(
+            "local_import.file.success",
+            "ローカルファイルの取り込みが完了",
+            **file_context,
+            media_id=media.id,
+            relative_path=rel_path,
+            imported_path=dest_path,
+            imported_filename=imported_filename,
+            session_id=session_id,
+            status="success",
+        )
+        return outcome.as_dict()
+
+    def _validate_playback(
+        self,
+        media: Media,
+        post_process_result: Dict[str, Any],
+        outcome: ImportOutcome,
+        file_context: Dict[str, Any],
+        session_id: Optional[str],
+    ) -> None:
+        playback_result = post_process_result.get("playback") or {}
+        if not playback_result.get("ok"):
+            note = playback_result.get("note") or "unknown"
+            if session_id and self._playback_policy.is_recoverable(note):
+                self._logger.warning(
+                    "local_import.file.playback_skipped",
+                    "動画の再生ファイル生成をスキップ",
+                    **file_context,
+                    media_id=media.id,
+                    note=note,
+                    session_id=session_id,
+                    status="warning",
+                )
+                warnings = outcome.details.setdefault("warnings", [])
+                warnings.append(f"playback_skipped:{note}")
+                return
+            raise PlaybackError(
+                f"動画の再生ファイル生成に失敗しました (理由: {note})"
+            )
+
+        self._db.session.refresh(media)
+        if not media.has_playback:
+            raise PlaybackError(
+                "動画の再生ファイル生成に失敗しました (理由: playback_not_marked)"
+            )
+
+        playback_entry = MediaPlayback.query.filter_by(
+            media_id=media.id, preset="std1080p"
+        ).first()
+        if not playback_entry or not playback_entry.rel_path:
+            raise PlaybackError(
+                "動画の再生ファイル生成に失敗しました (理由: playback_record_missing)"
+            )
+
+        play_dir = self._directory_resolver("FPV_NAS_PLAY_DIR")
+        playback_path = os.path.join(play_dir, playback_entry.rel_path)
+        if not os.path.exists(playback_path):
+            raise PlaybackError(
+                "動画の再生ファイル生成に失敗しました (理由: playback_file_missing)"
+            )
+
+    def _cleanup_destination(
+        self,
+        file_context: Dict[str, Any],
+        local_vars: Dict[str, Any],
+        session_id: Optional[str],
+    ) -> None:
+        dest_path = local_vars.get("dest_path")
+        if not dest_path:
+            return
+        try:
+            if os.path.exists(dest_path):
+                os.remove(dest_path)
+                self._logger.info(
+                    "local_import.file.cleanup",
+                    "エラー発生時にコピー済みファイルを削除",
+                    destination=dest_path,
+                    session_id=session_id,
+                    status="cleaned",
+                )
+        except Exception as cleanup_error:
+            self._logger.warning(
+                "local_import.file.cleanup_failed",
+                "エラー発生時のコピー済みファイル削除に失敗",
+                destination=dest_path,
+                error_type=type(cleanup_error).__name__,
+                error_message=str(cleanup_error),
+                session_id=session_id,
+                status="warning",
+            )

--- a/application/local_import/logger.py
+++ b/application/local_import/logger.py
@@ -1,0 +1,123 @@
+"""ローカルインポートタスク用のロギングユーティリティ."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from core.logging_config import log_task_error, log_task_info
+from domain.local_import.logging import compose_message, with_session
+
+
+class LocalImportTaskLogger:
+    """Celery タスク向けのロガーをまとめて扱うヘルパ."""
+
+    def __init__(self, task_logger, celery_logger) -> None:  # pragma: no cover - 型ヒント用
+        self._task_logger = task_logger
+        self._celery_logger = celery_logger
+
+    def info(
+        self,
+        event: str,
+        message: str,
+        *,
+        session_id: Optional[str] = None,
+        status: Optional[str] = None,
+        **details: Any,
+    ) -> None:
+        payload = with_session(details, session_id)
+        resolved_status = status if status is not None else "info"
+        composed = compose_message(message, payload, resolved_status)
+
+        log_task_info(
+            self._task_logger,
+            composed,
+            event=event,
+            status=resolved_status,
+            **payload,
+        )
+        self._celery_logger.info(
+            composed,
+            extra={"event": event, "status": resolved_status, **payload},
+        )
+
+    def warning(
+        self,
+        event: str,
+        message: str,
+        *,
+        session_id: Optional[str] = None,
+        status: Optional[str] = None,
+        **details: Any,
+    ) -> None:
+        payload = with_session(details, session_id)
+        resolved_status = status if status is not None else "warning"
+        composed = compose_message(message, payload, resolved_status)
+
+        self._task_logger.warning(
+            composed,
+            extra={"event": event, "status": resolved_status, **payload},
+        )
+        self._celery_logger.warning(
+            composed,
+            extra={"event": event, "status": resolved_status, **payload},
+        )
+
+    def error(
+        self,
+        event: str,
+        message: str,
+        *,
+        session_id: Optional[str] = None,
+        status: Optional[str] = None,
+        exc_info: bool = False,
+        **details: Any,
+    ) -> None:
+        payload = with_session(details, session_id)
+        resolved_status = status if status is not None else "error"
+        composed = compose_message(message, payload, resolved_status)
+
+        log_task_error(
+            self._task_logger,
+            composed,
+            event=event,
+            status=resolved_status,
+            exc_info=exc_info,
+            **payload,
+        )
+        self._celery_logger.error(
+            composed,
+            extra={"event": event, "status": resolved_status, **payload},
+            exc_info=exc_info,
+        )
+
+    def commit_with_error_logging(
+        self,
+        db,
+        event: str,
+        message: str,
+        *,
+        session_id: Optional[str] = None,
+        celery_task_id: Optional[str] = None,
+        exc_info: bool = True,
+        **details: Any,
+    ) -> None:
+        """``db.session.commit()`` を実行し、失敗時にはエラーログを出す."""
+
+        try:
+            db.session.commit()
+        except Exception as exc:  # pragma: no cover - 例外経路の網羅が困難
+            try:
+                db.session.rollback()
+            except Exception:  # pragma: no cover - ロールバック失敗はログのみ
+                pass
+
+            self.error(
+                event,
+                message,
+                session_id=session_id,
+                celery_task_id=celery_task_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=exc_info,
+                **details,
+            )
+            raise

--- a/application/local_import/queue.py
+++ b/application/local_import/queue.py
@@ -1,0 +1,349 @@
+"""ローカルインポートのキュー処理ロジック."""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from core.models.photo_models import PickerSelection
+from domain.local_import.logging import file_log_context
+
+
+class LocalImportQueueProcessor:
+    """Selection キューを処理するアプリケーションサービス."""
+
+    def __init__(
+        self,
+        *,
+        db,
+        logger,
+        importer,
+        cancel_requested,
+    ) -> None:
+        self._db = db
+        self._logger = logger
+        self._importer = importer
+        self._cancel_requested = cancel_requested
+
+    def enqueue(
+        self,
+        session,
+        file_paths: Iterable[str],
+        *,
+        active_session_id: Optional[str],
+        celery_task_id: Optional[str],
+    ) -> int:
+        if not session or not file_paths:
+            return 0
+
+        now = datetime.now(timezone.utc)
+        paths = list(file_paths)
+        existing: Dict[str, PickerSelection] = {}
+        selections = (
+            PickerSelection.query.filter(
+                PickerSelection.session_id == session.id,
+                PickerSelection.local_file_path.in_(paths),
+            ).all()
+        )
+        for sel in selections:
+            if sel.local_file_path:
+                existing[sel.local_file_path] = sel
+
+        enqueued = 0
+        for file_path in paths:
+            filename = os.path.basename(file_path)
+            file_context = file_log_context(file_path, filename)
+            selection = existing.get(file_path)
+            if selection is None:
+                selection = PickerSelection(
+                    session_id=session.id,
+                    google_media_id=None,
+                    local_file_path=file_path,
+                    local_filename=filename,
+                    status="enqueued",
+                    attempts=0,
+                    enqueued_at=now,
+                )
+                self._db.session.add(selection)
+                self._db.session.flush()
+                enqueued += 1
+                self._logger.info(
+                    "local_import.selection.created",
+                    "取り込み対象ファイルのSelectionを作成",
+                    session_db_id=session.id,
+                    **file_context,
+                    selection_id=selection.id,
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                )
+            else:
+                if selection.status in ("imported", "dup"):
+                    continue
+                selection.status = "enqueued"
+                selection.enqueued_at = now
+                selection.local_filename = filename
+                selection.local_file_path = file_path
+                enqueued += 1
+                self._logger.info(
+                    "local_import.selection.requeued",
+                    "既存Selectionを再キュー",
+                    session_db_id=session.id,
+                    **file_context,
+                    selection_id=selection.id,
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                )
+
+        self._logger.commit_with_error_logging(
+            self._db,
+            "local_import.selection.commit_failed",
+            "Selectionの状態保存に失敗",
+            session_id=active_session_id,
+            celery_task_id=celery_task_id,
+            session_db_id=getattr(session, "id", None),
+            enqueued=enqueued,
+        )
+        return enqueued
+
+    def pending_query(self, session):
+        pending_statuses = ("pending", "enqueued", "running")
+        return (
+            PickerSelection.query.filter(
+                PickerSelection.session_id == session.id,
+                PickerSelection.status.in_(pending_statuses),
+            )
+            .order_by(PickerSelection.id)
+        )
+
+    def process(
+        self,
+        session,
+        *,
+        import_dir: str,
+        originals_dir: str,
+        result: Dict[str, Any],
+        active_session_id: Optional[str],
+        celery_task_id: Optional[str],
+        task_instance=None,
+    ) -> int:
+        if not session:
+            return 0
+
+        selections = list(self.pending_query(session).all())
+        total_files = len(selections)
+
+        if self._cancel_requested(session, task_instance=task_instance):
+            self._logger.info(
+                "local_import.cancel.detected",
+                "キャンセル要求を検知したため処理を中断",
+                session_id=active_session_id,
+                celery_task_id=celery_task_id,
+            )
+            result["canceled"] = True
+            return 0
+
+        if task_instance and total_files:
+            task_instance.update_state(
+                state="PROGRESS",
+                meta={
+                    "status": f"{total_files}個のファイルの取り込みを開始します",
+                    "progress": 0,
+                    "current": 0,
+                    "total": total_files,
+                    "message": "取り込み開始",
+                },
+            )
+
+        canceled = False
+
+        for index, selection in enumerate(selections, 1):
+            file_path = selection.local_file_path
+            filename = selection.local_filename or (
+                os.path.basename(file_path) if file_path else f"selection_{selection.id}"
+            )
+            file_context = file_log_context(file_path, filename)
+            display_file = file_context.get("file") or filename
+
+            if self._cancel_requested(session, task_instance=task_instance):
+                self._logger.info(
+                    "local_import.cancel.pending_break",
+                    "キャンセル要求のため残りの処理をスキップ",
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                    processed=index - 1,
+                    remaining=total_files - (index - 1),
+                )
+                canceled = True
+                if task_instance and total_files:
+                    task_instance.update_state(
+                        state="PROGRESS",
+                        meta={
+                            "status": "キャンセル要求を受信しました",
+                            "progress": int(((index - 1) / total_files) * 100)
+                            if total_files
+                            else 0,
+                            "current": index - 1,
+                            "total": total_files,
+                            "message": "キャンセル処理中",
+                        },
+                    )
+                break
+
+            result["processed"] += 1
+
+            try:
+                selection.status = "running"
+                selection.started_at = datetime.now(timezone.utc)
+                selection.error = None
+                self._db.session.commit()
+                self._logger.info(
+                    "local_import.selection.running",
+                    "Selectionを処理中に更新",
+                    selection_id=selection.id,
+                    **file_context,
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                )
+            except Exception as exc:
+                self._db.session.rollback()
+                self._logger.error(
+                    "local_import.selection.running_update_failed",
+                    "Selectionを処理中に更新できませんでした",
+                    selection_id=getattr(selection, "id", None),
+                    **file_context,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                )
+
+            file_result = self._importer.import_file(
+                file_path or "",
+                import_dir,
+                originals_dir,
+                session_id=active_session_id,
+            )
+
+            detail = {
+                "file": display_file,
+                "status": "success" if file_result["success"] else "failed",
+                "reason": file_result["reason"],
+                "media_id": file_result.get("media_id"),
+            }
+            basename = file_context.get("basename")
+            if basename and basename != detail["file"]:
+                detail["basename"] = basename
+            result["details"].append(detail)
+
+            post_process_result = file_result.get("post_process")
+            if isinstance(post_process_result, dict):
+                thumb_result = post_process_result.get("thumbnails")
+                if isinstance(thumb_result, dict):
+                    thumb_detail = {
+                        "ok": thumb_result.get("ok"),
+                        "status": "error"
+                        if thumb_result.get("ok") is False
+                        else (
+                            "progress"
+                            if thumb_result.get("retry_scheduled")
+                            else "completed"
+                        ),
+                        "generated": thumb_result.get("generated"),
+                        "skipped": thumb_result.get("skipped"),
+                        "retryScheduled": bool(thumb_result.get("retry_scheduled")),
+                        "notes": thumb_result.get("notes"),
+                    }
+                    retry_details = thumb_result.get("retry_details")
+                    if isinstance(retry_details, dict):
+                        thumb_detail["retryDetails"] = retry_details
+                    detail["thumbnail"] = thumb_detail
+                    self._record_thumbnail_result(
+                        result,
+                        media_id=file_result.get("media_id"),
+                        thumb_result=thumb_result,
+                    )
+
+            try:
+                if file_result["success"]:
+                    selection.status = "imported"
+                    selection.completed_at = datetime.now(timezone.utc)
+                    selection.google_media_id = file_result.get("media_google_id")
+                    selection.media_id = file_result.get("media_id")
+                elif file_result.get("status") == "duplicate":
+                    selection.status = "dup"
+                else:
+                    selection.status = "failed"
+                    selection.error = file_result.get("reason")
+                self._db.session.commit()
+            except Exception as exc:
+                self._db.session.rollback()
+                self._logger.error(
+                    "local_import.selection.finalize_failed",
+                    "Selection結果の保存に失敗",
+                    selection_id=getattr(selection, "id", None),
+                    **file_context,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    session_id=active_session_id,
+                    celery_task_id=celery_task_id,
+                )
+
+            if file_result["success"]:
+                result["success"] += 1
+            else:
+                if file_result.get("status") == "skipped":
+                    result["skipped"] += 1
+                else:
+                    result["failed"] += 1
+
+            if task_instance and total_files:
+                task_instance.update_state(
+                    state="PROGRESS",
+                    meta={
+                        "status": f"{index}/{total_files} ファイルを処理済み",
+                        "progress": int((index / total_files) * 100),
+                        "current": index,
+                        "total": total_files,
+                        "message": "取り込み中",
+                    },
+                )
+
+        if canceled:
+            result["canceled"] = True
+
+        return total_files
+
+    def _record_thumbnail_result(
+        self,
+        aggregate: Dict[str, Any],
+        *,
+        media_id: Optional[int],
+        thumb_result: Dict[str, Any],
+    ) -> None:
+        if media_id is None or not isinstance(thumb_result, dict):
+            return
+
+        records = aggregate.setdefault("thumbnail_records", [])
+        entry: Dict[str, Any] = {
+            "mediaId": media_id,
+            "media_id": media_id,
+            "ok": thumb_result.get("ok"),
+            "notes": thumb_result.get("notes"),
+            "generated": thumb_result.get("generated"),
+            "skipped": thumb_result.get("skipped"),
+            "retry_scheduled": bool(thumb_result.get("retry_scheduled")),
+        }
+
+        retry_details = thumb_result.get("retry_details")
+        if isinstance(retry_details, dict):
+            entry["retry_details"] = retry_details
+
+        ok_flag = thumb_result.get("ok")
+        if ok_flag is False:
+            entry["status"] = "error"
+        elif entry["retry_scheduled"]:
+            entry["status"] = "progress"
+        else:
+            entry["status"] = "completed"
+
+        records.append(entry)

--- a/application/local_import/results.py
+++ b/application/local_import/results.py
@@ -1,0 +1,173 @@
+"""取り込み結果の集計ロジック."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
+from core.models.photo_models import Media, MediaItem, PickerSelection
+
+
+def build_thumbnail_task_snapshot(
+    db,
+    session,
+    recorded_entries: Optional[Iterable[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    summary: Dict[str, Any] = {
+        "total": 0,
+        "completed": 0,
+        "pending": 0,
+        "failed": 0,
+        "entries": [],
+        "status": "idle",
+    }
+
+    if session is None or session.id is None:
+        return summary
+
+    initial: Dict[int, Dict[str, Any]] = {}
+    if recorded_entries:
+        for entry in recorded_entries:
+            if not isinstance(entry, dict):
+                continue
+            media_id = entry.get("mediaId") or entry.get("media_id")
+            if media_id is None:
+                continue
+            try:
+                media_key = int(media_id)
+            except (TypeError, ValueError):
+                continue
+            initial[media_key] = {
+                "status": (entry.get("status") or "").lower() or None,
+                "ok": entry.get("ok"),
+                "notes": entry.get("notes"),
+                "retry_scheduled": bool(
+                    entry.get("retryScheduled") or entry.get("retry_scheduled")
+                ),
+                "retry_details": entry.get("retryDetails") or entry.get("retry_details"),
+            }
+
+    selection_rows = (
+        db.session.query(
+            PickerSelection.id,
+            PickerSelection.status,
+            Media.id.label("media_id"),
+            Media.thumbnail_rel_path,
+            Media.is_video,
+        )
+        .outerjoin(MediaItem, PickerSelection.google_media_id == MediaItem.id)
+        .outerjoin(Media, Media.google_media_id == MediaItem.id)
+        .filter(
+            PickerSelection.session_id == session.id,
+            PickerSelection.status == "imported",
+        )
+        .all()
+    )
+
+    if not selection_rows:
+        return summary
+
+    media_ids = [row.media_id for row in selection_rows if row.media_id is not None]
+    celery_records: Dict[int, CeleryTaskRecord] = {}
+
+    if media_ids:
+        str_ids = [str(mid) for mid in media_ids]
+        records = (
+            CeleryTaskRecord.query.filter(
+                CeleryTaskRecord.task_name == "thumbnail.retry",
+                CeleryTaskRecord.object_type == "media",
+                CeleryTaskRecord.object_id.in_(str_ids),
+            )
+            .order_by(CeleryTaskRecord.id.desc())
+            .all()
+        )
+        for record in records:
+            try:
+                mid = int(record.object_id) if record.object_id is not None else None
+            except (TypeError, ValueError):
+                continue
+            if mid is None or mid in celery_records:
+                continue
+            celery_records[mid] = record
+
+    summary["status"] = "progress"
+
+    for row in selection_rows:
+        media_id = row.media_id
+        if media_id is None:
+            continue
+
+        summary["total"] += 1
+
+        recorded = initial.get(media_id, {})
+        base_status = (recorded.get("status") or "").lower() or None
+        if recorded.get("ok") is False:
+            base_status = "error"
+        retry_flag = bool(recorded.get("retry_scheduled"))
+        note = recorded.get("notes")
+        retry_details = recorded.get("retry_details") if recorded else None
+
+        record = celery_records.get(media_id)
+
+        if row.thumbnail_rel_path:
+            final_status = "completed"
+            retry_flag = False
+        else:
+            if record is not None:
+                if record.status in {
+                    CeleryTaskStatus.SCHEDULED,
+                    CeleryTaskStatus.QUEUED,
+                    CeleryTaskStatus.RUNNING,
+                }:
+                    final_status = "progress"
+                    retry_flag = True
+                elif record.status == CeleryTaskStatus.SUCCESS:
+                    final_status = "completed"
+                    retry_flag = False
+                elif record.status in {
+                    CeleryTaskStatus.FAILED,
+                    CeleryTaskStatus.CANCELED,
+                }:
+                    final_status = "error"
+                else:
+                    final_status = base_status or "progress"
+            else:
+                if base_status == "error":
+                    final_status = "error"
+                elif retry_flag or base_status in {"progress", "pending", "processing"}:
+                    final_status = "progress"
+                elif base_status == "completed":
+                    final_status = "completed"
+                else:
+                    final_status = "progress"
+
+        if final_status == "error":
+            summary["failed"] += 1
+        elif final_status == "completed":
+            summary["completed"] += 1
+        else:
+            summary["pending"] += 1
+
+        entry_payload: Dict[str, Any] = {
+            "mediaId": media_id,
+            "selectionId": row.id,
+            "status": final_status,
+            "retryScheduled": retry_flag,
+            "thumbnailPath": row.thumbnail_rel_path,
+            "notes": note,
+            "isVideo": bool(row.is_video),
+        }
+        if isinstance(retry_details, dict):
+            entry_payload["retryDetails"] = retry_details
+        if record is not None:
+            entry_payload["celeryTaskStatus"] = record.status.value
+
+        summary["entries"].append(entry_payload)
+
+    if summary["failed"] > 0:
+        summary["status"] = "error"
+    elif summary["pending"] > 0:
+        summary["status"] = "progress"
+    else:
+        summary["status"] = "completed" if summary["total"] > 0 else "idle"
+
+    return summary

--- a/application/local_import/scanner.py
+++ b/application/local_import/scanner.py
@@ -1,0 +1,71 @@
+"""ローカルインポートの入力ディレクトリを走査するサービス."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from domain.local_import.logging import file_log_context
+
+
+class ImportDirectoryScanner:
+    """取り込み対象ファイルを抽出する."""
+
+    def __init__(
+        self,
+        *,
+        logger,
+        zip_service,
+        supported_extensions: Iterable[str],
+    ) -> None:
+        self._logger = logger
+        self._zip_service = zip_service
+        self._supported_extensions = {ext.lower() for ext in supported_extensions}
+
+    def scan(self, import_dir: str, *, session_id: Optional[str] = None) -> List[str]:
+        files: List[str] = []
+        if not os.path.exists(import_dir):
+            return files
+
+        for root, _, filenames in os.walk(import_dir):
+            for filename in filenames:
+                file_path = os.path.join(root, filename)
+                file_extension = Path(filename).suffix.lower()
+                file_context = file_log_context(file_path, filename)
+
+                if file_extension in self._supported_extensions:
+                    files.append(file_path)
+                    self._logger.info(
+                        "local_import.scan.file_added",
+                        "取り込み対象ファイルを検出",
+                        session_id=session_id,
+                        status="scanning",
+                        **file_context,
+                        extension=file_extension,
+                    )
+                elif file_extension == ".zip":
+                    self._logger.info(
+                        "local_import.scan.zip_detected",
+                        "ZIPファイルを検出",
+                        session_id=session_id,
+                        status="processing",
+                        zip_path=file_path,
+                    )
+                    extracted = self._zip_service.extract(
+                        file_path, session_id=session_id
+                    )
+                    files.extend(extracted)
+                else:
+                    self._logger.info(
+                        "local_import.scan.unsupported",
+                        "サポート対象外のファイルをスキップ",
+                        session_id=session_id,
+                        status="skipped",
+                        **file_context,
+                        extension=file_extension,
+                    )
+
+        return files
+
+    def cleanup(self) -> None:
+        self._zip_service.cleanup()

--- a/application/local_import/use_case.py
+++ b/application/local_import/use_case.py
@@ -1,0 +1,550 @@
+"""ローカルインポート Celery タスクのアプリケーション層実装."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from core.models.picker_session import PickerSession
+from core.models.photo_models import PickerSelection
+
+from .results import build_thumbnail_task_snapshot
+
+
+class LocalImportUseCase:
+    """ローカルインポート処理を調整するユースケース."""
+
+    def __init__(
+        self,
+        *,
+        db,
+        logger,
+        session_service,
+        scanner,
+        queue_processor,
+    ) -> None:
+        self._db = db
+        self._logger = logger
+        self._session_service = session_service
+        self._scanner = scanner
+        self._queue_processor = queue_processor
+
+    def execute(
+        self,
+        *,
+        session_id: Optional[str],
+        import_dir: str,
+        originals_dir: str,
+        celery_task_id: Optional[str] = None,
+        task_instance=None,
+    ) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "ok": True,
+            "errors": [],
+            "processed": 0,
+            "success": 0,
+            "skipped": 0,
+            "failed": 0,
+            "details": [],
+            "session_id": session_id,
+            "celery_task_id": celery_task_id,
+            "canceled": False,
+        }
+
+        session = self._load_or_create_session(session_id, result, celery_task_id)
+        if session is None and not result["ok"]:
+            return result
+
+        active_session_id = session.session_id if session else session_id
+
+        self._set_progress(
+            session,
+            status="expanding",
+            stage="expanding",
+            celery_task_id=celery_task_id,
+            stats_updates={
+                "total": 0,
+                "success": 0,
+                "skipped": 0,
+                "failed": 0,
+            },
+        )
+
+        self._logger.info(
+            "local_import.task.start",
+            "ローカルインポートタスクを開始",
+            session_id=active_session_id,
+            import_dir=import_dir,
+            originals_dir=originals_dir,
+            celery_task_id=celery_task_id,
+            status="running",
+        )
+
+        try:
+            if not self._ensure_directory_exists(
+                import_dir,
+                result,
+                session,
+                active_session_id,
+                celery_task_id,
+                reason_key="import_dir_missing",
+                log_event="local_import.dir.import_missing",
+                log_message="取り込み元デレクトリが存在しません",
+                error_message=lambda path: f"取り込みディレクトリが存在しません: {path}",
+                log_details={"import_dir": import_dir},
+            ):
+                return result
+
+            if not self._ensure_directory_exists(
+                originals_dir,
+                result,
+                session,
+                active_session_id,
+                celery_task_id,
+                reason_key="destination_dir_missing",
+                log_event="local_import.dir.destination_missing",
+                log_message="保存先ディレクトリが存在しません",
+                error_message=lambda path: f"保存先ディレクトリが存在しません: {path}",
+                log_details={"originals_dir": originals_dir},
+            ):
+                return result
+
+            files = self._scanner.scan(import_dir, session_id=active_session_id)
+            self._logger.info(
+                "local_import.scan.complete",
+                "取り込み対象ファイルのスキャンが完了",
+                import_dir=import_dir,
+                total=len(files),
+                samples=files[:5],
+                session_id=active_session_id,
+                celery_task_id=celery_task_id,
+                status="scanned",
+            )
+
+            total_files = len(files)
+            if total_files == 0:
+                self._handle_no_files(
+                    result,
+                    session,
+                    active_session_id,
+                    celery_task_id,
+                    import_dir,
+                )
+                return result
+
+            enqueued_count = self._queue_processor.enqueue(
+                session,
+                files,
+                active_session_id=active_session_id,
+                celery_task_id=celery_task_id,
+            )
+
+            pending_total = 0
+            if session:
+                pending_total = self._queue_processor.pending_query(session).count()
+
+            self._set_progress(
+                session,
+                status="processing",
+                stage="progress",
+                celery_task_id=celery_task_id,
+                stats_updates={
+                    "total": pending_total,
+                    "success": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                },
+            )
+
+            self._logger.info(
+                "local_import.queue.prepared",
+                "取り込み処理キューを準備",
+                enqueued=enqueued_count,
+                pending=pending_total,
+                session_id=active_session_id,
+                celery_task_id=celery_task_id,
+                status="queued",
+            )
+
+            self._queue_processor.process(
+                session,
+                import_dir=import_dir,
+                originals_dir=originals_dir,
+                result=result,
+                active_session_id=active_session_id,
+                celery_task_id=celery_task_id,
+                task_instance=task_instance,
+            )
+        except Exception as exc:
+            result["ok"] = False
+            result["errors"].append(f"取り込み処理でエラーが発生しました: {exc}")
+            self._logger.error(
+                "local_import.task.failed",
+                "ローカルインポート処理中に予期しないエラーが発生",
+                session_id=active_session_id,
+                celery_task_id=celery_task_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                exc_info=True,
+            )
+        finally:
+            try:
+                self._scanner.cleanup()
+            except Exception:
+                pass
+
+            self._finalize_session(
+                session,
+                result,
+                active_session_id,
+                celery_task_id,
+            )
+
+        self._logger.info(
+            "local_import.task.summary",
+            "ローカルインポートタスクが完了",
+            ok=result["ok"],
+            processed=result["processed"],
+            success=result["success"],
+            skipped=result["skipped"],
+            failed=result["failed"],
+            canceled=result.get("canceled", False),
+            session_id=result.get("session_id"),
+            celery_task_id=celery_task_id,
+            status="completed" if result.get("ok") else "error",
+        )
+
+        return result
+
+    # internal helpers
+    def _load_or_create_session(
+        self,
+        session_id: Optional[str],
+        result: Dict[str, Any],
+        celery_task_id: Optional[str],
+    ):
+        if session_id:
+            try:
+                session = PickerSession.query.filter_by(session_id=session_id).first()
+            except Exception as exc:
+                self._logger.error(
+                    "local_import.session.load_failed",
+                    "セッション取得時にエラーが発生",
+                    session_id=session_id,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                )
+                result["ok"] = False
+                result["errors"].append(f"セッション取得エラー: {exc}")
+                return None
+
+            if not session:
+                self._logger.error(
+                    "local_import.session.missing",
+                    "指定されたセッションIDのレコードが見つかりません",
+                    session_id=session_id,
+                )
+                result["ok"] = False
+                result["errors"].append(f"セッションが見つかりません: {session_id}")
+                return None
+
+            self._logger.info(
+                "local_import.session.attach",
+                "既存セッションをローカルインポートに紐付け",
+                session_id=session_id,
+                celery_task_id=celery_task_id,
+                status="attached",
+            )
+            return session
+
+        generated_session_id = f"local_import_{uuid.uuid4().hex}"
+        session = PickerSession(
+            session_id=generated_session_id,
+            status="expanding",
+            selected_count=0,
+        )
+        self._db.session.add(session)
+        try:
+            self._db.session.commit()
+        except Exception as exc:
+            self._db.session.rollback()
+            result["ok"] = False
+            result["errors"].append(f"セッション作成エラー: {exc}")
+            self._logger.error(
+                "local_import.session.create_failed",
+                "ローカルインポート用セッションの作成に失敗",
+                session_id=generated_session_id,
+                celery_task_id=celery_task_id,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+            )
+            return None
+
+        result["session_id"] = session.session_id
+        self._logger.info(
+            "local_import.session.created",
+            "ローカルインポート用セッションを新規作成",
+            session_id=session.session_id,
+            celery_task_id=celery_task_id,
+            status="created",
+        )
+        return session
+
+    def _set_progress(self, session, **kwargs: Any) -> None:
+        self._session_service.set_progress(session, **kwargs)
+
+    def _ensure_directory_exists(
+        self,
+        directory: str,
+        result: Dict[str, Any],
+        session,
+        active_session_id: Optional[str],
+        celery_task_id: Optional[str],
+        *,
+        reason_key: str,
+        log_event: str,
+        log_message: str,
+        error_message,
+        log_details: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        if os.path.exists(directory):
+            return True
+
+        if session:
+            session.selected_count = 0
+        self._set_progress(
+            session,
+            status="error",
+            stage=None,
+            celery_task_id=celery_task_id,
+            stats_updates={
+                "total": 0,
+                "success": 0,
+                "skipped": 0,
+                "failed": 0,
+                "reason": reason_key,
+            },
+        )
+
+        result["ok"] = False
+        details = log_details or {}
+        self._logger.error(
+            log_event,
+            log_message,
+            session_id=active_session_id,
+            celery_task_id=celery_task_id,
+            **details,
+        )
+        result["errors"].append(error_message(directory))
+        return False
+
+    def _handle_no_files(
+        self,
+        result: Dict[str, Any],
+        session,
+        active_session_id: Optional[str],
+        celery_task_id: Optional[str],
+        import_dir: str,
+    ) -> None:
+        if session:
+            session.selected_count = 0
+        self._set_progress(
+            session,
+            status="error",
+            stage=None,
+            celery_task_id=celery_task_id,
+            stats_updates={
+                "total": 0,
+                "success": 0,
+                "skipped": 0,
+                "failed": 0,
+                "reason": "no_files_found",
+            },
+        )
+
+        self._logger.warning(
+            "local_import.scan.empty",
+            "取り込み対象ファイルが存在しませんでした",
+            import_dir=import_dir,
+            session_id=active_session_id,
+            celery_task_id=celery_task_id,
+            status="empty",
+        )
+        result["ok"] = False
+        result["errors"].append(f"取り込み対象ファイルが見つかりません: {import_dir}")
+
+    def _finalize_session(
+        self,
+        session,
+        result: Dict[str, Any],
+        active_session_id: Optional[str],
+        celery_task_id: Optional[str],
+    ) -> None:
+        if not session:
+            return
+
+        try:
+            counts_query = (
+                self._db.session.query(
+                    PickerSelection.status,
+                    self._db.func.count(PickerSelection.id),
+                )
+                .filter(PickerSelection.session_id == session.id)
+                .group_by(PickerSelection.status)
+                .all()
+            )
+            counts_map = {row[0]: row[1] for row in counts_query}
+
+            pending_remaining = sum(
+                counts_map.get(status, 0)
+                for status in ("pending", "enqueued", "running")
+            )
+            imported_count = counts_map.get("imported", 0)
+            dup_count = counts_map.get("dup", 0)
+            skipped_count = counts_map.get("skipped", 0)
+            failed_count = counts_map.get("failed", 0)
+
+            result["success"] = imported_count
+            result["skipped"] = dup_count + skipped_count
+            result["failed"] = failed_count
+            result["processed"] = (
+                imported_count + dup_count + skipped_count + failed_count
+            )
+
+            cancel_requested = bool(result.get("canceled")) or self._session_service.cancel_requested(session)
+
+            recorded_thumbnails = result.get("thumbnail_records")
+            thumbnail_snapshot = build_thumbnail_task_snapshot(
+                self._db, session, recorded_thumbnails
+            )
+            result["thumbnail_snapshot"] = thumbnail_snapshot
+            thumbnail_status = (
+                thumbnail_snapshot.get("status")
+                if isinstance(thumbnail_snapshot, dict)
+                else None
+            )
+
+            thumbnails_pending = thumbnail_status == "progress"
+            thumbnails_failed = thumbnail_status == "error"
+
+            if cancel_requested:
+                final_status = "canceled"
+            elif pending_remaining > 0 or thumbnails_pending:
+                final_status = "processing"
+            else:
+                if (not result["ok"]) or result["failed"] > 0:
+                    final_status = "error"
+                elif thumbnails_failed:
+                    final_status = "imported"
+                elif (
+                    result["success"] > 0
+                    or result["skipped"] > 0
+                    or result["processed"] > 0
+                ):
+                    final_status = "imported"
+                else:
+                    final_status = "ready"
+
+            session.selected_count = imported_count
+
+            stats = {
+                "total": result["processed"],
+                "success": result["success"],
+                "skipped": result["skipped"],
+                "failed": result["failed"],
+                "pending": pending_remaining,
+                "celery_task_id": celery_task_id,
+            }
+
+            import_task_status = "canceled" if cancel_requested else None
+            if import_task_status is None:
+                if pending_remaining > 0:
+                    import_task_status = "progress"
+                elif result["failed"] > 0 or not result["ok"]:
+                    import_task_status = "error"
+                elif result["processed"] > 0:
+                    import_task_status = "completed"
+                else:
+                    import_task_status = "idle"
+
+            tasks_payload = [
+                {
+                    "key": "import",
+                    "label": "File Import",
+                    "status": import_task_status,
+                    "counts": {
+                        "total": result["processed"],
+                        "success": result["success"],
+                        "skipped": result["skipped"],
+                        "failed": result["failed"],
+                        "pending": pending_remaining,
+                    },
+                }
+            ]
+
+            if isinstance(thumbnail_snapshot, dict):
+                stats["thumbnails"] = thumbnail_snapshot
+                if thumbnail_snapshot.get("total") or thumbnail_snapshot.get("status") not in {None, "idle"}:
+                    tasks_payload.append(
+                        {
+                            "key": "thumbnails",
+                            "label": "Thumbnail Generation",
+                            "status": thumbnail_snapshot.get("status"),
+                            "counts": {
+                                "total": thumbnail_snapshot.get("total"),
+                                "completed": thumbnail_snapshot.get("completed"),
+                                "pending": thumbnail_snapshot.get("pending"),
+                                "failed": thumbnail_snapshot.get("failed"),
+                            },
+                            "entries": thumbnail_snapshot.get("entries"),
+                        }
+                    )
+
+            if tasks_payload:
+                stats["tasks"] = tasks_payload
+
+            stage_value = "canceled" if cancel_requested else None
+            if stage_value != "canceled":
+                if thumbnails_failed:
+                    stage_value = "error"
+                elif pending_remaining > 0 or thumbnails_pending:
+                    stage_value = "progress"
+                else:
+                    stage_value = "completed"
+            if cancel_requested:
+                stats.update(
+                    {
+                        "cancel_requested": False,
+                        "canceled_at": datetime.now(timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                    }
+                )
+
+            self._set_progress(
+                session,
+                status=final_status,
+                stage=stage_value,
+                celery_task_id=celery_task_id,
+                stats_updates=stats,
+            )
+
+            self._logger.info(
+                "local_import.session.updated",
+                "セッション情報を更新",
+                session_id=session.session_id,
+                status=final_status,
+                stats=stats,
+                celery_task_id=celery_task_id,
+            )
+        except Exception as exc:
+            result["errors"].append(f"セッション更新エラー: {exc}")
+            self._logger.error(
+                "local_import.session.update_failed",
+                "セッション更新時にエラーが発生",
+                session_id=session.session_id if session else None,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                celery_task_id=celery_task_id,
+            )

--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -1,27 +1,17 @@
 """ローカルファイル取り込みタスク."""
 
-import json
 import logging
 import os
-import shutil
-import uuid
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-
-from flask import current_app
 
 from core.db import db
 from core.models.photo_models import (
     Media,
     PickerSelection,
     MediaItem,
-    MediaPlayback,
 )
-from core.models.job_sync import JobSync
-from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
 from core.models.picker_session import PickerSession
-from core.logging_config import log_task_error, log_task_info, setup_task_logging
+from core.logging_config import setup_task_logging
 from core.storage_paths import first_existing_storage_path, storage_path_candidates
 from core.tasks.media_post_processing import (
     enqueue_thumbs_generate,
@@ -30,14 +20,15 @@ from core.tasks.media_post_processing import (
 from core.tasks.thumbs_generate import thumbs_generate as _thumbs_generate
 from webapp.config import Config
 
-from domain.local_import.logging import (
-    compose_message as _compose_message,
-    existing_media_destination_context as _existing_media_destination_context,
-    file_log_context as _file_log_context,
-    serialize_details as _serialize_details,
-    with_session as _with_session,
+from application.local_import.file_importer import (
+    LocalImportFileImporter,
+    PlaybackError as _PlaybackError,
 )
-from domain.local_import.entities import ImportFile, ImportOutcome
+from application.local_import.logger import LocalImportTaskLogger
+from application.local_import.queue import LocalImportQueueProcessor
+from application.local_import.scanner import ImportDirectoryScanner
+from application.local_import.use_case import LocalImportUseCase
+from application.local_import.results import build_thumbnail_task_snapshot as _build_thumbnail_task_snapshot
 from domain.local_import.media_entities import (
     apply_analysis_to_media_entity,
     build_media_from_analysis,
@@ -45,7 +36,15 @@ from domain.local_import.media_entities import (
     ensure_exif_for_media,
     update_media_item_from_analysis,
 )
-from domain.local_import.media_file import analyze_media_file
+from domain.local_import.media_file import (
+    DefaultMediaMetadataProvider,
+    MediaFileAnalyzer,
+)
+from domain.local_import.media_metadata import (
+    calculate_file_hash,
+    extract_exif_data,
+    get_image_dimensions,
+)
 from domain.local_import.policies import SUPPORTED_EXTENSIONS
 from domain.local_import.zip_archive import ZipArchiveService
 from domain.local_import.session import LocalImportSessionService
@@ -63,38 +62,12 @@ logger = setup_task_logging(__name__)
 celery_logger = logging.getLogger('celery.task.local_import')
 
 
-_THUMBNAIL_RETRY_TASK_NAME = "thumbnail.retry"
+LocalImportPlaybackError = _PlaybackError
 
 
-class LocalImportPlaybackError(RuntimeError):
-    """Raised when playback assets for a local video could not be prepared."""
+_task_logger = LocalImportTaskLogger(logger, celery_logger)
 
 
-def _is_recoverable_playback_failure(note: str) -> bool:
-    """Return ``True`` when a playback failure can be safely downgraded.
-
-    ``ffmpeg`` が利用できない (``ffmpeg_missing``) など、テスト環境や軽量な
-    実行環境では発生し得る失敗は、メディア自体の取り込みを止める必要がない。
-    そういったケースではセッションの進行を継続しつつ警告ログだけを残す。
-    """
-
-    if not note:
-        return False
-
-    normalized = note.lower()
-    recoverable_notes = {
-        "ffmpeg_missing",
-        "playback_skipped",  # 互換性維持のためのエイリアス
-    }
-
-    if normalized in recoverable_notes:
-        return True
-
-    # ``ffmpeg`` 周りの一般的な失敗は ``ffmpeg_`` 接頭辞を含む
-    if normalized.startswith("ffmpeg_"):
-        return True
-
-    return False
 def _log_info(
     event: str,
     message: str,
@@ -104,19 +77,13 @@ def _log_info(
     **details: Any,
 ) -> None:
     """情報ログを記録。"""
-    payload = _with_session(details, session_id)
-    resolved_status = status if status is not None else "info"
-    composed = _compose_message(message, payload, resolved_status)
-    log_task_info(
-        logger,
-        composed,
-        event=event,
-        status=resolved_status,
-        **payload,
-    )
-    celery_logger.info(
-        composed,
-        extra={"event": event, "status": resolved_status, **payload},
+
+    _task_logger.info(
+        event,
+        message,
+        session_id=session_id,
+        status=status,
+        **details,
     )
 
 
@@ -129,16 +96,13 @@ def _log_warning(
     **details: Any,
 ) -> None:
     """警告ログを記録。"""
-    payload = _with_session(details, session_id)
-    resolved_status = status if status is not None else "warning"
-    composed = _compose_message(message, payload, resolved_status)
-    logger.warning(
-        composed,
-        extra={"event": event, "status": resolved_status, **payload},
-    )
-    celery_logger.warning(
-        composed,
-        extra={"event": event, "status": resolved_status, **payload},
+
+    _task_logger.warning(
+        event,
+        message,
+        session_id=session_id,
+        status=status,
+        **details,
     )
 
 
@@ -151,22 +115,15 @@ def _log_error(
     **details: Any,
 ) -> None:
     """エラーログを記録。"""
+
     status_value = details.pop("status", None)
-    payload = _with_session(details, session_id)
-    resolved_status = status_value if status_value is not None else "error"
-    composed = _compose_message(message, payload, resolved_status)
-    log_task_error(
-        logger,
-        composed,
-        event=event,
+    _task_logger.error(
+        event,
+        message,
+        session_id=session_id,
+        status=status_value,
         exc_info=exc_info,
-        status=resolved_status,
-        **payload,
-    )
-    celery_logger.error(
-        composed,
-        extra={"event": event, "status": resolved_status, **payload},
-        exc_info=exc_info,
+        **details,
     )
 
 
@@ -181,26 +138,15 @@ def _commit_with_error_logging(
 ) -> None:
     """db.session.commit() を実行し、失敗時には詳細ログを記録する。"""
 
-    try:
-        db.session.commit()
-    except Exception as exc:
-        try:
-            db.session.rollback()
-        except Exception:
-            # ロールバック自体が失敗しても続行（元例外を優先）
-            pass
-
-        _log_error(
-            event,
-            message,
-            session_id=session_id,
-            celery_task_id=celery_task_id,
-            error_type=type(exc).__name__,
-            error_message=str(exc),
-            exc_info=exc_info,
-            **details,
-        )
-        raise
+    _task_logger.commit_with_error_logging(
+        db,
+        event,
+        message,
+        session_id=session_id,
+        celery_task_id=celery_task_id,
+        exc_info=exc_info,
+        **details,
+    )
 
 
 _session_service = LocalImportSessionService(db, _log_error)
@@ -214,10 +160,33 @@ _zip_service = ZipArchiveService(
 )
 
 
+_scanner = ImportDirectoryScanner(
+    logger=_task_logger,
+    zip_service=_zip_service,
+    supported_extensions=SUPPORTED_EXTENSIONS,
+)
+
+
+class _LocalImportMetadataProvider(DefaultMediaMetadataProvider):
+    """テストでのモンキーパッチを尊重するためのメタデータプロバイダ."""
+
+    def calculate_file_hash(self, file_path: str) -> str:
+        return calculate_file_hash(file_path)
+
+    def extract_exif_data(self, file_path: str):
+        return extract_exif_data(file_path)
+
+    def get_image_dimensions(self, file_path: str):
+        return get_image_dimensions(file_path)
+
+
+_media_analyzer = MediaFileAnalyzer(metadata_provider=_LocalImportMetadataProvider())
+
+
 def _cleanup_extracted_directories() -> None:
     """ZIP展開で生成されたディレクトリを削除。"""
 
-    _zip_service.cleanup()
+    _scanner.cleanup()
 
 
 def _extract_zip_archive(zip_path: str, *, session_id: Optional[str] = None) -> List[str]:
@@ -264,7 +233,7 @@ def _refresh_existing_media_metadata(
         )
         return False
 
-    analysis = analyze_media_file(source_path)
+    analysis = _media_analyzer.analyze(source_path)
 
     apply_analysis_to_media_entity(media, analysis)
 
@@ -440,401 +409,20 @@ def import_single_file(
     *,
     session_id: Optional[str] = None,
 ) -> Dict:
-    """
-    単一ファイルの取り込み処理
-    
-    Returns:
-        処理結果辞書
-    """
-    source = ImportFile(file_path)
-    outcome = ImportOutcome(
-        source,
-        details={
-            "success": False,
-            "file_path": file_path,
-            "reason": "",
-            "media_id": None,
-            "media_google_id": None,
-            "metadata_refreshed": False,
-        },
-    )
+    """単一ファイル取り込みのアプリケーションサービスへの委譲."""
 
-    file_context = _file_log_context(file_path)
-
-    _log_info(
-        "local_import.file.begin",
-        "ローカルファイルの取り込みを開始",
-        **file_context,
-        import_dir=import_dir,
-        originals_dir=originals_dir,
+    return _file_importer.import_file(
+        file_path,
+        import_dir,
+        originals_dir,
         session_id=session_id,
-        status="processing",
     )
-
-    try:
-        # ファイル存在チェック
-        if not os.path.exists(file_path):
-            outcome.mark("missing", reason="ファイルが存在しません")
-            _log_warning(
-                "local_import.file.missing",
-                "取り込み対象ファイルが見つかりません",
-                **file_context,
-                session_id=session_id,
-                status="missing",
-            )
-            return outcome.as_dict()
-
-        # 拡張子チェック
-        file_extension = Path(file_path).suffix.lower()
-        if file_extension not in SUPPORTED_EXTENSIONS:
-            outcome.mark(
-                "unsupported",
-                reason=f"サポートされていない拡張子: {file_extension}",
-            )
-            _log_warning(
-                "local_import.file.unsupported",
-                "サポート対象外拡張子のためスキップ",
-                **file_context,
-                extension=file_extension,
-                session_id=session_id,
-                status="unsupported",
-            )
-            return outcome.as_dict()
-
-        # ファイルサイズとハッシュ計算
-        file_size = os.path.getsize(file_path)
-        if file_size == 0:
-            outcome.mark("skipped", reason="ファイルサイズが0です")
-            _log_warning(
-                "local_import.file.empty",
-                "ファイルサイズが0のためスキップ",
-                **file_context,
-                session_id=session_id,
-                status="skipped",
-            )
-            return outcome.as_dict()
-
-        analysis = analyze_media_file(file_path)
-
-        # 重複チェック
-        existing_media = check_duplicate_media(analysis.file_hash, analysis.file_size)
-        if existing_media:
-            outcome.details.update(
-                {
-                    "reason": f"重複ファイル (既存ID: {existing_media.id})",
-                    "media_id": existing_media.id,
-                    "media_google_id": existing_media.google_media_id,
-                }
-            )
-            outcome.mark("duplicate")
-
-            destination_details = _existing_media_destination_context(
-                existing_media, originals_dir
-            )
-            for key in ("imported_path", "imported_filename", "relative_path"):
-                value = destination_details.get(key)
-                if value:
-                    outcome.details[key] = value
-
-            refreshed = False
-            try:
-                refreshed = _refresh_existing_media_metadata(
-                    existing_media,
-                    originals_dir=originals_dir,
-                    fallback_path=file_path,
-                    file_extension=file_extension,
-                    session_id=session_id,
-                )
-            except Exception as refresh_exc:
-                _log_error(
-                    "local_import.file.duplicate_refresh_failed",
-                    "重複ファイルのメタデータ更新中にエラーが発生",
-                    **file_context,
-                    media_id=existing_media.id,
-                    **destination_details,
-                    error_type=type(refresh_exc).__name__,
-                    error_message=str(refresh_exc),
-                    exc_info=True,
-                    session_id=session_id,
-                )
-            else:
-                if refreshed:
-                    outcome.details["metadata_refreshed"] = True
-                    outcome.details["reason"] = (
-                        f"重複ファイル (既存ID: {existing_media.id}) - メタデータ更新"
-                    )
-                    outcome.mark("duplicate_refreshed")
-                    _log_info(
-                        "local_import.file.duplicate_refreshed",
-                        "重複ファイルから既存メディアのメタデータを更新",
-                        **file_context,
-                        media_id=existing_media.id,
-                        **destination_details,
-                        session_id=session_id,
-                        status="duplicate_refreshed",
-                    )
-                    try:
-                        os.remove(file_path)
-                        _log_info(
-                            "local_import.file.duplicate_source_removed",
-                            "重複ファイルのソースを削除",
-                            **file_context,
-                            media_id=existing_media.id,
-                            **destination_details,
-                            session_id=session_id,
-                            status="cleaned",
-                        )
-                    except FileNotFoundError:
-                        pass
-                    except OSError as cleanup_exc:
-                        _log_warning(
-                            "local_import.file.duplicate_source_remove_failed",
-                            "重複ファイル削除に失敗",
-                            **file_context,
-                            media_id=existing_media.id,
-                            **destination_details,
-                            error_type=type(cleanup_exc).__name__,
-                            error_message=str(cleanup_exc),
-                            session_id=session_id,
-                            status="warning",
-                        )
-                else:
-                    _log_info(
-                        "local_import.file.duplicate",
-                        "重複ファイルを検出したためスキップ",
-                        **file_context,
-                        media_id=existing_media.id,
-                        **destination_details,
-                        session_id=session_id,
-                        status="duplicate",
-                    )
-
-            if existing_media.is_video:
-                regen_success, regen_error = _regenerate_duplicate_video_thumbnails(
-                    existing_media,
-                    session_id=session_id,
-                )
-                if not regen_success:
-                    outcome.details["thumbnail_regen_error"] = (
-                        regen_error
-                        or "重複動画のサムネイル再生成に失敗しました"
-                    )
-
-            return outcome.as_dict()
-
-        is_video = analysis.is_video
-
-        imported_filename = analysis.destination_filename
-        rel_path = analysis.relative_path
-        dest_path = os.path.join(originals_dir, rel_path)
-
-        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-
-        shutil.copy2(file_path, dest_path)
-        _log_info(
-            "local_import.file.copied",
-            "ファイルを保存先にコピーしました",
-            **file_context,
-            destination=dest_path,
-            imported_path=dest_path,
-            imported_filename=imported_filename,
-            session_id=session_id,
-            status="copied",
-        )
-
-        aggregate = build_media_item_from_analysis(analysis)
-        db.session.add(aggregate.media_item)
-        if aggregate.photo_metadata is not None:
-            db.session.add(aggregate.photo_metadata)
-        if aggregate.video_metadata is not None:
-            db.session.add(aggregate.video_metadata)
-        db.session.flush()
-
-        media = build_media_from_analysis(
-            analysis,
-            google_media_id=aggregate.media_item.id,
-            relative_path=rel_path,
-        )
-        db.session.add(media)
-        db.session.flush()
-
-        exif_model = ensure_exif_for_media(media, analysis)
-        if exif_model is not None:
-            db.session.add(exif_model)
-        
-        db.session.commit()
-
-        post_process_result = process_media_post_import(
-            media,
-            logger_override=logger,
-            request_context={
-                "session_id": session_id,
-                "source": "local_import",
-            },
-        )
-
-        if post_process_result is not None:
-            outcome.details["post_process"] = post_process_result
-
-        if is_video:
-            playback_result = (post_process_result or {}).get("playback") or {}
-            if not playback_result.get("ok"):
-                note = playback_result.get("note") or "unknown"
-                if session_id and _is_recoverable_playback_failure(note):
-                    _log_warning(
-                        "local_import.file.playback_skipped",
-                        "動画の再生ファイル生成をスキップ",
-                        **file_context,
-                        media_id=media.id,
-                        note=note,
-                        session_id=session_id,
-                        status="warning",
-                    )
-                    warnings = outcome.details.setdefault("warnings", [])
-                    warnings.append(f"playback_skipped:{note}")
-                else:
-                    raise LocalImportPlaybackError(
-                        f"動画の再生ファイル生成に失敗しました (理由: {note})"
-                    )
-            else:
-                db.session.refresh(media)
-                if not media.has_playback:
-                    raise LocalImportPlaybackError(
-                        "動画の再生ファイル生成に失敗しました (理由: playback_not_marked)"
-                    )
-
-                playback_entry = MediaPlayback.query.filter_by(
-                    media_id=media.id, preset="std1080p"
-                ).first()
-                if not playback_entry or not playback_entry.rel_path:
-                    raise LocalImportPlaybackError(
-                        "動画の再生ファイル生成に失敗しました (理由: playback_record_missing)"
-                    )
-
-                play_dir = _resolve_directory("FPV_NAS_PLAY_DIR")
-                playback_path = os.path.join(play_dir, playback_entry.rel_path)
-                if not os.path.exists(playback_path):
-                    raise LocalImportPlaybackError(
-                        "動画の再生ファイル生成に失敗しました (理由: playback_file_missing)"
-                    )
-
-        # 元ファイルの削除
-        os.remove(file_path)
-        _log_info(
-            "local_import.file.source_removed",
-            "取り込み完了後に元ファイルを削除",
-            **file_context,
-            session_id=session_id,
-            status="cleaned",
-        )
-
-        outcome.details.update(
-            {
-                "success": True,
-                "media_id": media.id,
-                "media_google_id": media.google_media_id,
-                "reason": "取り込み成功",
-                "imported_filename": imported_filename,
-                "imported_path": dest_path,
-            }
-        )
-        outcome.mark("success")
-
-        _log_info(
-            "local_import.file.success",
-            "ローカルファイルの取り込みが完了",
-            **file_context,
-            media_id=media.id,
-            relative_path=rel_path,
-            imported_path=dest_path,
-            imported_filename=imported_filename,
-            session_id=session_id,
-            status="success",
-        )
-
-    except Exception as e:
-        db.session.rollback()
-        _log_error(
-            "local_import.file.failed",
-            "ローカルファイル取り込み中にエラーが発生",
-            **file_context,
-            error_type=type(e).__name__,
-            error_message=str(e),
-            exc_info=True,
-            session_id=session_id,
-            status="failed",
-        )
-        outcome.mark("failed", reason=f"エラー: {str(e)}")
-
-        # コピー先ファイルが作成されていた場合は削除
-        try:
-            if 'dest_path' in locals() and os.path.exists(dest_path):
-                os.remove(dest_path)
-                _log_info(
-                    "local_import.file.cleanup",
-                    "エラー発生時にコピー済みファイルを削除",
-                    destination=dest_path,
-                    session_id=session_id,
-                    status="cleaned",
-                )
-        except Exception as cleanup_error:
-            _log_warning(
-                "local_import.file.cleanup_failed",
-                "エラー発生時のコピー済みファイル削除に失敗",
-                destination=dest_path if 'dest_path' in locals() else None,
-                error_type=type(cleanup_error).__name__,
-                error_message=str(cleanup_error),
-                session_id=session_id,
-                status="warning",
-            )
-
-    return outcome.as_dict()
 
 
 def scan_import_directory(import_dir: str, *, session_id: Optional[str] = None) -> List[str]:
-    """取り込みディレクトリをスキャンしてサポートファイルを取得"""
-    files = []
-    
-    if not os.path.exists(import_dir):
-        return files
-    
-    for root, dirs, filenames in os.walk(import_dir):
-        for filename in filenames:
-            file_path = os.path.join(root, filename)
-            file_extension = Path(filename).suffix.lower()
-            file_context = _file_log_context(file_path, filename)
+    """取り込みディレクトリをスキャンするラッパー."""
 
-            if file_extension in SUPPORTED_EXTENSIONS:
-                files.append(file_path)
-                _log_info(
-                    "local_import.scan.file_added",
-                    "取り込み対象ファイルを検出",
-                    session_id=session_id,
-                    status="scanning",
-                    **file_context,
-                    extension=file_extension,
-                )
-            elif file_extension == ".zip":
-                _log_info(
-                    "local_import.scan.zip_detected",
-                    "ZIPファイルを検出",
-                    session_id=session_id,
-                    status="processing",
-                    zip_path=file_path,
-                )
-                extracted = _extract_zip_archive(file_path, session_id=session_id)
-                files.extend(extracted)
-            else:
-                _log_info(
-                    "local_import.scan.unsupported",
-                    "サポート対象外のファイルをスキップ",
-                    session_id=session_id,
-                    status="skipped",
-                    **file_context,
-                    extension=file_extension,
-                )
-
-    return files
+    return _scanner.scan(import_dir, session_id=session_id)
 
 
 def _resolve_directory(config_key: str) -> str:
@@ -851,606 +439,49 @@ def _resolve_directory(config_key: str) -> str:
     raise RuntimeError(f"No storage directory candidates available for {config_key}")
 
 
-def _set_session_progress(
-    session: Optional[PickerSession],
-    *,
-    status: Optional[str] = None,
-    stage: Optional[str] = None,
-    celery_task_id: Optional[str] = None,
-    stats_updates: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Update session status/stats during local import processing."""
+_file_importer = LocalImportFileImporter(
+    db=db,
+    logger=_task_logger,
+    duplicate_checker=check_duplicate_media,
+    metadata_refresher=_refresh_existing_media_metadata,
+    post_process_service=process_media_post_import,
+    post_process_logger=logger,
+    directory_resolver=_resolve_directory,
+    analysis_service=_media_analyzer.analyze,
+    thumbnail_regenerator=lambda media, session_id=None: _regenerate_duplicate_video_thumbnails(
+        media, session_id=session_id
+    ),
+    supported_extensions=SUPPORTED_EXTENSIONS,
+)
 
-    _session_service.set_progress(
-        session,
-        status=status,
-        stage=stage,
-        celery_task_id=celery_task_id,
-        stats_updates=stats_updates,
-    )
+_queue_processor = LocalImportQueueProcessor(
+    db=db,
+    logger=_task_logger,
+    importer=_file_importer,
+    cancel_requested=_session_service.cancel_requested,
+)
 
-
-def _session_cancel_requested(
-    session: Optional[PickerSession],
-    *,
-    task_instance=None,
-) -> bool:
-    """Return True when cancellation has been requested for *session*."""
-
-    return _session_service.cancel_requested(session, task_instance=task_instance)
-
-
-def _record_thumbnail_result(
-    aggregate: Dict[str, Any],
-    *,
-    media_id: Optional[int],
-    thumb_result: Dict[str, Any],
-) -> None:
-    """Collect thumbnail generation metadata for later aggregation."""
-
-    if media_id is None or not isinstance(thumb_result, dict):
-        return
-
-    records = aggregate.setdefault("thumbnail_records", [])
-    entry: Dict[str, Any] = {
-        "mediaId": media_id,
-        "media_id": media_id,
-        "ok": thumb_result.get("ok"),
-        "notes": thumb_result.get("notes"),
-        "generated": thumb_result.get("generated"),
-        "skipped": thumb_result.get("skipped"),
-        "retry_scheduled": bool(thumb_result.get("retry_scheduled")),
-    }
-
-    retry_details = thumb_result.get("retry_details")
-    if isinstance(retry_details, dict):
-        entry["retry_details"] = retry_details
-
-    ok_flag = thumb_result.get("ok")
-    if ok_flag is False:
-        entry["status"] = "error"
-    elif entry["retry_scheduled"]:
-        entry["status"] = "progress"
-    else:
-        entry["status"] = "completed"
-
-    records.append(entry)
+_use_case = LocalImportUseCase(
+    db=db,
+    logger=_task_logger,
+    session_service=_session_service,
+    scanner=_scanner,
+    queue_processor=_queue_processor,
+)
 
 
 def build_thumbnail_task_snapshot(
     session: Optional[PickerSession],
     recorded_entries: Optional[Iterable[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
-    """Summarise thumbnail generation state for *session*."""
+    """外部から利用されるサマリ生成の互換 API."""
 
-    summary: Dict[str, Any] = {
-        "total": 0,
-        "completed": 0,
-        "pending": 0,
-        "failed": 0,
-        "entries": [],
-        "status": "idle",
-    }
-
-    if session is None or session.id is None:
-        return summary
-
-    initial: Dict[int, Dict[str, Any]] = {}
-    if recorded_entries:
-        for entry in recorded_entries:
-            if not isinstance(entry, dict):
-                continue
-            media_id = entry.get("mediaId") or entry.get("media_id")
-            if media_id is None:
-                continue
-            try:
-                media_key = int(media_id)
-            except (TypeError, ValueError):
-                continue
-            initial[media_key] = {
-                "status": (entry.get("status") or "").lower() or None,
-                "ok": entry.get("ok"),
-                "notes": entry.get("notes"),
-                "retry_scheduled": bool(
-                    entry.get("retryScheduled") or entry.get("retry_scheduled")
-                ),
-                "retry_details": entry.get("retryDetails") or entry.get("retry_details"),
-            }
-
-    selection_rows = (
-        db.session.query(
-            PickerSelection.id,
-            PickerSelection.status,
-            Media.id.label("media_id"),
-            Media.thumbnail_rel_path,
-            Media.is_video,
-        )
-        .outerjoin(MediaItem, PickerSelection.google_media_id == MediaItem.id)
-        .outerjoin(Media, Media.google_media_id == MediaItem.id)
-        .filter(
-            PickerSelection.session_id == session.id,
-            PickerSelection.status == "imported",
-        )
-        .all()
-    )
-
-    if not selection_rows:
-        return summary
-
-    media_ids = [row.media_id for row in selection_rows if row.media_id is not None]
-    celery_records: Dict[int, CeleryTaskRecord] = {}
-
-    if media_ids:
-        str_ids = [str(mid) for mid in media_ids]
-        records = (
-            CeleryTaskRecord.query.filter(
-                CeleryTaskRecord.task_name == _THUMBNAIL_RETRY_TASK_NAME,
-                CeleryTaskRecord.object_type == "media",
-                CeleryTaskRecord.object_id.in_(str_ids),
-            )
-            .order_by(CeleryTaskRecord.id.desc())
-            .all()
-        )
-        for record in records:
-            try:
-                mid = int(record.object_id) if record.object_id is not None else None
-            except (TypeError, ValueError):
-                continue
-            if mid is None or mid in celery_records:
-                continue
-            celery_records[mid] = record
-
-    summary["status"] = "progress"
-
-    for row in selection_rows:
-        media_id = row.media_id
-        if media_id is None:
-            continue
-
-        summary["total"] += 1
-
-        recorded = initial.get(media_id, {})
-        base_status = (recorded.get("status") or "").lower() or None
-        if recorded.get("ok") is False:
-            base_status = "error"
-        retry_flag = bool(recorded.get("retry_scheduled"))
-        note = recorded.get("notes")
-        retry_details = recorded.get("retry_details") if recorded else None
-
-        record = celery_records.get(media_id)
-
-        if row.thumbnail_rel_path:
-            final_status = "completed"
-            retry_flag = False
-        else:
-            if record is not None:
-                if record.status in {
-                    CeleryTaskStatus.SCHEDULED,
-                    CeleryTaskStatus.QUEUED,
-                    CeleryTaskStatus.RUNNING,
-                }:
-                    final_status = "progress"
-                    retry_flag = True
-                elif record.status == CeleryTaskStatus.SUCCESS:
-                    final_status = "completed"
-                    retry_flag = False
-                elif record.status in {
-                    CeleryTaskStatus.FAILED,
-                    CeleryTaskStatus.CANCELED,
-                }:
-                    final_status = "error"
-                else:
-                    final_status = base_status or "progress"
-            else:
-                if base_status == "error":
-                    final_status = "error"
-                elif retry_flag or base_status in {"progress", "pending", "processing"}:
-                    final_status = "progress"
-                elif base_status == "completed":
-                    final_status = "completed"
-                else:
-                    final_status = "progress"
-
-        if final_status == "error":
-            summary["failed"] += 1
-        elif final_status == "completed":
-            summary["completed"] += 1
-        else:
-            summary["pending"] += 1
-
-        entry_payload: Dict[str, Any] = {
-            "mediaId": media_id,
-            "selectionId": row.id,
-            "status": final_status,
-            "retryScheduled": retry_flag,
-            "thumbnailPath": row.thumbnail_rel_path,
-            "notes": note,
-            "isVideo": bool(row.is_video),
-        }
-        if isinstance(retry_details, dict):
-            entry_payload["retryDetails"] = retry_details
-        if record is not None:
-            entry_payload["celeryTaskStatus"] = record.status.value
-
-        summary["entries"].append(entry_payload)
-
-    if summary["failed"] > 0:
-        summary["status"] = "error"
-    elif summary["pending"] > 0:
-        summary["status"] = "progress"
-    else:
-        summary["status"] = "completed" if summary["total"] > 0 else "idle"
-
-    return summary
-
-
-def _enqueue_local_import_selections(
-    session: Optional[PickerSession],
-    file_paths: List[str],
-    *,
-    active_session_id: Optional[str],
-    celery_task_id: Optional[str],
-) -> int:
-    """Ensure :class:`PickerSelection` rows exist for *file_paths* and mark them enqueued."""
-
-    if not session or not file_paths:
-        return 0
-
-    now = datetime.now(timezone.utc)
-    existing: Dict[str, PickerSelection] = {}
-    selections = (
-        PickerSelection.query.filter(
-            PickerSelection.session_id == session.id,
-            PickerSelection.local_file_path.in_(file_paths),
-        ).all()
-    )
-    for sel in selections:
-        if sel.local_file_path:
-            existing[sel.local_file_path] = sel
-
-    enqueued = 0
-    for file_path in file_paths:
-        filename = os.path.basename(file_path)
-        file_context = _file_log_context(file_path, filename)
-        selection = existing.get(file_path)
-        if selection is None:
-            selection = PickerSelection(
-                session_id=session.id,
-                google_media_id=None,
-                local_file_path=file_path,
-                local_filename=filename,
-                status="enqueued",
-                attempts=0,
-                enqueued_at=now,
-            )
-            db.session.add(selection)
-            db.session.flush()
-            enqueued += 1
-            _log_info(
-                "local_import.selection.created",
-                "取り込み対象ファイルのSelectionを作成",
-                session_db_id=session.id,
-                **file_context,
-                selection_id=selection.id,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-        else:
-            if selection.status in ("imported", "dup"):
-                continue
-            selection.status = "enqueued"
-            selection.enqueued_at = now
-            selection.local_filename = filename
-            selection.local_file_path = file_path
-            enqueued += 1
-            _log_info(
-                "local_import.selection.requeued",
-                "既存Selectionを再キュー",
-                session_db_id=session.id,
-                **file_context,
-                selection_id=selection.id,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-
-    _commit_with_error_logging(
-        "local_import.selection.commit_failed",
-        "Selectionの状態保存に失敗",
-        session_id=active_session_id,
-        celery_task_id=celery_task_id,
-        session_db_id=getattr(session, "id", None),
-        enqueued=enqueued,
-    )
-    return enqueued
-
-
-def _pending_selections_query(session: PickerSession):
-    pending_statuses = ("pending", "enqueued", "running")
-    return (
-        PickerSelection.query.filter(
-            PickerSelection.session_id == session.id,
-            PickerSelection.status.in_(pending_statuses),
-        )
-        .order_by(PickerSelection.id)
-    )
-
-
-def _process_local_import_queue(
-    session: Optional[PickerSession],
-    *,
-    import_dir: str,
-    originals_dir: str,
-    result: Dict[str, Any],
-    active_session_id: Optional[str],
-    celery_task_id: Optional[str],
-    task_instance=None,
-) -> int:
-    """Process pending selections for the session and import media files."""
-
-    if not session:
-        return 0
-
-    selections = list(_pending_selections_query(session).all())
-    total_files = len(selections)
-
-    if _session_cancel_requested(session, task_instance=task_instance):
-        _log_info(
-            "local_import.cancel.detected",
-            "キャンセル要求を検知したため処理を中断",
-            session_id=active_session_id,
-            celery_task_id=celery_task_id,
-        )
-        result["canceled"] = True
-        return 0
-
-    if task_instance and total_files:
-        task_instance.update_state(
-            state="PROGRESS",
-            meta={
-                "status": f"{total_files}個のファイルの取り込みを開始します",
-                "progress": 0,
-                "current": 0,
-                "total": total_files,
-                "message": "取り込み開始",
-            },
-        )
-
-    canceled = False
-
-    for index, selection in enumerate(selections, 1):
-        file_path = selection.local_file_path
-        filename = selection.local_filename or (os.path.basename(file_path) if file_path else f"selection_{selection.id}")
-        file_context = _file_log_context(file_path, filename)
-        display_file = file_context.get("file") or filename
-
-        if _session_cancel_requested(session, task_instance=task_instance):
-            _log_info(
-                "local_import.cancel.pending_break",
-                "キャンセル要求のため残りの処理をスキップ",
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-                processed=index - 1,
-                remaining=total_files - (index - 1),
-            )
-            canceled = True
-            if task_instance and total_files:
-                task_instance.update_state(
-                    state="PROGRESS",
-                    meta={
-                        "status": "キャンセル要求を受信しました",
-                        "progress": int(((index - 1) / total_files) * 100) if total_files else 0,
-                        "current": index - 1,
-                        "total": total_files,
-                        "message": "キャンセル処理中",
-                    },
-                )
-            break
-
-        result["processed"] += 1
-
-        try:
-            selection.status = "running"
-            selection.started_at = datetime.now(timezone.utc)
-            selection.error = None
-            db.session.commit()
-            _log_info(
-                "local_import.selection.running",
-                "Selectionを処理中に更新",
-                selection_id=selection.id,
-                **file_context,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-        except Exception as exc:
-            db.session.rollback()
-            _log_error(
-                "local_import.selection.running_update_failed",
-                "Selectionを処理中に更新できませんでした",
-                selection_id=getattr(selection, "id", None),
-                **file_context,
-                error_type=type(exc).__name__,
-                error_message=str(exc),
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-
-        file_result = import_single_file(
-            file_path or "",
-            import_dir,
-            originals_dir,
-            session_id=active_session_id,
-        )
-
-        detail = {
-            "file": display_file,
-            "status": "success" if file_result["success"] else "failed",
-            "reason": file_result["reason"],
-            "media_id": file_result.get("media_id"),
-        }
-        basename = file_context.get("basename")
-        if basename and basename != detail["file"]:
-            detail["basename"] = basename
-        result["details"].append(detail)
-
-        post_process_result = file_result.get("post_process")
-        if isinstance(post_process_result, dict):
-            thumb_result = post_process_result.get("thumbnails")
-            if isinstance(thumb_result, dict):
-                thumb_detail: Dict[str, Any] = {
-                    "ok": thumb_result.get("ok"),
-                    "status": "error"
-                    if thumb_result.get("ok") is False
-                    else (
-                        "progress"
-                        if thumb_result.get("retry_scheduled")
-                        else "completed"
-                    ),
-                    "generated": thumb_result.get("generated"),
-                    "skipped": thumb_result.get("skipped"),
-                    "retryScheduled": bool(thumb_result.get("retry_scheduled")),
-                    "notes": thumb_result.get("notes"),
-                }
-                retry_details = thumb_result.get("retry_details")
-                if isinstance(retry_details, dict):
-                    thumb_detail["retryDetails"] = retry_details
-                detail["thumbnail"] = thumb_detail
-                _record_thumbnail_result(
-                    result,
-                    media_id=file_result.get("media_id"),
-                    thumb_result=thumb_result,
-                )
-
-        try:
-            media_google_id = file_result.get("media_google_id")
-            if media_google_id:
-                selection.google_media_id = media_google_id
-
-            if file_result["success"]:
-                selection.status = "imported"
-                selection.finished_at = datetime.now(timezone.utc)
-                result["success"] += 1
-                _log_info(
-                    "local_import.file.processed_success",
-                    "ファイルの取り込みに成功",
-                    **file_context,
-                    media_id=file_result.get("media_id"),
-                    session_id=active_session_id,
-                    celery_task_id=celery_task_id,
-                )
-            else:
-                reason = file_result["reason"]
-                if "重複ファイル" in reason:
-                    selection.status = "dup"
-                    selection.finished_at = datetime.now(timezone.utc)
-                    result["skipped"] += 1
-                    detail["status"] = "skipped"
-                    if file_result.get("thumbnail_regen_error"):
-                        regen_message = file_result["thumbnail_regen_error"]
-                        result["ok"] = False
-                        result["errors"].append(
-                            f"{file_path}: {regen_message}"
-                        )
-                        detail["notes"] = regen_message
-                    try:
-                        if file_path and os.path.exists(file_path):
-                            os.remove(file_path)
-                            _log_info(
-                                "local_import.file.duplicate_cleanup",
-                                "重複ファイルの元ファイルを削除",
-                                **file_context,
-                                session_id=active_session_id,
-                                celery_task_id=celery_task_id,
-                            )
-                    except Exception:
-                        _log_warning(
-                            "local_import.file.duplicate_cleanup_failed",
-                            "重複ファイルの削除に失敗",
-                            **file_context,
-                            session_id=active_session_id,
-                            celery_task_id=celery_task_id,
-                        )
-                else:
-                    selection.status = "failed"
-                    selection.error = reason
-                    selection.finished_at = datetime.now(timezone.utc)
-                    selection.attempts = (selection.attempts or 0) + 1
-                    result["failed"] += 1
-                    result["errors"].append(f"{display_file}: {reason}")
-                    _log_warning(
-                        "local_import.file.processed_failed",
-                        "ファイルの取り込みに失敗",
-                        **file_context,
-                        reason=reason,
-                        session_id=active_session_id,
-                        celery_task_id=celery_task_id,
-                    )
-
-            db.session.commit()
-            _log_info(
-                "local_import.selection.updated",
-                "Selectionの状態を更新",
-                selection_id=selection.id,
-                **file_context,
-                status=selection.status,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-        except Exception as e:
-            db.session.rollback()
-            _log_error(
-                "local_import.selection.update_failed",
-                "Selectionの状態更新に失敗",
-                **file_context,
-                selection_id=getattr(selection, "id", None),
-                error_type=type(e).__name__,
-                error_message=str(e),
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-
-        if task_instance and total_files:
-            progress = int((index / total_files) * 100)
-            task_instance.update_state(
-                state="PROGRESS",
-                meta={
-                    "status": f"ファイル処理中: {display_file}",
-                    "progress": progress,
-                    "current": index,
-                    "total": total_files,
-                    "message": f"{index}/{total_files} 処理中",
-                },
-            )
-
-    if canceled:
-        result["canceled"] = True
-
-    if task_instance and total_files and not canceled:
-        task_instance.update_state(
-            state="PROGRESS",
-            meta={
-                "status": "取り込み完了",
-                "progress": 100,
-                "current": total_files,
-                "total": total_files,
-                "message": f"完了: 成功{result['success']}, スキップ{result['skipped']}, 失敗{result['failed']}",
-            },
-        )
-
-    return total_files
+    return _build_thumbnail_task_snapshot(db, session, recorded_entries)
 
 
 def local_import_task(task_instance=None, session_id=None) -> Dict:
-    """
-    ローカル取り込みタスクのメイン処理
-    
-    Args:
-        task_instance: Celeryタスクインスタンス（進行状況報告用）
-        session_id: API側で作成されたPickerSessionのID
-    
-    Returns:
-        処理結果辞書
-    """
-    # Flaskアプリケーションのコンテキストから設定を取得
+    """ローカルインポートタスクをアプリケーション層に委譲する。"""
+
     try:
         import_dir = _resolve_directory('LOCAL_IMPORT_DIR')
     except RuntimeError:
@@ -1463,440 +494,18 @@ def local_import_task(task_instance=None, session_id=None) -> Dict:
 
     celery_task_id = None
     if task_instance is not None:
-        request = getattr(task_instance, "request", None)
-        celery_task_id = getattr(request, "id", None)
+        request = getattr(task_instance, 'request', None)
+        celery_task_id = getattr(request, 'id', None)
 
-    result = {
-        "ok": True,
-        "processed": 0,
-        "success": 0,
-        "skipped": 0,
-        "failed": 0,
-        "errors": [],
-        "details": [],
-        "session_id": session_id,
-        "celery_task_id": celery_task_id,
-        "canceled": False,
-    }
-
-    # API側で作成されたセッションを取得
-    session = None
-    if session_id:
-        try:
-            session = PickerSession.query.filter_by(session_id=session_id).first()
-            if not session:
-                _log_error(
-                    "local_import.session.missing",
-                    "指定されたセッションIDのレコードが見つかりません",
-                    session_id=session_id,
-                )
-                result["errors"].append(f"セッションが見つかりません: {session_id}")
-                return result
-            _log_info(
-                "local_import.session.attach",
-                "既存セッションをローカルインポートに紐付け",
-                session_id=session_id,
-                celery_task_id=celery_task_id,
-                status="attached",
-            )
-        except Exception as e:
-            _log_error(
-                "local_import.session.load_failed",
-                "セッション取得時にエラーが発生",
-                session_id=session_id,
-                error_type=type(e).__name__,
-                error_message=str(e),
-            )
-            result["errors"].append(f"セッション取得エラー: {str(e)}")
-            return result
-    else:
-        # セッションIDが無い場合は新規セッションを作成
-        generated_session_id = f"local_import_{uuid.uuid4().hex}"
-        session = PickerSession(
-            session_id=generated_session_id,
-            status="expanding",
-            selected_count=0,
-        )
-        db.session.add(session)
-        try:
-            db.session.commit()
-        except Exception as exc:
-            db.session.rollback()
-            result["ok"] = False
-            error_message = f"セッション作成エラー: {str(exc)}"
-            result["errors"].append(error_message)
-            _log_error(
-                "local_import.session.create_failed",
-                "ローカルインポート用セッションの作成に失敗",
-                session_id=generated_session_id,
-                celery_task_id=celery_task_id,
-                error_type=type(exc).__name__,
-                error_message=str(exc),
-            )
-            return result
-
-        session_id = session.session_id
-        result["session_id"] = session_id
-        _log_info(
-            "local_import.session.created",
-            "ローカルインポート用セッションを新規作成",
-            session_id=session_id,
-            celery_task_id=celery_task_id,
-            status="created",
-        )
-
-    active_session_id = session.session_id if session else session_id
-
-    _set_session_progress(
-        session,
-        status="expanding",
-        stage="expanding",
-        celery_task_id=celery_task_id,
-        stats_updates={
-            "total": 0,
-            "success": 0,
-            "skipped": 0,
-            "failed": 0,
-        },
-    )
-
-    _log_info(
-        "local_import.task.start",
-        "ローカルインポートタスクを開始",
-        session_id=active_session_id,
+    result = _use_case.execute(
+        session_id=session_id,
         import_dir=import_dir,
         originals_dir=originals_dir,
         celery_task_id=celery_task_id,
-        status="running",
+        task_instance=task_instance,
     )
 
-    try:
-        # ディレクトリの存在チェック
-        if not os.path.exists(import_dir):
-            if session:
-                session.selected_count = 0
-            _set_session_progress(
-                session,
-                status="error",
-                stage=None,
-                celery_task_id=celery_task_id,
-                stats_updates={
-                    "total": 0,
-                    "success": 0,
-                    "skipped": 0,
-                    "failed": 0,
-                    "reason": "import_dir_missing",
-                },
-            )
-
-            result["ok"] = False
-            _log_error(
-                "local_import.dir.import_missing",
-                "取り込み元ディレクトリが存在しません",
-                import_dir=import_dir,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-            result["errors"].append(f"取り込みディレクトリが存在しません: {import_dir}")
-            return result
-
-        if not os.path.exists(originals_dir):
-            if session:
-                session.selected_count = 0
-            _set_session_progress(
-                session,
-                status="error",
-                stage=None,
-                celery_task_id=celery_task_id,
-                stats_updates={
-                    "total": 0,
-                    "success": 0,
-                    "skipped": 0,
-                    "failed": 0,
-                    "reason": "destination_dir_missing",
-                },
-            )
-
-            result["ok"] = False
-            _log_error(
-                "local_import.dir.destination_missing",
-                "保存先ディレクトリが存在しません",
-                originals_dir=originals_dir,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-            )
-            result["errors"].append(f"保存先ディレクトリが存在しません: {originals_dir}")
-            return result
-
-        # ファイル一覧の取得
-        files = scan_import_directory(import_dir, session_id=active_session_id)
-        _log_info(
-            "local_import.scan.complete",
-            "取り込み対象ファイルのスキャンが完了",
-            import_dir=import_dir,
-            total=len(files),
-            samples=files[:5],
-            session_id=active_session_id,
-            celery_task_id=celery_task_id,
-            status="scanned",
-        )
-
-        total_files = len(files)
-
-        if total_files == 0:
-            if session:
-                session.selected_count = 0
-            _set_session_progress(
-                session,
-                status="error",
-                stage=None,
-                celery_task_id=celery_task_id,
-                stats_updates={
-                    "total": 0,
-                    "success": 0,
-                    "skipped": 0,
-                    "failed": 0,
-                    "reason": "no_files_found",
-                },
-            )
-
-            _log_warning(
-                "local_import.scan.empty",
-                "取り込み対象ファイルが存在しませんでした",
-                import_dir=import_dir,
-                session_id=active_session_id,
-                celery_task_id=celery_task_id,
-                status="empty",
-            )
-            result["ok"] = False
-            result["errors"].append(f"取り込み対象ファイルが見つかりません: {import_dir}")
-            return result
-
-        enqueued_count = _enqueue_local_import_selections(
-            session,
-            files,
-            active_session_id=active_session_id,
-            celery_task_id=celery_task_id,
-        )
-
-        pending_total = 0
-        if session:
-            pending_total = _pending_selections_query(session).count()
-
-        _set_session_progress(
-            session,
-            status="processing",
-            stage="progress",
-            celery_task_id=celery_task_id,
-            stats_updates={
-                "total": pending_total,
-                "success": 0,
-                "skipped": 0,
-                "failed": 0,
-            },
-        )
-
-        _log_info(
-            "local_import.queue.prepared",
-            "取り込み処理キューを準備",
-            enqueued=enqueued_count,
-            pending=pending_total,
-            session_id=active_session_id,
-            celery_task_id=celery_task_id,
-            status="queued",
-        )
-
-        _process_local_import_queue(
-            session,
-            import_dir=import_dir,
-            originals_dir=originals_dir,
-            result=result,
-            active_session_id=active_session_id,
-            celery_task_id=celery_task_id,
-            task_instance=task_instance,
-        )
-        
-    except Exception as e:
-        result["ok"] = False
-        result["errors"].append(f"取り込み処理でエラーが発生しました: {str(e)}")
-        _log_error(
-            "local_import.task.failed",
-            "ローカルインポート処理中に予期しないエラーが発生",
-            error_type=type(e).__name__,
-            error_message=str(e),
-            exc_info=True,
-            session_id=active_session_id,
-            celery_task_id=celery_task_id,
-        )
-    finally:
-        _cleanup_extracted_directories()
-
-    # セッションステータスの更新
-    if session:
-        try:
-            counts_query = (
-                db.session.query(
-                    PickerSelection.status,
-                    db.func.count(PickerSelection.id)
-                )
-                .filter(PickerSelection.session_id == session.id)
-                .group_by(PickerSelection.status)
-                .all()
-            )
-            counts_map = {row[0]: row[1] for row in counts_query}
-
-            pending_remaining = sum(
-                counts_map.get(status, 0) for status in ("pending", "enqueued", "running")
-            )
-            imported_count = counts_map.get("imported", 0)
-            dup_count = counts_map.get("dup", 0)
-            skipped_count = counts_map.get("skipped", 0)
-            failed_count = counts_map.get("failed", 0)
-
-            result["success"] = imported_count
-            result["skipped"] = dup_count + skipped_count
-            result["failed"] = failed_count
-            result["processed"] = imported_count + dup_count + skipped_count + failed_count
-
-            cancel_requested = bool(result.get("canceled")) or _session_cancel_requested(session)
-
-            recorded_thumbnails = result.get("thumbnail_records")
-            thumbnail_snapshot = build_thumbnail_task_snapshot(session, recorded_thumbnails)
-            result["thumbnail_snapshot"] = thumbnail_snapshot
-            thumbnail_status = thumbnail_snapshot.get("status") if isinstance(thumbnail_snapshot, dict) else None
-
-            thumbnails_pending = thumbnail_status == "progress"
-            thumbnails_failed = thumbnail_status == "error"
-
-            if cancel_requested:
-                final_status = "canceled"
-            elif pending_remaining > 0 or thumbnails_pending:
-                final_status = "processing"
-            else:
-                if (not result["ok"]) or result["failed"] > 0:
-                    final_status = "error"
-                elif thumbnails_failed:
-                    final_status = "imported"
-                elif result["success"] > 0 or result["skipped"] > 0 or result["processed"] > 0:
-                    final_status = "imported"
-                else:
-                    final_status = "ready"
-
-            session.selected_count = imported_count
-
-            stats = {
-                "total": result["processed"],
-                "success": result["success"],
-                "skipped": result["skipped"],
-                "failed": result["failed"],
-                "pending": pending_remaining,
-                "celery_task_id": celery_task_id,
-            }
-
-            import_task_status = "canceled" if cancel_requested else None
-            if import_task_status is None:
-                if pending_remaining > 0:
-                    import_task_status = "progress"
-                elif result["failed"] > 0 or not result["ok"]:
-                    import_task_status = "error"
-                elif result["processed"] > 0:
-                    import_task_status = "completed"
-                else:
-                    import_task_status = "idle"
-
-            tasks_payload: List[Dict[str, Any]] = [
-                {
-                    "key": "import",
-                    "label": "File Import",
-                    "status": import_task_status,
-                    "counts": {
-                        "total": result["processed"],
-                        "success": result["success"],
-                        "skipped": result["skipped"],
-                        "failed": result["failed"],
-                        "pending": pending_remaining,
-                    },
-                }
-            ]
-
-            if isinstance(thumbnail_snapshot, dict):
-                stats["thumbnails"] = thumbnail_snapshot
-                if thumbnail_snapshot.get("total") or thumbnail_snapshot.get("status") not in {None, "idle"}:
-                    tasks_payload.append(
-                        {
-                            "key": "thumbnails",
-                            "label": "Thumbnail Generation",
-                            "status": thumbnail_snapshot.get("status"),
-                            "counts": {
-                                "total": thumbnail_snapshot.get("total"),
-                                "completed": thumbnail_snapshot.get("completed"),
-                                "pending": thumbnail_snapshot.get("pending"),
-                                "failed": thumbnail_snapshot.get("failed"),
-                            },
-                            "entries": thumbnail_snapshot.get("entries"),
-                        }
-                    )
-
-            if tasks_payload:
-                stats["tasks"] = tasks_payload
-
-            stage_value = "canceled" if cancel_requested else None
-            if stage_value != "canceled":
-                if thumbnails_failed:
-                    stage_value = "error"
-                elif pending_remaining > 0 or thumbnails_pending:
-                    stage_value = "progress"
-                else:
-                    stage_value = "completed"
-            if cancel_requested:
-                stats.update(
-                    {
-                        "cancel_requested": False,
-                        "canceled_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                    }
-                )
-
-            _set_session_progress(
-                session,
-                status=final_status,
-                stage=stage_value,
-                celery_task_id=celery_task_id,
-                stats_updates=stats,
-            )
-
-            _log_info(
-                "local_import.session.updated",
-                "セッション情報を更新",
-                session_id=session.session_id,
-                status=final_status,
-                stats=stats,
-                celery_task_id=celery_task_id,
-            )
-        except Exception as e:
-            result["errors"].append(f"セッション更新エラー: {str(e)}")
-            _log_error(
-                "local_import.session.update_failed",
-                "セッション更新時にエラーが発生",
-                session_id=session.session_id if session else None,
-                error_type=type(e).__name__,
-                error_message=str(e),
-                celery_task_id=celery_task_id,
-            )
-
-    _log_info(
-        "local_import.task.summary",
-        "ローカルインポートタスクが完了",
-        ok=result["ok"],
-        processed=result["processed"],
-        success=result["success"],
-        skipped=result["skipped"],
-        failed=result["failed"],
-        canceled=result.get("canceled", False),
-        session_id=result.get("session_id"),
-        celery_task_id=celery_task_id,
-        status="completed" if result.get("ok") else "error",
-    )
-
+    _cleanup_extracted_directories()
     return result
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ ALWAYS_RUN = {
     "tests/test_local_import_duplicate_refresh.py",
     "tests/test_local_import.py",
     "tests/test_local_import_ui.py",
+    "tests/test_local_import_services.py",
 }
 
 

--- a/tests/test_local_import_services.py
+++ b/tests/test_local_import_services.py
@@ -1,0 +1,317 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from application.local_import.file_importer import LocalImportFileImporter, PlaybackFailurePolicy
+from application.local_import.scanner import ImportDirectoryScanner
+from application.local_import.use_case import LocalImportUseCase
+from application.local_import.logger import LocalImportTaskLogger
+from application.local_import.queue import LocalImportQueueProcessor
+from application.local_import import logger as logger_module
+
+
+class DummyAnalysis:
+    def __init__(self, file_hash: str, file_size: int, *, is_video: bool = False):
+        self.file_hash = file_hash
+        self.file_size = file_size
+        self.is_video = is_video
+        self.destination_filename = "sample.jpg"
+        self.relative_path = "sample/sample.jpg"
+
+
+class DummyMedia:
+    def __init__(self):
+        self.id = 1
+        self.google_media_id = 2
+        self.local_rel_path = "existing/sample.jpg"
+        self.filename = "sample.jpg"
+        self.is_video = False
+
+
+def _build_importer(tmp_path, logger=None):
+    db = SimpleNamespace(session=MagicMock())
+    duplicate_checker = MagicMock(return_value=None)
+    metadata_refresher = MagicMock()
+    post_process_service = MagicMock(return_value={})
+    directory_resolver = MagicMock(return_value=str(tmp_path))
+    analysis_service = MagicMock(side_effect=lambda path: DummyAnalysis("hash", 10))
+    thumbnail_regenerator = MagicMock(return_value=(True, None))
+    logger = logger or MagicMock()
+
+    importer = LocalImportFileImporter(
+        db=db,
+        logger=logger,
+        duplicate_checker=duplicate_checker,
+        metadata_refresher=metadata_refresher,
+        post_process_service=post_process_service,
+        post_process_logger=MagicMock(),
+        directory_resolver=directory_resolver,
+        analysis_service=analysis_service,
+        thumbnail_regenerator=thumbnail_regenerator,
+        supported_extensions={".jpg"},
+        playback_policy=PlaybackFailurePolicy(()),
+    )
+    return (
+        importer,
+        db,
+        duplicate_checker,
+        metadata_refresher,
+        post_process_service,
+        directory_resolver,
+        analysis_service,
+        thumbnail_regenerator,
+    )
+
+
+def test_file_importer_missing_file_returns_missing(tmp_path):
+    importer, db, duplicate_checker, *_ = _build_importer(tmp_path)
+
+    result = importer.import_file(
+        file_path=str(tmp_path / "missing.jpg"),
+        import_dir=str(tmp_path),
+        originals_dir=str(tmp_path),
+    )
+
+    assert result["status"] == "missing"
+    duplicate_checker.assert_not_called()
+    db.session.commit.assert_not_called()
+
+
+def test_file_importer_duplicate_refreshes_metadata(tmp_path):
+    importer, db, duplicate_checker, metadata_refresher, *_ = _build_importer(tmp_path)
+
+    existing_media = DummyMedia()
+    duplicate_checker.return_value = existing_media
+    metadata_refresher.return_value = True
+
+    source = tmp_path / "source.jpg"
+    source.write_bytes(b"data")
+
+    result = importer.import_file(
+        file_path=str(source),
+        import_dir=str(tmp_path),
+        originals_dir=str(tmp_path),
+    )
+
+    assert result["status"] == "duplicate_refreshed"
+    metadata_refresher.assert_called_once()
+    assert not source.exists()
+
+
+def test_directory_scanner_collects_supported_files_and_zip(tmp_path):
+    logger = MagicMock()
+    zip_service = MagicMock()
+    zip_service.extract.return_value = [str(tmp_path / "from_zip.jpg")]
+    scanner = ImportDirectoryScanner(
+        logger=logger,
+        zip_service=zip_service,
+        supported_extensions={".jpg"},
+    )
+
+    supported = tmp_path / "image.jpg"
+    supported.write_bytes(b"data")
+    zip_file = tmp_path / "archive.zip"
+    zip_file.write_bytes(b"zip")
+
+    result = scanner.scan(str(tmp_path), session_id="S1")
+
+    assert str(supported) in result
+    assert str(tmp_path / "from_zip.jpg") in result
+    zip_service.extract.assert_called_once_with(str(zip_file), session_id="S1")
+
+
+def test_local_import_use_case_handles_missing_directory(tmp_path):
+    class DummySession:
+        def __init__(self):
+            self.add = MagicMock()
+            self.commit = MagicMock()
+            self.rollback = MagicMock()
+
+    db = SimpleNamespace(session=DummySession())
+    logger = MagicMock()
+    session_service = MagicMock()
+    session_service.set_progress = MagicMock()
+    session_service.cancel_requested.return_value = False
+    scanner = MagicMock()
+    queue_processor = MagicMock()
+    use_case = LocalImportUseCase(
+        db=db,
+        logger=logger,
+        session_service=session_service,
+        scanner=scanner,
+        queue_processor=queue_processor,
+    )
+
+    result = use_case.execute(
+        session_id=None,
+        import_dir=str(tmp_path / "missing"),
+        originals_dir=str(tmp_path / "originals"),
+        celery_task_id="ctid",
+    )
+
+    assert result["ok"] is False
+    assert any("取り込みディレクトリが存在しません" in err for err in result["errors"])
+    scanner.scan.assert_not_called()
+    session_service.set_progress.assert_called()
+
+
+def test_task_logger_error_logs_to_celery_and_task_logger(monkeypatch):
+    task_logger = MagicMock()
+    celery_logger = MagicMock()
+    recorded = {}
+
+    def fake_compose(message, payload, status):
+        recorded["composed"] = (message, payload, status)
+        return f"{message}|{status}"
+
+    def fake_log_task_error(logger, message, **kwargs):
+        recorded["log_task_error"] = (logger, message, kwargs)
+
+    monkeypatch.setattr(logger_module, "compose_message", fake_compose)
+    monkeypatch.setattr(logger_module, "log_task_error", fake_log_task_error)
+
+    task_logger_instance = LocalImportTaskLogger(task_logger, celery_logger)
+
+    task_logger_instance.error(
+        "event.id",
+        "エラー発生",
+        session_id="S1",
+        exc_info=True,
+        status="custom",
+        detail="x",
+    )
+
+    assert recorded["composed"] == ("エラー発生", {"detail": "x", "session_id": "S1"}, "custom")
+    assert recorded["log_task_error"][0] is task_logger
+    assert recorded["log_task_error"][1] == "エラー発生|custom"
+    assert recorded["log_task_error"][2]["event"] == "event.id"
+    celery_logger.error.assert_called_once()
+    assert celery_logger.error.call_args.kwargs["extra"]["session_id"] == "S1"
+    assert celery_logger.error.call_args.kwargs["exc_info"] is True
+
+
+def test_queue_processor_handles_cancel_request(monkeypatch):
+    db = SimpleNamespace(session=MagicMock())
+    logger = MagicMock()
+    importer = MagicMock()
+    cancel_calls = iter([False, True])
+
+    def cancel_requested(session, task_instance=None):
+        return next(cancel_calls, True)
+
+    session = SimpleNamespace(id=1)
+    selection = SimpleNamespace(
+        id=2,
+        local_file_path="/tmp/file.jpg",
+        local_filename="file.jpg",
+        status="enqueued",
+        attempts=0,
+        started_at=None,
+        error=None,
+        google_media_id=None,
+        media_id=None,
+        completed_at=None,
+    )
+
+    class DummyQuery:
+        def all(self):
+            return [selection]
+
+    processor = LocalImportQueueProcessor(
+        db=db,
+        logger=logger,
+        importer=importer,
+        cancel_requested=cancel_requested,
+    )
+
+    monkeypatch.setattr(processor, "pending_query", lambda _session: DummyQuery())
+
+    result = {"processed": 0, "success": 0, "skipped": 0, "failed": 0, "details": []}
+
+    processor.process(
+        session,
+        import_dir="/import",
+        originals_dir="/orig",
+        result=result,
+        active_session_id="S1",
+        celery_task_id="C1",
+    )
+
+    importer.import_file.assert_not_called()
+    assert result["processed"] == 0
+    assert result["canceled"] is True
+
+
+def test_queue_processor_logs_commit_error(monkeypatch):
+    db_session = MagicMock()
+    db = SimpleNamespace(session=db_session)
+    logger = MagicMock()
+    importer = MagicMock(
+        import_file=MagicMock(
+            return_value={
+                "success": True,
+                "reason": "",
+                "media_id": 10,
+                "media_google_id": 11,
+            }
+        )
+    )
+
+    cancel_requested = MagicMock(return_value=False)
+
+    session = SimpleNamespace(id=1)
+    selection = SimpleNamespace(
+        id=3,
+        local_file_path="/tmp/file.jpg",
+        local_filename="file.jpg",
+        status="enqueued",
+        attempts=0,
+        started_at=None,
+        error=None,
+        google_media_id=None,
+        media_id=None,
+        completed_at=None,
+    )
+
+    class DummyQuery:
+        def all(self):
+            return [selection]
+
+    db_session.commit.side_effect = [None, RuntimeError("boom")]
+
+    processor = LocalImportQueueProcessor(
+        db=db,
+        logger=logger,
+        importer=importer,
+        cancel_requested=cancel_requested,
+    )
+    monkeypatch.setattr(processor, "pending_query", lambda _session: DummyQuery())
+
+    result = {"processed": 0, "success": 0, "skipped": 0, "failed": 0, "details": []}
+
+    processor.process(
+        session,
+        import_dir="/import",
+        originals_dir="/orig",
+        result=result,
+        active_session_id="S1",
+        celery_task_id="C1",
+    )
+
+    assert result["success"] == 1
+    assert result["processed"] == 1
+    db_session.rollback.assert_called_once()
+    logger.error.assert_any_call(
+        "local_import.selection.finalize_failed",
+        "Selection結果の保存に失敗",
+        selection_id=selection.id,
+        file="/tmp/file.jpg",
+        file_path="/tmp/file.jpg",
+        basename="file.jpg",
+        session_id="S1",
+        celery_task_id="C1",
+        error_type="RuntimeError",
+        error_message="boom",
+    )


### PR DESCRIPTION
## Summary
- introduce a MediaFileAnalyzer domain service with an injectable metadata provider to remove ad-hoc overrides
- update the local import task to use the analyzer for duplicate refreshes while wiring application services through the new provider
- add focused unit tests for the local import logger and queue processor and ensure they are always collected

## Testing
- pytest tests/test_local_import_services.py -q
- pytest tests/test_local_import_duplicate_refresh.py::test_duplicate_import_refreshes_metadata -q
- pytest tests/test_local_import.py -k scan_directory -q

------
https://chatgpt.com/codex/tasks/task_e_68e22f3b9cd883238c044824cef5c7f4