### PR TITLE
Adjust login language selector layout

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -3,28 +3,29 @@
 {% block body_attributes %} class="login-page"{% endblock %}
 
 {% block content %}
-{% if not current_user.is_authenticated and language_selector_languages %}
-<div class="language-selector d-flex justify-content-end mb-3 w-100">
-  <div class="dropdown">
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
-            data-bs-toggle="dropdown" aria-expanded="false">
-      <i class="bi bi-translate me-1"></i>
-      {{ language_labels.get(current_language) or (current_language|upper) }}
-    </button>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
-      {% for lang_code in language_selector_languages %}
-      <li>
-        <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
-          {{ language_labels.get(lang_code) or (lang_code|upper) }}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-{% endif %}
 <div class="login-container">
   <div class="login-card">
+    {% if not current_user.is_authenticated and language_selector_languages %}
+    <div class="login-card-toolbar">
+      <div class="language-selector dropdown">
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown"
+                data-bs-toggle="dropdown" aria-expanded="false"
+                aria-label="{{ _('Select language') }}">
+          <i class="bi bi-translate"></i>
+          <span class="language-label">{{ language_labels.get(current_language) or (current_language|upper) }}</span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
+          {% for lang_code in language_selector_languages %}
+          <li>
+            <a class="dropdown-item{% if lang_code == current_language %} active{% endif %}" href="{{ url_for('set_lang', lang_code=lang_code) }}">
+              {{ language_labels.get(lang_code) or (lang_code|upper) }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    {% endif %}
     <div class="login-header">
       <h1 class="login-title">{{ _('Welcome Back') }}</h1>
       <p class="login-subtitle">{{ _('Sign in to your PhotoNest account') }}</p>

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -397,6 +397,33 @@ body.login-page .flash-messages .alert {
   pointer-events: auto;
 }
 
+.login-card-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1.5rem;
+}
+
+body.login-page .login-card .language-selector {
+  align-self: flex-end;
+}
+
+.login-card .language-selector .dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  line-height: 1.2;
+}
+
+.login-card .language-selector .dropdown-toggle .bi-translate {
+  font-size: 1.05rem;
+}
+
+.login-card .language-selector .dropdown-menu {
+  min-width: 11rem;
+}
+
 .login-card {
   animation: fadeInUp 0.6s ease-out;
 }
@@ -467,6 +494,27 @@ body.login-page .flash-messages .alert {
     min-width: 0;
     max-width: none;
     width: 100%;
+  }
+
+  .login-card-toolbar {
+    justify-content: flex-end;
+  }
+
+  .login-card .language-selector .dropdown-toggle {
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0.5rem;
+    border-radius: 50%;
+    justify-content: center;
+    gap: 0;
+  }
+
+  .login-card .language-selector .dropdown-toggle .language-label {
+    display: none;
+  }
+
+  .login-card .language-selector .dropdown-toggle .bi-translate {
+    margin: 0;
   }
 
   .language-selector {

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -504,7 +504,7 @@ body.login-page .login-card .language-selector {
     width: 2.5rem;
     height: 2.5rem;
     padding: 0.5rem;
-    border-radius: 50%;
+    border-radius: 0.75rem;
     justify-content: center;
     gap: 0;
   }


### PR DESCRIPTION
## Summary
- move the login language selector inside the card so it sits in the top-right corner
- restyle the selector so the label hides on narrow screens and the button becomes icon-only on mobile

## Testing
- manual: viewed `/auth/login` in desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68e4aa641bc08323a2bcac658cf7442c