### PR TITLE
Fix playback path alignment for duplicate imports

### DIFF
--- a/tests/test_local_import_duplicate_refresh.py
+++ b/tests/test_local_import_duplicate_refresh.py
@@ -138,6 +138,7 @@ def test_duplicate_import_updates_relative_path(monkeypatch, tmp_path, app_conte
     import_dir.mkdir()
     originals_dir.mkdir()
     monkeypatch.setenv("FPV_NAS_PLAY_DIR", str(playback_dir))
+    monkeypatch.setattr(local_import, "_playback_storage_root", lambda: playback_dir)
 
     payload = b"dummy-video-payload"
     file_path = import_dir / "sample.mov"
@@ -274,3 +275,127 @@ def test_duplicate_import_updates_relative_path(monkeypatch, tmp_path, app_conte
     assert (playback_dir / expected_playback_rel).exists()
     assert (playback_dir / expected_poster_rel).exists()
 
+
+def test_duplicate_refresh_realigns_playback_paths(
+    monkeypatch, tmp_path, app_context
+):
+    """撮影日時が変わらなくても再生アセットのディレクトリを補正する。"""
+
+    import_dir = tmp_path / "import"
+    originals_dir = tmp_path / "originals"
+    playback_dir = tmp_path / "playback"
+    import_dir.mkdir()
+    originals_dir.mkdir()
+    monkeypatch.setenv("FPV_NAS_PLAY_DIR", str(playback_dir))
+    monkeypatch.setattr(local_import, "_playback_storage_root", lambda: playback_dir)
+
+    original_update = local_import._update_media_playback_paths
+    update_calls = {}
+
+    def _tracking_update(*args, **kwargs):
+        update_calls["called"] = True
+        update_calls["kwargs"] = kwargs
+        return original_update(*args, **kwargs)
+
+    monkeypatch.setattr(local_import, "_update_media_playback_paths", _tracking_update)
+
+    payload = b"dummy-video-payload"
+    file_path = import_dir / "sample.mov"
+
+    class DummyAnalyzer:
+        def __init__(self) -> None:
+            self.mode = "old"
+            self.relative_path = "2018/01/28/20180128_local_dummy.mov"
+
+        def analyze(self, path: str) -> MediaFileAnalysis:
+            file_hash = local_import.calculate_file_hash(path)
+            size = Path(path).stat().st_size
+            shot = datetime(2018, 1, 28, 1, 39, 22, tzinfo=timezone.utc)
+            width = 1920 if self.mode == "old" else 3840
+            return MediaFileAnalysis(
+                source=ImportFile(path),
+                extension=".mov",
+                file_size=size,
+                file_hash=file_hash,
+                mime_type="video/quicktime",
+                is_video=True,
+                width=width,
+                height=1080,
+                duration_ms=1234,
+                orientation=None,
+                shot_at=shot,
+                exif_data={},
+                video_metadata={"fps": 30.0},
+                destination_filename=Path(self.relative_path).name,
+                relative_path=self.relative_path,
+            )
+
+    analyzer = DummyAnalyzer()
+    monkeypatch.setattr(local_import, "_media_analyzer", analyzer)
+    monkeypatch.setattr(local_import._file_importer, "_analysis_service", analyzer.analyze)
+    monkeypatch.setattr(
+        local_import._file_importer,
+        "_post_process_service",
+        lambda media, *, logger_override, request_context: {"playback": {"ok": True}},
+    )
+    monkeypatch.setattr(
+        local_import._file_importer,
+        "_validate_playback",
+        lambda *args, **kwargs: None,
+    )
+
+    file_path.write_bytes(payload)
+    first = import_single_file(str(file_path), str(import_dir), str(originals_dir))
+    assert first["success"] is True
+
+    media = Media.query.get(first["media_id"])
+    old_relative = analyzer.relative_path
+    assert media.local_rel_path == old_relative
+
+    media.has_playback = True
+    db.session.add(media)
+
+    misaligned_rel = "2025/09/26/20250926_local_dummy.mp4"
+    misaligned_poster = "2025/09/26/20250926_local_dummy.jpg"
+    playback_path = playback_dir / misaligned_rel
+    poster_path = playback_dir / misaligned_poster
+    playback_path.parent.mkdir(parents=True, exist_ok=True)
+    playback_path.write_bytes(b"playback-data")
+    poster_path.parent.mkdir(parents=True, exist_ok=True)
+    poster_path.write_bytes(b"poster-data")
+
+    playback_record = MediaPlayback(
+        media_id=media.id,
+        preset="std1080p",
+        rel_path=misaligned_rel,
+        poster_rel_path=misaligned_poster,
+        status="done",
+    )
+    db.session.add(playback_record)
+    db.session.commit()
+
+    assert MediaPlayback.query.filter_by(media_id=media.id).count() == 1
+
+    analyzer.mode = "new"
+    file_path.write_bytes(payload)
+    second = import_single_file(str(file_path), str(import_dir), str(originals_dir))
+
+    assert second["success"] is False
+    assert second["metadata_refreshed"] is True
+    assert second["relative_path"] == old_relative
+
+    db.session.expire_all()
+    refreshed = Media.query.get(first["media_id"])
+    playback_entry = MediaPlayback.query.filter_by(media_id=refreshed.id).one()
+
+    assert update_calls.get("called") is True
+
+    expected_playback_rel = Path(old_relative).with_suffix(".mp4").as_posix()
+    expected_poster_rel = Path(old_relative).with_suffix(".jpg").as_posix()
+
+    assert playback_entry.rel_path == expected_playback_rel
+    assert playback_entry.poster_rel_path == expected_poster_rel
+    assert not (playback_dir / misaligned_rel).exists()
+    assert not (playback_dir / misaligned_poster).exists()
+    assert (playback_dir / expected_playback_rel).exists()
+    assert (playback_dir / expected_poster_rel).exists()


### PR DESCRIPTION
## Summary
- realign duplicate media playback assets even when the stored relative path does not change
- add a regression test that covers playback path correction for duplicate MOV imports

## Testing
- pytest tests/test_local_import_duplicate_refresh.py -k "realign or relative" -v

------
https://chatgpt.com/codex/tasks/task_e_68e4ad3cc7a88323ab6245b3655a4130