### PR TITLE
Link duplicate selections to media items

### DIFF
--- a/application/local_import/queue.py
+++ b/application/local_import/queue.py
@@ -275,6 +275,9 @@ class LocalImportQueueProcessor:
                     selection.media_id = file_result.get("media_id")
                 elif result_status in {"duplicate", "duplicate_refreshed"}:
                     selection.status = "dup"
+                    existing_google_id = file_result.get("media_google_id")
+                    if existing_google_id:
+                        selection.google_media_id = existing_google_id
                 else:
                     selection.status = "failed"
                     selection.error = file_result.get("reason")


### PR DESCRIPTION
## Summary
- ensure duplicate selections persist the media identifiers needed to render links in the session view
- add a regression test that exercises the local import queue when a duplicate file is detected

## Testing
- pytest tests/test_local_import.py::test_local_import_duplicate_sets_google_media_id

------
https://chatgpt.com/codex/tasks/task_e_68e49dadf5548323be1c3e1e41305ebf