### PR TITLE
Fix duplicate import path updates for MOV creation time

### DIFF
--- a/application/local_import/file_importer.py
+++ b/application/local_import/file_importer.py
@@ -292,6 +292,13 @@ class LocalImportFileImporter:
                 outcome.details["reason"] = (
                     f"重複ファイル (既存ID: {existing_media.id}) - メタデータ更新"
                 )
+                destination_details = existing_media_destination_context(
+                    existing_media, originals_dir
+                )
+                for key in ("imported_path", "imported_filename", "relative_path"):
+                    value = destination_details.get(key)
+                    if value:
+                        outcome.details[key] = value
                 outcome.mark("duplicate_refreshed")
                 self._logger.info(
                     "local_import.file.duplicate_refreshed",


### PR DESCRIPTION
## Summary
- ensure duplicate metadata refresh realigns stored originals when the computed relative path changes
- propagate refreshed destination details after updating MOV creation time metadata
- add a regression test covering directory updates on duplicate import

## Testing
- pytest tests/test_local_import_duplicate_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a2a70d54832388879c2c3edc8ee5