### PR TITLE
Log regenerated playback asset paths for duplicate videos

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -476,6 +476,8 @@ def _regenerate_duplicate_video_thumbnails(
             media_id=media.id,
             note=playback_result.get("note"),
             playback_status=playback_result.get("playback_status"),
+            playback_output_path=playback_result.get("output_path"),
+            playback_poster_path=playback_result.get("poster_path"),
             status="playback_refreshed",
             attempts=attempts,
         )


### PR DESCRIPTION
## Summary
- include playback output and poster paths in the local import log that records duplicate video playback regeneration completion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e463bea360832398d47f093366755c