### PR TITLE
Add upload preparation and commit workflow

### DIFF
--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,0 +1,115 @@
+import io
+from pathlib import Path
+
+import pytest
+
+from core.models.user import User
+from webapp.extensions import db
+from webapp.services.token_service import TokenService
+
+
+@pytest.fixture
+def client(app_context, tmp_path):
+    app = app_context
+    app.config['UPLOAD_TMP_DIR'] = str(tmp_path / 'tmp')
+    app.config['UPLOAD_DESTINATION_DIR'] = str(tmp_path / 'dest')
+    app.config['UPLOAD_MAX_SIZE'] = 1024 * 1024
+
+    (tmp_path / 'tmp').mkdir(parents=True, exist_ok=True)
+    (tmp_path / 'dest').mkdir(parents=True, exist_ok=True)
+
+    with app.app_context():
+        user = User(email='upload@example.com')
+        user.set_password('password')
+        db.session.add(user)
+        db.session.commit()
+
+    return app.test_client()
+
+
+@pytest.fixture
+def auth_headers(client):
+    app = client.application
+    with app.app_context():
+        user = User.query.filter_by(email='upload@example.com').first()
+        token = TokenService.generate_access_token(user)
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_prepare_upload_analyzes_file(client, auth_headers):
+    file_content = b'col1,col2\n1,2\n3,4\n'
+    response = client.post(
+        '/api/upload/prepare',
+        data={'file': (io.BytesIO(file_content), 'sample.csv')},
+        headers=auth_headers,
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['fileName'] == 'sample.csv'
+    assert payload['status'] == 'analyzed'
+    assert payload['fileSize'] == len(file_content)
+    assert payload['analysisResult']['format'] == 'CSV'
+    assert payload['analysisResult']['recordCount'] == 3
+
+    with client.session_transaction() as sess:
+        session_id = sess.get('upload_session_id')
+
+    assert session_id
+    tmp_dir = Path(client.application.config['UPLOAD_TMP_DIR']) / session_id
+    stored_path = tmp_dir / payload['tempFileId']
+    metadata_path = tmp_dir / f"{payload['tempFileId']}.json"
+    assert stored_path.exists()
+    assert metadata_path.exists()
+
+
+def test_commit_upload_moves_files(client, auth_headers):
+    file_content = b'col1\nvalue\n'
+    prepare_resp = client.post(
+        '/api/upload/prepare',
+        data={'file': (io.BytesIO(file_content), 'commit.csv')},
+        headers=auth_headers,
+        content_type='multipart/form-data',
+    )
+    temp_payload = prepare_resp.get_json()
+    assert prepare_resp.status_code == 200
+
+    with client.session_transaction() as sess:
+        session_id = sess.get('upload_session_id')
+
+    assert session_id
+    tmp_dir = Path(client.application.config['UPLOAD_TMP_DIR']) / session_id
+    assert tmp_dir.exists()
+
+    commit_resp = client.post(
+        '/api/upload/commit',
+        json={'files': [{'tempFileId': temp_payload['tempFileId']}]},
+        headers=auth_headers,
+    )
+    assert commit_resp.status_code == 200
+    commit_data = commit_resp.get_json()
+    assert commit_data['uploaded'][0]['status'] == 'success'
+
+    assert not tmp_dir.exists()
+
+    app = client.application
+    with app.app_context():
+        user = User.query.filter_by(email='upload@example.com').first()
+        dest_dir = Path(app.config['UPLOAD_DESTINATION_DIR']) / str(user.id)
+        stored_file = dest_dir / 'commit.csv'
+        assert stored_file.exists()
+        assert stored_file.read_bytes() == file_content
+
+
+def test_prepare_rejects_unsupported_extension(client, auth_headers):
+    response = client.post(
+        '/api/upload/prepare',
+        data={'file': (io.BytesIO(b'not allowed'), 'payload.exe')},
+        headers=auth_headers,
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload['error'] == 'unsupported_format'

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -7,6 +7,7 @@ from . import health  # noqa
 from . import picker_session  # noqa
 from . import openapi  # noqa
 from . import version  # noqa
+from . import upload  # noqa
 
 # picker_session Blueprintをapi Blueprintに登録
 from .picker_session import bp as picker_session_bp

--- a/webapp/api/upload.py
+++ b/webapp/api/upload.py
@@ -10,6 +10,7 @@ from ..services.upload_service import (
     UnsupportedFormatError,
     prepare_upload,
     commit_uploads,
+    has_pending_uploads,
 )
 
 
@@ -87,7 +88,7 @@ def api_upload_commit():
 
     success_count = sum(1 for item in results if item.get("status") == "success")
 
-    if success_count:
+    if success_count and not has_pending_uploads(upload_session_id):
         session.pop("upload_session_id", None)
 
     return jsonify({"uploaded": results})

--- a/webapp/api/upload.py
+++ b/webapp/api/upload.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from flask import jsonify, request, session
+
+from . import bp
+from .routes import get_current_user, login_or_jwt_required
+from ..services.upload_service import (
+    UploadError,
+    UploadTooLargeError,
+    UnsupportedFormatError,
+    prepare_upload,
+    commit_uploads,
+)
+
+
+def _get_or_create_upload_session_id() -> str:
+    upload_session_id = session.get("upload_session_id")
+    if not upload_session_id:
+        from uuid import uuid4
+
+        upload_session_id = uuid4().hex
+        session["upload_session_id"] = upload_session_id
+    return upload_session_id
+
+
+@bp.post("/upload/prepare")
+@login_or_jwt_required
+def api_upload_prepare():
+    file = request.files.get("file")
+    if not file:
+        return jsonify({"error": "file_required"}), 400
+
+    upload_session_id = _get_or_create_upload_session_id()
+
+    try:
+        prepared = prepare_upload(file, upload_session_id)
+    except UploadTooLargeError as exc:
+        return jsonify({"error": "file_too_large", "message": str(exc)}), 400
+    except UnsupportedFormatError as exc:
+        return jsonify({"error": "unsupported_format", "message": str(exc)}), 400
+    except UploadError as exc:
+        return jsonify({"error": "upload_failed", "message": str(exc)}), 400
+
+    response_payload = {
+        "tempFileId": prepared.temp_file_id,
+        "fileName": prepared.file_name,
+        "fileSize": prepared.file_size,
+        "status": prepared.status,
+        "analysisResult": prepared.analysis_result,
+    }
+
+    return jsonify(response_payload)
+
+
+@bp.post("/upload/commit")
+@login_or_jwt_required
+def api_upload_commit():
+    payload = request.get_json(silent=True) or {}
+    files = payload.get("files")
+
+    if not isinstance(files, list) or not files:
+        return jsonify({"error": "invalid_payload", "message": "No files specified"}), 400
+
+    upload_session_id = session.get("upload_session_id")
+    if not upload_session_id:
+        return jsonify({"error": "session_not_found", "message": "No prepared files found"}), 400
+
+    user = get_current_user()
+    if not user or not getattr(user, "id", None):
+        return jsonify({"error": "authentication_required"}), 401
+
+    temp_ids: list[str] = []
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        temp_id = file_entry.get("tempFileId") or file_entry.get("temp_file_id")
+        if temp_id:
+            temp_ids.append(str(temp_id))
+
+    if not temp_ids:
+        return jsonify({"error": "invalid_payload", "message": "No files specified"}), 400
+
+    try:
+        results = commit_uploads(upload_session_id, getattr(user, "id", None), temp_ids)
+    except UploadError as exc:
+        return jsonify({"error": "upload_failed", "message": str(exc)}), 400
+
+    success_count = sum(1 for item in results if item.get("status") == "success")
+
+    if success_count:
+        session.pop("upload_session_id", None)
+
+    return jsonify({"uploaded": results})

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -71,6 +71,9 @@ class Config:
     FPV_URL_TTL_THUMB = int(os.environ.get("FPV_URL_TTL_THUMB", "600"))
     FPV_URL_TTL_PLAYBACK = int(os.environ.get("FPV_URL_TTL_PLAYBACK", "600"))
     FPV_URL_TTL_ORIGINAL = int(os.environ.get("FPV_URL_TTL_ORIGINAL", "600"))
+    UPLOAD_TMP_DIR = os.environ.get("UPLOAD_TMP_DIR", "/data/tmp/upload")
+    UPLOAD_DESTINATION_DIR = os.environ.get("UPLOAD_DESTINATION_DIR", "/data/uploads")
+    UPLOAD_MAX_SIZE = int(os.environ.get("UPLOAD_MAX_SIZE", str(100 * 1024 * 1024)))
     FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_CONTAINER_DIR") or os.environ.get(
         "FPV_NAS_THUMBS_DIR", ""
     )
@@ -113,6 +116,8 @@ class TestConfig(Config):
     
     # Session設定
     SESSION_COOKIE_SECURE = False
-    
+
     # Feature X DB binding（テスト時は無効）
     SQLALCHEMY_BINDS = {}
+    UPLOAD_TMP_DIR = "/tmp/test_upload/tmp"
+    UPLOAD_DESTINATION_DIR = "/tmp/test_upload/dest"

--- a/webapp/photo_view/templates/photo_view/home.html
+++ b/webapp/photo_view/templates/photo_view/home.html
@@ -37,6 +37,33 @@
     background-color: var(--bs-tertiary-bg);
   }
 
