### PR TITLE
Fix picker retry loop after rate limit responses

### DIFF
--- a/webapp/auth/templates/auth/picker.html
+++ b/webapp/auth/templates/auth/picker.html
@@ -143,7 +143,7 @@
     const defaultRetryDelayMs = 1000;
     try {
       let cursor = null;
-      do {
+      while (true) {
         const resp = await fetch('/api/picker/session/mediaItems', {
           method: 'POST',
           headers: {
@@ -178,7 +178,10 @@
         }
         const data = await resp.json();
         cursor = data.nextCursor;
-      } while (cursor);
+        if (!cursor) {
+          break;
+        }
+      }
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
## Summary
- switch the picker media fetch loop to an open-ended while loop so 429 responses are retried after the delay
- exit the loop explicitly when the server stops returning a next cursor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c819139c83238f224abbd48ff196