### PR TITLE
Move local import duplicate handling to session screen

### DIFF
--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -75,6 +75,26 @@
         <button id="refresh-sessions" class="btn btn-outline-primary d-flex align-items-center justify-content-center">
           <i id="refresh-icon" class="fas fa-arrows-rotate me-2"></i>{{ _("Refresh sessions") }}
         </button>
+        {% if is_admin %}
+          <div class="border rounded p-3 bg-body-tertiary">
+            <div class="fw-semibold small mb-1">{{ _("Duplicate handling") }}</div>
+            <p class="text-muted small mb-2">{{ _("Choose how duplicate videos should refresh their thumbnails and playback assets during import.") }}</p>
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="duplicate-regeneration" id="duplicate-regenerate" value="regenerate" checked>
+              <label class="form-check-label" for="duplicate-regenerate">
+                {{ _("Regenerate thumbnails and playback assets") }}
+              </label>
+              <div class="form-text">{{ _("Always recreate thumbnails and playback MP4 files even when they already exist.") }}</div>
+            </div>
+            <div class="form-check mt-2">
+              <input class="form-check-input" type="radio" name="duplicate-regeneration" id="duplicate-skip" value="skip">
+              <label class="form-check-label" for="duplicate-skip">
+                {{ _("Keep existing assets for duplicates") }}
+              </label>
+              <div class="form-text">{{ _("Skip regeneration when the duplicate already has thumbnails and playback assets.") }}</div>
+            </div>
+          </div>
+        {% endif %}
         <button type="button" id="local-import-btn" class="btn btn-outline-info d-flex align-items-center justify-content-center"
                 data-import-display="{{ local_import_info.import.display or '' }}"
                 data-import-absolute="{{ local_import_info.import.absolute or '' }}"
@@ -179,6 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const createSessionBtn = document.getElementById('create-session-btn');
   const accountSelect = document.getElementById('session-account');
   const localImportBtn = document.getElementById('local-import-btn');
+  const duplicateModeRadios = document.querySelectorAll('input[name="duplicate-regeneration"]');
   const isAdmin = {{ 'true' if is_admin else 'false' }};
 
   const selectAccountMessage = '{{ _("Please choose a Google account first.") }}';
@@ -199,6 +220,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportCancelConfirmMessage = '{{ _("Are you sure you want to cancel the local import?") }}';
   const stopLocalImportLabel = '{{ _("Stop Local Import") }}';
   const localImportRunningMessage = '{{ _("Local import is running. You can stop it if needed.") }}';
+  const duplicateModeSummaryLabel = '{{ _("Duplicate handling") }}';
+  const duplicateModeRegenerateLabel = '{{ _("Regenerate thumbnails and playback assets") }}';
+  const duplicateModeSkipLabel = '{{ _("Keep existing assets for duplicates") }}';
+  const duplicateModeRegenerateDescription = '{{ _("Always recreate thumbnails and playback MP4 files even when they already exist.") }}';
+  const duplicateModeSkipDescription = '{{ _("Skip regeneration when the duplicate already has thumbnails and playback assets.") }}';
 
   let totalLoaded = 0;
   const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
