### PR TITLE
Handle invalid duplicate video regeneration modes

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -327,7 +327,21 @@ def _regenerate_duplicate_video_thumbnails(
 
     thumb_func = thumbs_generate
     operation_id = f"duplicate-video-{media.id}"
-    regen_mode = (regeneration_mode or "regenerate").lower()
+    regen_mode_raw = regeneration_mode or "regenerate"
+    if not isinstance(regen_mode_raw, str):
+        regen_mode_raw = "regenerate"
+
+    regen_mode = regen_mode_raw.strip().lower()
+    if regen_mode not in {"regenerate", "skip"}:
+        _log_warning(
+            "local_import.duplicate_video.invalid_regeneration_mode",
+            "未知の再生成モードが指定されたため既定値にフォールバックします",
+            session_id=session_id,
+            media_id=media.id,
+            requested_mode=regen_mode_raw,
+            status="invalid_regen_mode",
+        )
+        regen_mode = "regenerate"
 
     if regen_mode == "skip":
         _log_info(


### PR DESCRIPTION
## Summary
- normalize the duplicate video regeneration mode and fall back to regenerate when an unknown value is provided
- add a regression test to ensure playback assets are forced to regenerate when the mode is invalid

## Testing
- pytest tests/test_video_import.py::test_duplicate_video_invalid_regen_mode_forces_playback


------
https://chatgpt.com/codex/tasks/task_e_68e493fc50588323a57582fd98a75589