+  .upload-dropzone {
+    border: 2px dashed var(--bs-border-color-translucent);
+    border-radius: var(--bs-border-radius);
+    padding: 2rem 1rem;
+    text-align: center;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+  }
+
+  .upload-dropzone.drag-over {
+    background-color: rgba(var(--bs-primary-rgb), 0.05);
+    border-color: rgba(var(--bs-primary-rgb), 0.4);
+  }
+
+  .upload-file-list {
+    max-height: 240px;
+    overflow-y: auto;
+  }
+
+  .upload-summary-text {
+    font-size: 0.875rem;
+  }
+
+  .upload-status-badge {
+    font-size: 0.75rem;
+  }
+
   @media (min-width: 992px) {
     .quick-actions-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -143,6 +170,9 @@
           <div class="quick-actions-grid">
             <button id="refresh-sessions" class="btn btn-outline-primary quick-action-compact quick-actions-full">
               <i id="refresh-icon" class="fas fa-arrows-rotate me-2"></i>{{ _("Refresh sessions") }}
+            </button>
+            <button type="button" id="open-upload-modal" class="btn btn-outline-secondary quick-action-compact">
+              <i class="bi bi-upload me-2"></i>{{ _("Upload files") }}
             </button>
             {% if is_admin %}
               <div class="quick-actions-panel quick-actions-full">
@@ -260,6 +290,47 @@
   </div>
 </div>
 
+<div class="modal fade" id="upload-modal" tabindex="-1" aria-labelledby="upload-modal-title" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="upload-modal-title">{{ _("Upload files") }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _("Close") }}"></button>
+      </div>
+      <div class="modal-body">
+        <div id="upload-status-message" class="alert alert-info d-none" role="status"></div>
+        <div id="upload-dropzone" class="upload-dropzone mb-3">
+          <div class="fw-semibold mb-1">{{ _("Drag & drop files here") }}</div>
+          <div class="text-muted small mb-0">{{ _("You can also click to choose files manually.") }}</div>
+        </div>
+        <label for="upload-file-input" class="form-label">{{ _("Select files") }}</label>
+        <input type="file" id="upload-file-input" class="form-control" multiple>
+        <div class="table-responsive mt-3 border rounded">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>{{ _("File") }}</th>
+                <th class="text-end">{{ _("Size") }}</th>
+                <th>{{ _("Status") }}</th>
+                <th class="text-end">{{ _("Actions") }}</th>
+              </tr>
+            </thead>
+            <tbody id="upload-file-list" class="upload-file-list">
+              <tr class="text-muted text-center">
+                <td colspan="4">{{ _("Drop files above to start analysis.") }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" id="upload-clear-btn">{{ _("Cancel") }}</button>
+        <button type="button" class="btn btn-primary" id="upload-commit-btn" disabled>{{ _("Upload") }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const sessionsBody = document.getElementById('sessions-body');
@@ -296,6 +367,36 @@ document.addEventListener('DOMContentLoaded', () => {
   const duplicateModeSkipLabel = '{{ _("Keep existing assets for duplicates") }}';
   const duplicateModeRegenerateDescription = '{{ _("Always recreate thumbnails and playback MP4 files even when they already exist.") }}';
   const duplicateModeSkipDescription = '{{ _("Skip regeneration when the duplicate already has thumbnails and playback assets.") }}';
+
+  const uploadStatusLabels = {
+    pending: '{{ _("Waiting") }}',
+    analyzing: '{{ _("Analyzing") }}',
+    analyzed: '{{ _("Analysis complete") }}',
+    uploaded: '{{ _("Uploaded") }}',
+    error: '{{ _("Error") }}',
+  };
+  const uploadStatusBadgeClasses = {
+    pending: 'bg-secondary',
+    analyzing: 'bg-warning text-dark',
+    analyzed: 'bg-info',
+    uploaded: 'bg-success',
+    error: 'bg-danger',
+  };
+  const uploadAnalysisPendingLabel = '{{ _("Waiting for analysis to start.") }}';
+  const uploadAnalyzingLabel = '{{ _("Analyzing file...") }}';
+  const uploadFormatLabel = '{{ _("Format") }}';
+  const uploadRecordsLabel = '{{ _("Records") }}';
+  const uploadLinesLabel = '{{ _("Lines") }}';
+  const uploadInvalidJsonLabel = '{{ _("Invalid JSON data") }}';
+  const uploadErrorGeneric = '{{ _("Failed to prepare the file.") }}';
+  const uploadNetworkError = '{{ _("Network error occurred while preparing the file.") }}';
+  const uploadCommitSuccessMessage = '{{ _("Upload completed successfully.") }}';
+  const uploadCommitPartialMessage = '{{ _("Some files could not be uploaded.") }}';
+  const uploadNoReadyFilesMessage = '{{ _("No analyzed files are ready for upload.") }}';
+  const uploadClearedMessage = '{{ _("Upload list cleared.") }}';
+  const uploadUploadingMessage = '{{ _("Uploading files...") }}';
+  const uploadRemoveLabel = '{{ _("Remove") }}';
+  const uploadDropPlaceholder = '{{ _("Drop files above to start analysis.") }}';
 
   let totalLoaded = 0;
   const sessionsLoadedLabel = '{{ _("sessions loaded") }}';
@@ -397,6 +498,424 @@ document.addEventListener('DOMContentLoaded', () => {
       default: return 'secondary';
     }
   }
+
+  const uploadItems = new Map();
+  let uploadSequence = 0;
+
+  function escapeHtml(str) {
+    if (str == null) {
+      return '';
+    }
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatBytes(bytes) {
+    const numeric = Number(bytes);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      return '-';
+    }
+    if (numeric === 0) {
+      return '0 B';
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const exponent = Math.min(Math.floor(Math.log(numeric) / Math.log(1024)), units.length - 1);
+    const value = numeric / (1024 ** exponent);
+    const decimals = exponent === 0 ? 0 : 1;
+    return `${value.toFixed(decimals)} ${units[exponent]}`;
+  }
+
+  function setUploadStatus(level, message) {
+    if (!uploadStatusMessage) {
+      return;
+    }
+    uploadStatusMessage.className = 'alert';
+    uploadStatusMessage.classList.add('d-none');
+    if (!message) {
+      uploadStatusMessage.textContent = '';
+      return;
+    }
+
+    const levelClass = {
+      success: 'alert-success',
+      error: 'alert-danger',
+      warning: 'alert-warning',
+      info: 'alert-info',
+    }[level || 'info'] || 'alert-info';
+
+    uploadStatusMessage.classList.add(levelClass);
+    uploadStatusMessage.textContent = message;
+    uploadStatusMessage.classList.remove('d-none');
+  }
+
+  function resetUploadStatus() {
+    setUploadStatus(null, '');
+  }
+
+  function buildAnalysisSummary(item) {
+    if (item.status === 'analyzing') {
+      return escapeHtml(uploadAnalyzingLabel);
+    }
+    if (!item.analysisResult) {
+      if (item.status === 'pending') {
+        return escapeHtml(uploadAnalysisPendingLabel);
+      }
+      if (item.status === 'error' && item.message) {
+        return escapeHtml(item.message);
+      }
+      return '';
+    }
+    const summaryParts = [];
+    const analysis = item.analysisResult;
+    if (analysis.format) {
+      summaryParts.push(`${uploadFormatLabel}: ${analysis.format}`);
+    }
+    if (typeof analysis.recordCount === 'number') {
+      summaryParts.push(`${uploadRecordsLabel}: ${analysis.recordCount}`);
+    }
+    if (
+      typeof analysis.lineCount === 'number'
+      && analysis.lineCount !== analysis.recordCount
+      && analysis.lineCount > 0
+    ) {
+      summaryParts.push(`${uploadLinesLabel}: ${analysis.lineCount}`);
+    }
+    if (analysis.valid === false) {
+      summaryParts.push(uploadInvalidJsonLabel);
+    }
+    return summaryParts.map((part) => escapeHtml(part)).join(' · ');
+  }
+
+  function renderUploadRows() {
+    if (!uploadFileList) {
+      return;
+    }
+
+    uploadFileList.innerHTML = '';
+
+    if (uploadItems.size === 0) {
+      const emptyRow = document.createElement('tr');
+      emptyRow.className = 'text-muted text-center';
+      emptyRow.innerHTML = `<td colspan="4">${escapeHtml(uploadDropPlaceholder)}</td>`;
+      uploadFileList.appendChild(emptyRow);
+      return;
+    }
+
+    uploadItems.forEach((item) => {
+      const row = document.createElement('tr');
+      row.dataset.uploadId = item.id;
+      const statusKey = item.status || 'pending';
+      const badgeClass = uploadStatusBadgeClasses[statusKey] || 'bg-secondary';
+      const statusLabel = uploadStatusLabels[statusKey] || statusKey;
+      const summary = buildAnalysisSummary(item);
+      const messageHtml = item.message
+        ? `<div class="small mt-1 ${item.status === 'error' ? 'text-danger' : 'text-success'}">${escapeHtml(item.message)}</div>`
+        : '';
+
+      row.innerHTML = `
+        <td>
+          <div class="fw-semibold">${escapeHtml(item.file?.name || item.serverFileName || '-')}</div>
+          ${summary ? `<div class="text-muted upload-summary-text mt-1">${summary}</div>` : ''}
+        </td>
+        <td class="text-end">${formatBytes(item.file?.size ?? item.serverFileSize ?? 0)}</td>
+        <td>
+          <span class="badge ${badgeClass} upload-status-badge">${escapeHtml(statusLabel)}</span>
+          ${messageHtml}
+        </td>
+        <td class="text-end">
+          <button type="button" class="btn btn-sm btn-link text-danger p-0" data-remove-upload="${escapeHtml(item.id)}">
+            <i class="bi bi-x-circle me-1"></i>${escapeHtml(uploadRemoveLabel)}
+          </button>
+        </td>
+      `;
+      uploadFileList.appendChild(row);
+    });
+  }
+
+  function updateUploadControls() {
+    if (!uploadCommitBtn || !uploadClearBtn) {
+      return;
+    }
+    const hasReady = Array.from(uploadItems.values()).some((item) => item.status === 'analyzed' && item.tempFileId);
+    uploadCommitBtn.disabled = !hasReady;
+    uploadClearBtn.disabled = uploadItems.size === 0;
+  }
+
+  function findUploadEntryByTempId(tempFileId) {
+    for (const [key, value] of uploadItems.entries()) {
+      if (value.tempFileId === tempFileId) {
+        return [key, value];
+      }
+    }
+    return [null, null];
+  }
+
+  function handleFiles(fileList) {
+    if (!fileList || fileList.length === 0) {
+      return;
+    }
+    resetUploadStatus();
+    Array.from(fileList).forEach((file) => {
+      const id = `local-${Date.now()}-${uploadSequence += 1}`;
+      const item = {
+        id,
+        file,
+        status: 'pending',
+        message: '',
+        tempFileId: null,
+        analysisResult: null,
+        serverFileName: null,
+        serverFileSize: file?.size ?? 0,
+      };
+      uploadItems.set(id, item);
+      renderUploadRows();
+      updateUploadControls();
+      prepareUpload(item).catch((error) => {
+        console.error('Failed to prepare upload', error);
+      });
+    });
+  }
+
+  async function prepareUpload(item) {
+    item.status = 'analyzing';
+    item.message = uploadAnalyzingLabel;
+    renderUploadRows();
+    updateUploadControls();
+
+    const formData = new FormData();
+    formData.append('file', item.file, item.file?.name || 'upload');
+
+    const headers = {};
+    if (window.apiClient && typeof window.apiClient.getCsrfTokenFromCookie === 'function') {
+      const token = window.apiClient.getCsrfTokenFromCookie();
+      if (token) {
+        headers['X-CSRFToken'] = token;
+      }
+    }
+
+    try {
+      const response = await fetch('/api/upload/prepare', {
+        method: 'POST',
+        headers,
+        body: formData,
+      });
+
+      if (!response.ok) {
+        let payload = {};
+        try {
+          payload = await response.json();
+        } catch (err) {
+          payload = {};
+        }
+        item.status = 'error';
+        item.message = payload.message || payload.error || uploadErrorGeneric;
+        renderUploadRows();
+        updateUploadControls();
+        return;
+      }
+
+      const data = await response.json();
+      item.status = data.status || 'analyzed';
+      item.tempFileId = data.tempFileId;
+      item.serverFileName = data.fileName || item.file?.name;
+      item.serverFileSize = data.fileSize ?? item.serverFileSize;
+      item.analysisResult = data.analysisResult || null;
+      item.message = '';
+    } catch (error) {
+      console.error('Upload preparation failed', error);
+      item.status = 'error';
+      item.message = uploadNetworkError;
+    }
+
+    renderUploadRows();
+    updateUploadControls();
+  }
+
+  async function commitUploads() {
+    if (!uploadCommitBtn) {
+      return;
+    }
+
+    const readyItems = Array.from(uploadItems.values()).filter((item) => item.status === 'analyzed' && item.tempFileId);
+    if (!readyItems.length) {
+      setUploadStatus('warning', uploadNoReadyFilesMessage);
+      return;
+    }
+
+    uploadCommitBtn.disabled = true;
+    setUploadStatus('info', uploadUploadingMessage);
+
+    try {
+      const payload = {
+        files: readyItems.map((item) => ({ tempFileId: item.tempFileId })),
+      };
+      const response = await window.apiClient.post('/api/upload/commit', payload);
+      let data = {};
+      try {
+        data = await response.json();
+      } catch (err) {
+        data = {};
+      }
+
+      if (!response.ok) {
+        const message = data.message || data.error || uploadErrorGeneric;
+        readyItems.forEach((item) => {
+          item.status = 'error';
+          item.message = message;
+        });
+        setUploadStatus('error', message);
+        return;
+      }
+
+      const results = Array.isArray(data.uploaded) ? data.uploaded : [];
+      let successCount = 0;
+      let errorCount = 0;
+      results.forEach((result) => {
+        const [key, item] = findUploadEntryByTempId(result.tempFileId);
+        if (!item) {
+          return;
+        }
+        if (result.status === 'success') {
+          successCount += 1;
+          uploadItems.delete(key);
+        } else {
+          errorCount += 1;
+          item.status = 'error';
+          item.message = result.message || uploadErrorGeneric;
+        }
+      });
+
+      if (successCount && !errorCount) {
+        renderUploadRows();
+        updateUploadControls();
+        setUploadStatus('success', uploadCommitSuccessMessage);
+        if (uploadModal) {
+          setTimeout(() => uploadModal.hide(), 1200);
+        }
+        return;
+      }
+
+      if (successCount && errorCount) {
+        setUploadStatus('warning', uploadCommitPartialMessage);
+      } else if (!successCount && errorCount) {
+        setUploadStatus('error', uploadCommitPartialMessage);
+      } else {
+        setUploadStatus('error', uploadErrorGeneric);
+      }
+    } catch (error) {
+      console.error('Upload commit failed', error);
+      setUploadStatus('error', uploadNetworkError);
+    } finally {
+      uploadCommitBtn.disabled = false;
+      renderUploadRows();
+      updateUploadControls();
+    }
+  }
+
+  function clearUploads() {
+    if (uploadItems.size === 0) {
+      return;
+    }
+    uploadItems.clear();
+    renderUploadRows();
+    updateUploadControls();
+    setUploadStatus('info', uploadClearedMessage);
+  }
+
+  if (uploadModalTrigger && uploadModal) {
+    uploadModalTrigger.addEventListener('click', () => {
+      resetUploadStatus();
+      renderUploadRows();
+      updateUploadControls();
+      uploadModal.show();
+    });
+  }
+
+  if (uploadClearBtn) {
+    uploadClearBtn.addEventListener('click', () => {
+      clearUploads();
+      if (uploadModal) {
+        uploadModal.hide();
+      }
+    });
+  }
+
+  if (uploadCommitBtn) {
+    uploadCommitBtn.addEventListener('click', () => {
+      commitUploads();
+    });
+  }
+
+  if (uploadFileInput) {
+    uploadFileInput.addEventListener('change', (event) => {
+      handleFiles(event.target.files);
+      event.target.value = '';
+    });
+  }
+
+  if (uploadFileList) {
+    uploadFileList.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-remove-upload]');
+      if (!trigger) {
+        return;
+      }
+      event.preventDefault();
+      const identifier = trigger.getAttribute('data-remove-upload');
+      if (!identifier) {
+        return;
+      }
+      uploadItems.delete(identifier);
+      renderUploadRows();
+      updateUploadControls();
+    });
+  }
+
+  if (uploadDropzone) {
+    const preventDefaults = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    ['dragenter', 'dragover'].forEach((eventName) => {
+      uploadDropzone.addEventListener(eventName, (event) => {
+        preventDefaults(event);
+        uploadDropzone.classList.add('drag-over');
+      });
+    });
+
+    ['dragleave', 'drop'].forEach((eventName) => {
+      uploadDropzone.addEventListener(eventName, (event) => {
+        preventDefaults(event);
+        if (eventName === 'drop') {
+          const files = event.dataTransfer?.files;
+          if (files && files.length) {
+            handleFiles(files);
+          }
+        }
+        uploadDropzone.classList.remove('drag-over');
+      });
+    });
+
+    uploadDropzone.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (uploadFileInput) {
+        uploadFileInput.click();
+      }
+    });
+  }
+
+  if (uploadModalElement) {
+    uploadModalElement.addEventListener('hidden.bs.modal', () => {
+      resetUploadStatus();
+    });
+  }
+
+  renderUploadRows();
+  updateUploadControls();
 
   function hasOnlyDuplicates(counts = {}) {
     let duplicateTotal = 0;

--- a/webapp/services/upload_service.py
+++ b/webapp/services/upload_service.py
@@ -277,6 +277,23 @@ def commit_uploads(session_id: str, user_id: Optional[int], temp_file_ids: Itera
             "storedPath": str(destination_path),
         })
 