@@ -254,6 +280,37 @@ document.addEventListener('DOMContentLoaded', () => {
       return session.accountEmail;
     }
     return '-';
+  }
+
+  function normalizeDuplicateMode(value) {
+    if (typeof value !== 'string') {
+      return 'regenerate';
+    }
+    return value.toLowerCase() === 'skip' ? 'skip' : 'regenerate';
+  }
+
+  function getSelectedDuplicateMode() {
+    let selected = 'regenerate';
+    duplicateModeRadios.forEach((radio) => {
+      if (radio.checked) {
+        selected = normalizeDuplicateMode(radio.value);
+      }
+    });
+    return selected;
+  }
+
+  function describeDuplicateMode(mode) {
+    const normalized = normalizeDuplicateMode(mode);
+    if (normalized === 'skip') {
+      return {
+        label: duplicateModeSkipLabel,
+        description: duplicateModeSkipDescription,
+      };
+    }
+    return {
+      label: duplicateModeRegenerateLabel,
+      description: duplicateModeRegenerateDescription,
+    };
   }
 
   function getStatusBadgeClass(status) {
@@ -494,6 +551,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const destinationDisplay = localImportBtn.dataset.destinationDisplay || localImportBtn.dataset.destinationAbsolute || '';
       const destinationReal = localImportBtn.dataset.destinationRealpath || '';
       const destinationExists = localImportBtn.dataset.destinationExists === '1';
+      const duplicateMode = getSelectedDuplicateMode();
+      const duplicateModeInfo = describeDuplicateMode(duplicateMode);
 
       const confirmLines = [localImportPromptHeader];
       if (importDisplay) {
@@ -518,6 +577,10 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         confirmLines.push(localImportDestinationUnset);
       }
+      confirmLines.push(`${duplicateModeSummaryLabel}: ${duplicateModeInfo.label}`);
+      if (duplicateModeInfo.description) {
+        confirmLines.push(duplicateModeInfo.description);
+      }
       confirmLines.push(localImportRemovalNotice);
 
       if (!confirm(confirmLines.join('\n'))) {
@@ -528,7 +591,9 @@ document.addEventListener('DOMContentLoaded', () => {
         // Notify that the import is starting
         showInfoToast(localImportStartingNotice, 3000);
 
-        const resp = await window.apiClient.post('/api/sync/local-import');
+        const resp = await window.apiClient.post('/api/sync/local-import', {
+          duplicateRegeneration: duplicateMode,
+        });
 
         if (!resp.ok) {
           const text = await resp.text().catch(() => '');

--- a/webapp/photo_view/templates/photo_view/settings.html
+++ b/webapp/photo_view/templates/photo_view/settings.html
@@ -78,27 +78,6 @@
 
                 <div id="status-message" class="alert alert-warning mt-3 d-none" role="alert"></div>
 
-                {% if is_admin %}
-                <div id="duplicate-regeneration-options" class="mt-4">
-                    <h3 class="h6 mb-2">{{ _("Duplicate handling") }}</h3>
-                    <p class="text-muted small mb-3">{{ _("Choose how duplicate videos should refresh their thumbnails and playback assets during import.") }}</p>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" name="duplicate-regeneration" id="duplicate-regenerate" value="regenerate" checked>
-                        <label class="form-check-label" for="duplicate-regenerate">
-                            {{ _("Regenerate thumbnails and playback assets") }}
-                        </label>
-                        <div class="form-text">{{ _("Always recreate thumbnails and playback MP4 files even when they already exist.") }}</div>
-                    </div>
-                    <div class="form-check mt-2">
-                        <input class="form-check-input" type="radio" name="duplicate-regeneration" id="duplicate-skip" value="skip">
-                        <label class="form-check-label" for="duplicate-skip">
-                            {{ _("Keep existing assets for duplicates") }}
-                        </label>
-                        <div class="form-text">{{ _("Skip regeneration when the duplicate already has thumbnails and playback assets.") }}</div>
-                    </div>
-                </div>
-                {% endif %}
-
                 {% if not is_admin %}
                 <p class="text-muted small mt-3 mb-0">
                     <i class="bi bi-info-circle"></i>
@@ -159,11 +138,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressTotal = document.getElementById('progress-total');
   const progressMessage = document.getElementById('progress-message');
   const resultDiv = document.getElementById('import-result');
-  const duplicateOptionsSection = document.getElementById('duplicate-regeneration-options');
-  const duplicateModeRadios = document.querySelectorAll('input[name="duplicate-regeneration"]');
 
   const isAdmin = JSON.parse("{{ is_admin | tojson }}");
-  const duplicateModeStorageKey = 'localImportDuplicateRegeneration';
 
   let currentTaskId = null;
   let progressInterval = null;
@@ -183,54 +159,6 @@ document.addEventListener('DOMContentLoaded', () => {
     statusMessageEl.classList.add('d-none');
     statusMessageEl.classList.remove('alert-warning', 'alert-danger', 'alert-success', 'alert-info');
     statusMessageEl.innerHTML = '';
-  }
-
-  function normalizeDuplicateMode(value) {
-    if (typeof value !== 'string') {
-      return 'regenerate';
-    }
-    const normalized = value.toLowerCase();
-    return normalized === 'skip' ? 'skip' : 'regenerate';
-  }
-
-  function loadStoredDuplicateMode(defaultValue = 'regenerate') {
-    let stored = defaultValue;
-    try {
-      const raw = window.localStorage?.getItem(duplicateModeStorageKey);
-      if (raw) {
-        stored = normalizeDuplicateMode(raw);
-      }
-    } catch (error) {
-      stored = defaultValue;
-    }
-    return stored;
-  }
-
-  function persistDuplicateMode(mode) {
-    const normalized = normalizeDuplicateMode(mode);
-    try {
-      window.localStorage?.setItem(duplicateModeStorageKey, normalized);
-    } catch (error) {
-      // ignore
-    }
-    return normalized;
-  }
-
-  function setDuplicateMode(mode) {
-    const normalized = normalizeDuplicateMode(mode);
-    duplicateModeRadios.forEach((radio) => {
-      radio.checked = radio.value === normalized;
-    });
-  }
-
-  function getDuplicateMode() {
-    let mode = 'regenerate';
-    duplicateModeRadios.forEach((radio) => {
-      if (radio.checked) {
-        mode = normalizeDuplicateMode(radio.value);
-      }
-    });
-    return mode;
   }
 
   function showStatusMessage(message, level = 'warning') {
@@ -361,11 +289,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     updateSystemStatus(data.status, data.config);
 
-    if (isAdmin && duplicateModeRadios.length) {
-      const defaultMode = normalizeDuplicateMode(data?.defaults?.duplicateRegeneration || 'regenerate');
-      const storedMode = loadStoredDuplicateMode(defaultMode);
-      setDuplicateMode(storedMode);
-    }
   }
 
   async function loadStatus() {
@@ -526,11 +449,10 @@ document.addEventListener('DOMContentLoaded', () => {
     showProgressSection();
 
     try {
-      const duplicateMode = persistDuplicateMode(getDuplicateMode());
       const response = await fetch('/api/sync/local-import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ duplicateRegeneration: duplicateMode }),
+        body: JSON.stringify({ duplicateRegeneration: 'regenerate' }),
       });
       const data = await response.json();
       if (!response.ok || !data.success) {
@@ -582,17 +504,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!startImportBtn.disabled) {
         handleStartImport();
       }
-    });
-  }
-
-  if (duplicateOptionsSection && duplicateModeRadios.length) {
-    setDuplicateMode(loadStoredDuplicateMode());
-    duplicateModeRadios.forEach((radio) => {
-      radio.addEventListener('change', () => {
-        if (radio.checked) {
-          persistDuplicateMode(radio.value);
-        }
-      });
     });
   }
 


### PR DESCRIPTION
## Summary
- add duplicate handling radio buttons to the photo-view session page so admins can choose how duplicates are processed during local import
- send the selected duplicate handling mode with the Start local import action and show the choice in the confirmation prompt
- simplify the settings page script by removing the duplicate handling controls and always using the default behaviour there

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e478f40408832397bf4182d8730c46