+    _cleanup_session_dir_if_empty(session_dir)
+
+    return results
+
+
+def has_pending_uploads(session_id: str) -> bool:
+    session_dir = _tmp_base_dir() / session_id
+    try:
+        next(session_dir.iterdir())
+    except StopIteration:
+        return False
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _cleanup_session_dir_if_empty(session_dir: Path) -> None:
     try:
         next(session_dir.iterdir())
     except StopIteration:
@@ -287,8 +304,6 @@ def commit_uploads(session_id: str, user_id: Optional[int], temp_file_ids: Itera
     except FileNotFoundError:
         pass
 
-    return results
-
 
 __all__ = [
     "PreparedUpload",
@@ -298,4 +313,5 @@ __all__ = [
     "PreparedFileNotFoundError",
     "prepare_upload",
     "commit_uploads",
+    "has_pending_uploads",
 ]

--- a/webapp/services/upload_service.py
+++ b/webapp/services/upload_service.py
@@ -1,0 +1,301 @@
+"""ファイルアップロード関連のユーティリティ"""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+from uuid import uuid4
+
+from flask import current_app
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+
+class UploadError(Exception):
+    """アップロード関連の基本例外"""
+
+
+class UploadTooLargeError(UploadError):
+    """ファイルサイズ制限を超過した場合の例外"""
+
+
+class UnsupportedFormatError(UploadError):
+    """対応していないファイル形式の例外"""
+
+
+class PreparedFileNotFoundError(UploadError):
+    """準備済みファイルが存在しない場合の例外"""
+
+
+@dataclass
+class PreparedUpload:
+    """一時保存されたファイルのメタデータ"""
+
+    temp_file_id: str
+    file_name: str
+    file_size: int
+    status: str
+    analysis_result: dict
+
+
+_ALLOWED_EXTENSIONS = {".csv", ".tsv", ".json", ".txt"}
+_ALLOWED_MIME_PREFIXES = ("text/", "application/json")
+
+
+def _ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _tmp_base_dir() -> Path:
+    return Path(current_app.config.get("UPLOAD_TMP_DIR", "/data/tmp/upload"))
+
+
+def _destination_base_dir() -> Path:
+    return Path(current_app.config.get("UPLOAD_DESTINATION_DIR", "/data/uploads"))
+
+
+def _max_upload_size() -> int:
+    return int(current_app.config.get("UPLOAD_MAX_SIZE", 100 * 1024 * 1024))
+
+
+def _determine_session_dir(session_id: str) -> Path:
+    base = _tmp_base_dir()
+    target = base / session_id
+    _ensure_directory(target)
+    return target
+
+
+def _sanitize_filename(filename: str) -> str:
+    sanitized = secure_filename(filename or "uploaded")
+    return sanitized or "uploaded"
+
+
+def _save_stream(file: FileStorage, destination: Path) -> int:
+    max_size = _max_upload_size()
+    total = 0
+    stream = file.stream
+
+    if hasattr(stream, "seek") and stream.seekable():
+        stream.seek(0)
+
+    with destination.open("wb") as fh:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_size:
+                fh.close()
+                destination.unlink(missing_ok=True)
+                raise UploadTooLargeError("File exceeds the allowed size limit")
+            fh.write(chunk)
+
+    if hasattr(stream, "seek") and stream.seekable():
+        stream.seek(0)
+
+    return total
+
+
+def _detect_format(filename: str) -> str:
+    suffix = (Path(filename).suffix or "").lower()
+    if suffix == ".csv":
+        return "CSV"
+    if suffix == ".tsv":
+        return "TSV"
+    if suffix == ".json":
+        return "JSON"
+    if suffix == ".txt":
+        return "TEXT"
+    return "UNKNOWN"
+
+
+def _analyze_text_file(path: Path) -> dict:
+    line_count = 0
+    non_empty = 0
+    with path.open("r", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            line_count += 1
+            if line.strip():
+                non_empty += 1
+    return {"lineCount": line_count, "recordCount": non_empty}
+
+
+def _analyze_json_file(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {"format": "JSON", "recordCount": 0, "valid": False}
+
+    if isinstance(data, list):
+        record_count = len(data)
+    elif isinstance(data, dict):
+        record_count = len(data)
+    else:
+        record_count = 1
+
+    return {"format": "JSON", "recordCount": record_count, "valid": True}
+
+
+def _build_analysis(path: Path, filename: str) -> dict:
+    detected_format = _detect_format(filename)
+    if detected_format == "CSV" or detected_format == "TSV" or detected_format == "TEXT":
+        stats = _analyze_text_file(path)
+        stats.setdefault("recordCount", stats.get("lineCount", 0))
+        stats["format"] = detected_format
+        return stats
+    if detected_format == "JSON":
+        stats = _analyze_json_file(path)
+        stats.setdefault("format", "JSON")
+        return stats
+    return {"format": detected_format}
+
+
+def prepare_upload(file: FileStorage, session_id: str) -> PreparedUpload:
+    if not file or not getattr(file, "filename", None):
+        raise UploadError("No file uploaded")
+
+    original_name = file.filename
+    suffix = (Path(original_name).suffix or "").lower()
+    mimetype = (file.mimetype or "").lower()
+
+    if suffix not in _ALLOWED_EXTENSIONS:
+        raise UnsupportedFormatError("Unsupported file format")
+
+    if mimetype and not any(mimetype.startswith(prefix) for prefix in _ALLOWED_MIME_PREFIXES):
+        raise UnsupportedFormatError("Unsupported file format")
+
+    session_dir = _determine_session_dir(session_id)
+    temp_file_id = uuid4().hex
+    temp_path = session_dir / temp_file_id
+
+    file_size = _save_stream(file, temp_path)
+
+    analysis_result = _build_analysis(temp_path, original_name)
+    analysis_result.setdefault("format", _detect_format(original_name))
+
+    metadata = {
+        "temp_file_id": temp_file_id,
+        "file_name": original_name,
+        "file_size": file_size,
+        "status": "analyzed",
+        "analysis_result": analysis_result,
+    }
+
+    metadata_path = session_dir / f"{temp_file_id}.json"
+    metadata_path.write_text(json.dumps(metadata, ensure_ascii=False), encoding="utf-8")
+
+    return PreparedUpload(
+        temp_file_id=temp_file_id,
+        file_name=original_name,
+        file_size=file_size,
+        status="analyzed",
+        analysis_result=analysis_result,
+    )
+
+
+def _load_metadata(session_dir: Path, temp_file_id: str) -> dict:
+    metadata_path = session_dir / f"{temp_file_id}.json"
+    if not metadata_path.exists():
+        raise PreparedFileNotFoundError("Prepared file metadata not found")
+    text = metadata_path.read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def _delete_metadata(session_dir: Path, temp_file_id: str) -> None:
+    metadata_path = session_dir / f"{temp_file_id}.json"
+    metadata_path.unlink(missing_ok=True)
+
+
+def _generate_destination_path(dest_dir: Path, filename: str) -> Path:
+    sanitized = _sanitize_filename(filename)
+    candidate = dest_dir / sanitized
+    if not candidate.exists():
+        return candidate
+
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 1
+    while True:
+        numbered = dest_dir / f"{stem}_{counter}{suffix}"
+        if not numbered.exists():
+            return numbered
+        counter += 1
+
+
+def commit_uploads(session_id: str, user_id: Optional[int], temp_file_ids: Iterable[str]) -> list[dict]:
+    if not user_id:
+        raise UploadError("User information is required to commit uploads")
+
+    session_dir = _determine_session_dir(session_id)
+    destination_dir = _destination_base_dir() / str(user_id)
+    _ensure_directory(destination_dir)
+
+    results = []
+
+    for temp_file_id in temp_file_ids:
+        try:
+            metadata = _load_metadata(session_dir, temp_file_id)
+        except PreparedFileNotFoundError:
+            results.append({
+                "tempFileId": temp_file_id,
+                "status": "error",
+                "message": "File not found or already committed",
+            })
+            continue
+
+        temp_path = session_dir / temp_file_id
+        if not temp_path.exists():
+            _delete_metadata(session_dir, temp_file_id)
+            results.append({
+                "tempFileId": temp_file_id,
+                "status": "error",
+                "message": "File not found or already committed",
+            })
+            continue
+
+        destination_path = _generate_destination_path(destination_dir, metadata.get("file_name", "uploaded"))
+
+        try:
+            shutil.move(str(temp_path), str(destination_path))
+        except FileNotFoundError:
+            results.append({
+                "tempFileId": temp_file_id,
+                "status": "error",
+                "message": "File not found or already committed",
+            })
+            continue
+
+        _delete_metadata(session_dir, temp_file_id)
+
+        results.append({
+            "tempFileId": temp_file_id,
+            "status": "success",
+            "fileName": metadata.get("file_name"),
+            "storedPath": str(destination_path),
+        })
+
+    try:
+        next(session_dir.iterdir())
+    except StopIteration:
+        try:
+            session_dir.rmdir()
+        except OSError:
+            pass
+    except FileNotFoundError:
+        pass
+
+    return results
+
+
+__all__ = [
+    "PreparedUpload",
+    "UploadError",
+    "UploadTooLargeError",
+    "UnsupportedFormatError",
+    "PreparedFileNotFoundError",
+    "prepare_upload",
+    "commit_uploads",
+]

--- a/webapp/static/js/api-client.js
+++ b/webapp/static/js/api-client.js
@@ -80,15 +80,29 @@ class APIClient {
       headers['X-CSRFToken'] = csrfToken;
     }
 
-    // Content-Typeが指定されていない場合はJSONを設定
-    if (body && typeof body === 'object' && !headers['Content-Type']) {
+    const isFormData = typeof FormData !== 'undefined' && body instanceof FormData;
+    const isURLSearchParams = typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams;
+    const isBlob = typeof Blob !== 'undefined' && body instanceof Blob;
+    const isArrayBuffer = typeof ArrayBuffer !== 'undefined' && body instanceof ArrayBuffer;
+    const isDataView = typeof DataView !== 'undefined' && body instanceof DataView;
+    const shouldSerializeJson = (
+      body &&
+      typeof body === 'object' &&
+      !isFormData &&
+      !isURLSearchParams &&
+      !isBlob &&
+      !isArrayBuffer &&
+      !isDataView
+    );
+
+    if (shouldSerializeJson && !headers['Content-Type']) {
       headers['Content-Type'] = 'application/json';
     }
 
     const requestConfig = {
       method,
       headers,
-      body: typeof body === 'object' ? JSON.stringify(body) : body,
+      body: shouldSerializeJson ? JSON.stringify(body) : body,
       ...options
     };
 


### PR DESCRIPTION
## Summary
- implement upload preparation and commit endpoints with temporary storage, file analysis, and commit handling
- add upload modal to the picker session home screen with drag-and-drop uploads and status updates
- extend the API client to support FormData payloads and cover the new upload flow with tests

## Testing
- pytest tests/test_upload_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b4a9d0448323b201daf43260f65d