### PR TITLE
Refactor media post-processing tasks into layered services

### DIFF
--- a/application/media_processing/__init__.py
+++ b/application/media_processing/__init__.py
@@ -1,0 +1,25 @@
+"""アプリケーション層: メディア後処理ユースケース."""
+
+from .interfaces import (
+    ThumbnailRetryEntry,
+    ThumbnailRetryRepository,
+    ThumbnailRetryScheduler,
+)
+from .logger import StructuredMediaTaskLogger
+from .playback_service import MediaPlaybackService
+from .post_processing_service import MediaPostProcessingService
+from .retry_monitor import ThumbnailRetryMonitorService
+from .retry_service import ThumbnailRetryService
+from .thumbnail_service import ThumbnailGenerationService
+
+__all__ = [
+    "MediaPlaybackService",
+    "MediaPostProcessingService",
+    "StructuredMediaTaskLogger",
+    "ThumbnailGenerationService",
+    "ThumbnailRetryEntry",
+    "ThumbnailRetryMonitorService",
+    "ThumbnailRetryRepository",
+    "ThumbnailRetryScheduler",
+    "ThumbnailRetryService",
+]

--- a/application/media_processing/interfaces.py
+++ b/application/media_processing/interfaces.py
@@ -1,0 +1,93 @@
+"""メディア後処理アプリケーション層の抽象インターフェース."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, Optional, Protocol
+
+
+@dataclass(frozen=True)
+class ThumbnailRetryEntry:
+    """再試行レコードのスナップショット."""
+
+    id: int
+    media_id: Optional[int]
+    attempts: int
+    payload: Dict[str, object]
+
+    def with_attempts(self, attempts: int) -> "ThumbnailRetryEntry":
+        return ThumbnailRetryEntry(
+            id=self.id,
+            media_id=self.media_id,
+            attempts=attempts,
+            payload=dict(self.payload),
+        )
+
+
+class ThumbnailRetryRepository(Protocol):
+    """再試行レコードの永続化を担当するリポジトリ."""
+
+    def get_or_create(self, media_id: int) -> ThumbnailRetryEntry:
+        ...
+
+    def persist_scheduled(
+        self,
+        entry: ThumbnailRetryEntry,
+        *,
+        countdown_seconds: int,
+        force: bool,
+        celery_task_id: Optional[str],
+        attempt: int,
+        blockers: Optional[Dict[str, object]] = None,
+    ) -> None:
+        ...
+
+    def mark_exhausted(
+        self,
+        entry: ThumbnailRetryEntry,
+        *,
+        force: bool,
+        blockers: Optional[Dict[str, object]] = None,
+    ) -> None:
+        ...
+
+    def clear_success(self, media_id: int) -> None:
+        ...
+
+    def iter_due(self, limit: int) -> Iterable[ThumbnailRetryEntry]:
+        ...
+
+    def mark_running(self, entry: ThumbnailRetryEntry, *, started_at: datetime) -> None:
+        ...
+
+    def mark_canceled(self, entry: ThumbnailRetryEntry, *, finished_at: datetime) -> None:
+        ...
+
+    def mark_finished(
+        self,
+        entry: ThumbnailRetryEntry,
+        *,
+        finished_at: datetime,
+        success: bool,
+    ) -> None:
+        ...
+
+    def find_disabled(self, limit: int) -> Iterable[ThumbnailRetryEntry]:
+        ...
+
+    def mark_monitor_reported(self, entries: Iterable[ThumbnailRetryEntry]) -> None:
+        ...
+
+
+class ThumbnailRetryScheduler(Protocol):
+    """再試行ジョブを外部キューに投入するスケジューラ."""
+
+    def schedule(
+        self,
+        *,
+        media_id: int,
+        force: bool,
+        countdown_seconds: int,
+    ) -> Optional[str]:
+        ...

--- a/application/media_processing/logger.py
+++ b/application/media_processing/logger.py
@@ -1,0 +1,131 @@
+"""メディア後処理用の構造化ロガー."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from core.logging_config import log_task_error, log_task_info
+
+
+class StructuredMediaTaskLogger:
+    """背景タスク向けの構造化ログ出力を担当する."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+
+    def info(
+        self,
+        *,
+        event: str,
+        message: str,
+        operation_id: str,
+        media_id: int,
+        request_context: Optional[Dict[str, Any]] = None,
+        **details: Any,
+    ) -> None:
+        self._log(
+            level="info",
+            event=event,
+            message=message,
+            operation_id=operation_id,
+            media_id=media_id,
+            request_context=request_context,
+            details=details,
+        )
+
+    def warning(
+        self,
+        *,
+        event: str,
+        message: str,
+        operation_id: str,
+        media_id: int,
+        request_context: Optional[Dict[str, Any]] = None,
+        **details: Any,
+    ) -> None:
+        self._log(
+            level="warning",
+            event=event,
+            message=message,
+            operation_id=operation_id,
+            media_id=media_id,
+            request_context=request_context,
+            details=details,
+        )
+
+    def error(
+        self,
+        *,
+        event: str,
+        message: str,
+        operation_id: str,
+        media_id: int,
+        request_context: Optional[Dict[str, Any]] = None,
+        exc_info: bool = False,
+        **details: Any,
+    ) -> None:
+        self._log(
+            level="error",
+            event=event,
+            message=message,
+            operation_id=operation_id,
+            media_id=media_id,
+            request_context=request_context,
+            details=details,
+            exc_info=exc_info,
+        )
+
+    def _log(
+        self,
+        *,
+        level: str,
+        event: str,
+        message: str,
+        operation_id: str,
+        media_id: int,
+        request_context: Optional[Dict[str, Any]],
+        details: Dict[str, Any],
+        exc_info: bool = False,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            "level": level.upper(),
+            "message": message,
+            "operationId": operation_id,
+            "mediaId": media_id,
+        }
+        if request_context:
+            payload["requestContext"] = request_context
+        if details:
+            payload["details"] = details
+
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+        log_kwargs = dict(details)
+        log_kwargs.update({"event": event, "operation_id": operation_id, "media_id": media_id})
+
+        level_lower = level.lower()
+        if level_lower == "info":
+            log_task_info(
+                self._logger,
+                serialized,
+                event=event,
+                operation_id=operation_id,
+                media_id=media_id,
+                **details,
+            )
+        elif level_lower == "warning":
+            self._logger.warning(serialized, extra=log_kwargs)
+        else:
+            log_task_error(
+                self._logger,
+                serialized,
+                event=event,
+                operation_id=operation_id,
+                media_id=media_id,
+                exc_info=exc_info,
+                **details,
+            )

--- a/application/media_processing/playback_service.py
+++ b/application/media_processing/playback_service.py
@@ -1,0 +1,181 @@
+"""動画再生資産生成ユースケース."""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+from uuid import uuid4
+
+from core.db import db
+from core.models.photo_models import MediaPlayback
+
+from .logger import StructuredMediaTaskLogger
+
+
+class MediaPlaybackService:
+    """動画の再生用エンコーディング処理を調停する."""
+
+    def __init__(
+        self,
+        *,
+        worker: Callable[..., Dict[str, Any]],
+        thumbnail_generator: Optional[Callable[..., Optional[Dict[str, Any]]]],
+        thumbnail_regenerator: Optional[Callable[..., Dict[str, Any]]] = None,
+        logger: StructuredMediaTaskLogger,
+    ) -> None:
+        self._worker = worker
+        self._thumbnail_generator = thumbnail_generator
+        self._thumbnail_regenerator = thumbnail_regenerator
+        self._logger = logger
+
+    def prepare(
+        self,
+        *,
+        media_id: int,
+        force_regenerate: bool = False,
+        operation_id: Optional[str] = None,
+        request_context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        op_id = operation_id or str(uuid4())
+
+        if not shutil.which("ffmpeg"):
+            self._logger.warning(
+                event="video_transcoding.ffmpeg_missing",
+                message="ffmpeg not available, skipping video transcoding.",
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+            )
+            return {"ok": False, "note": "ffmpeg_missing"}
+
+        try:
+            playback = MediaPlayback.query.filter_by(media_id=media_id, preset="std1080p").first()
+            if not playback:
+                return {"ok": False, "note": "playback_missing"}
+
+            if force_regenerate:
+                playback.update_paths(None, None)
+                db.session.commit()
+                result = self._worker(media_playback_id=playback.id, force=True)
+                db.session.refresh(playback)
+                if result.get("ok"):
+                    self._logger.info(
+                        event="video_transcoding.regenerated",
+                        message="Video transcoding regenerated.",
+                        operation_id=op_id,
+                        media_id=media_id,
+                        request_context=request_context,
+                        playback_rel_path=playback.rel_path,
+                        poster_rel_path=playback.poster_rel_path,
+                    )
+                else:
+                    self._logger.warning(
+                        event="video_transcoding.regenerate_failed",
+                        message=result.get("note", "Video transcoding regeneration failed."),
+                        operation_id=op_id,
+                        media_id=media_id,
+                        request_context=request_context,
+                        playback_rel_path=playback.rel_path,
+                        poster_rel_path=playback.poster_rel_path,
+                    )
+                    return result
+
+                if self._thumbnail_generator is not None:
+                    thumb_result = self._thumbnail_generator(media_id=media_id, force=True)
+                    if thumb_result is not None:
+                        result = dict(result)
+                        result["thumbnails"] = thumb_result
+                return result
+
+            if playback.status in {"done", "processing"}:
+                if force_regenerate and playback.status == "done":
+                    self._logger.info(
+                        event="video_transcoding.force_restart",
+                        message="Playback regeneration forced; restarting transcoding.",
+                        operation_id=op_id,
+                        media_id=media_id,
+                        request_context=request_context,
+                        previous_status=playback.status,
+                    )
+                    playback.status = "pending"
+                    playback.error_msg = None
+                    playback.updated_at = datetime.now(timezone.utc)
+                    db.session.commit()
+                else:
+                    thumb_result: Optional[Dict[str, Any]] = None
+                    if playback.status == "done":
+                        if self._thumbnail_regenerator is not None:
+                            thumb_result = self._thumbnail_regenerator(
+                                media_id=media_id,
+                                operation_id=op_id,
+                                request_context=request_context,
+                            )
+                        elif self._thumbnail_generator is not None:
+                            thumb_result = self._thumbnail_generator(media_id=media_id, force=False)
+
+                    log_details: Dict[str, Any] = {"playback_status": playback.status}
+                    if thumb_result is not None:
+                        log_details.update(
+                            thumbnail_ok=thumb_result.get("ok"),
+                            thumbnail_generated=thumb_result.get("generated"),
+                            thumbnail_skipped=thumb_result.get("skipped"),
+                            thumbnail_notes=thumb_result.get("notes"),
+                        )
+
+                    self._logger.info(
+                        event="video_transcoding.skipped",
+                        message=f"Video playback already {playback.status}.",
+                        operation_id=op_id,
+                        media_id=media_id,
+                        request_context=request_context,
+                        **log_details,
+                    )
+
+                    response: Dict[str, Any] = {
+                        "ok": playback.status == "done",
+                        "note": f"already_{playback.status}",
+                        "playback_status": playback.status,
+                    }
+                    if thumb_result is not None:
+                        response["thumbnails"] = thumb_result
+                    return response
+
+            result = self._worker(media_playback_id=playback.id)
+            db.session.refresh(playback)
+            log_kwargs = dict(
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                width=result.get("width"),
+                height=result.get("height"),
+                duration_ms=result.get("duration_ms"),
+                note=result.get("note"),
+                playback_rel_path=playback.rel_path,
+                playback_output_path=result.get("output_path"),
+                poster_rel_path=playback.poster_rel_path,
+                poster_output_path=result.get("poster_path"),
+            )
+            if result.get("ok"):
+                self._logger.info(
+                    event="video_transcoding.complete",
+                    message="Video transcoding completed.",
+                    **log_kwargs,
+                )
+            else:
+                self._logger.warning(
+                    event="video_transcoding.failed",
+                    message=result.get("note", "Video transcoding failed."),
+                    **log_kwargs,
+                )
+            return result
+        except Exception as exc:  # pragma: no cover - 外部依存の例外経路
+            self._logger.error(
+                event="video_transcoding.exception",
+                message=f"Exception during video transcoding: {exc}",
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                exc_info=True,
+            )
+            return {"ok": False, "note": "exception", "error": str(exc)}

--- a/application/media_processing/post_processing_service.py
+++ b/application/media_processing/post_processing_service.py
@@ -1,0 +1,59 @@
+"""メディア取り込み後の後処理ユースケース."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from uuid import uuid4
+
+from core.models.photo_models import Media
+
+from .logger import StructuredMediaTaskLogger
+from .playback_service import MediaPlaybackService
+from .thumbnail_service import ThumbnailGenerationService
+
+
+class MediaPostProcessingService:
+    """メディア種別に応じた後処理パイプラインを提供する."""
+
+    def __init__(
+        self,
+        *,
+        thumbnail_service: ThumbnailGenerationService,
+        playback_service: MediaPlaybackService,
+        logger: StructuredMediaTaskLogger,
+    ) -> None:
+        self._thumbnail_service = thumbnail_service
+        self._playback_service = playback_service
+        self._logger = logger
+
+    def process(
+        self,
+        *,
+        media: Media,
+        request_context: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        operation_id = str(uuid4())
+
+        self._logger.info(
+            event="media_post_process.start",
+            message="Starting post-import processing.",
+            operation_id=operation_id,
+            media_id=media.id,
+            request_context=request_context,
+            media_type="video" if media.is_video else "photo",
+        )
+
+        if media.is_video:
+            playback = self._playback_service.prepare(
+                media_id=media.id,
+                operation_id=operation_id,
+                request_context=request_context,
+            )
+            return {"playback": playback}
+
+        thumbnails = self._thumbnail_service.generate(
+            media_id=media.id,
+            operation_id=operation_id,
+            request_context=request_context,
+        )
+        return {"thumbnails": thumbnails}

--- a/application/media_processing/retry_monitor.py
+++ b/application/media_processing/retry_monitor.py
@@ -1,0 +1,118 @@
+"""サムネイル再試行監視ユースケース."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict
+
+from .interfaces import ThumbnailRetryRepository
+from .logger import StructuredMediaTaskLogger
+from .thumbnail_service import ThumbnailGenerationService
+
+
+class ThumbnailRetryMonitorService:
+    """期限切れの再試行レコードを処理するアプリケーションサービス."""
+
+    def __init__(
+        self,
+        *,
+        repository: ThumbnailRetryRepository,
+        thumbnail_service: ThumbnailGenerationService,
+        logger: StructuredMediaTaskLogger,
+    ) -> None:
+        self._repository = repository
+        self._thumbnail_service = thumbnail_service
+        self._logger = logger
+
+    def process_due(self, *, limit: int = 50) -> Dict[str, int]:
+        now = datetime.now(timezone.utc)
+        pending = list(self._repository.iter_due(limit))
+
+        if not pending:
+            self._log_idle_state()
+            return {
+                "processed": 0,
+                "rescheduled": 0,
+                "cleared": 0,
+                "pending_before": 0,
+            }
+
+        processed = 0
+        rescheduled = 0
+        cleared = 0
+
+        for entry in pending:
+            processed += 1
+            if entry.media_id is None:
+                self._repository.mark_canceled(entry, finished_at=now)
+                continue
+
+            try:
+                media_id = int(entry.media_id)
+            except (TypeError, ValueError):
+                self._repository.mark_canceled(entry, finished_at=now)
+                continue
+
+            self._repository.mark_running(entry, started_at=now)
+            result = self._thumbnail_service.generate(
+                media_id=media_id,
+                operation_id=f"thumbnail-retry-{media_id}",
+                request_context={"source": "retry-monitor"},
+                force=bool(entry.payload.get("force", False)),
+            )
+            if result.get("retry_scheduled"):
+                rescheduled += 1
+            else:
+                cleared += 1
+
+        self._logger.info(
+            event="thumbnail_generation.retry_monitor",
+            message="Processed pending thumbnail retries.",
+            operation_id="thumbnail-retry-monitor",
+            media_id=0,
+            processed=processed,
+            rescheduled=rescheduled,
+            cleared=cleared,
+            pending_before=len(pending),
+        )
+
+        return {
+            "processed": processed,
+            "rescheduled": rescheduled,
+            "cleared": cleared,
+            "pending_before": len(pending),
+        }
+
+    def _log_idle_state(self) -> None:
+        disabled = list(self._repository.find_disabled(limit=5))
+        alerts = []
+        records_to_mark = []
+        for entry in disabled:
+            payload = entry.payload
+            if not payload.get("retry_disabled"):
+                continue
+            if payload.get("monitor_reported"):
+                continue
+            alerts.append(
+                {
+                    "media_id": entry.media_id,
+                    "attempts": payload.get("attempts"),
+                    "blockers": payload.get("blockers"),
+                }
+            )
+            records_to_mark.append(entry)
+
+        if not alerts:
+            return
+
+        self._repository.mark_monitor_reported(records_to_mark)
+        self._logger.warning(
+            event="thumbnail_generation.retry_monitor_blocked",
+            message=(
+                "No pending thumbnail retries; some media exhausted their retry budget and require manual attention."
+            ),
+            operation_id="thumbnail-retry-monitor",
+            media_id=0,
+            disabled=len(alerts),
+            samples=alerts,
+        )

--- a/application/media_processing/retry_service.py
+++ b/application/media_processing/retry_service.py
@@ -1,0 +1,131 @@
+"""サムネイル再試行を調停するアプリケーションサービス."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from domain.media_processing import ThumbnailRetryPolicy
+
+from .interfaces import ThumbnailRetryRepository, ThumbnailRetryScheduler
+from .logger import StructuredMediaTaskLogger
+
+
+@dataclass(frozen=True)
+class RetryScheduleResult:
+    """再試行スケジュール結果を表現する値オブジェクト."""
+
+    scheduled: bool
+    attempts: int
+    max_attempts: int
+    countdown: Optional[int] = None
+    celery_task_id: Optional[str] = None
+    reason: Optional[str] = None
+    keep_record: bool = False
+    blockers: Optional[Dict[str, Any]] = None
+
+
+class ThumbnailRetryService:
+    """再試行ポリシーとリポジトリを調停する."""
+
+    def __init__(
+        self,
+        *,
+        policy: ThumbnailRetryPolicy,
+        repository: ThumbnailRetryRepository,
+        scheduler: ThumbnailRetryScheduler,
+        logger: StructuredMediaTaskLogger,
+        countdown_seconds: int,
+    ) -> None:
+        self._policy = policy
+        self._repository = repository
+        self._scheduler = scheduler
+        self._logger = logger
+        self._countdown_seconds = countdown_seconds
+
+    def schedule_if_allowed(
+        self,
+        *,
+        media_id: int,
+        force: bool,
+        operation_id: str,
+        request_context: Optional[Dict[str, Any]],
+        blockers: Optional[Dict[str, Any]] = None,
+    ) -> Optional[RetryScheduleResult]:
+        entry = self._repository.get_or_create(media_id)
+        decision = self._policy.decide(entry.attempts)
+
+        if not decision.can_retry:
+            self._repository.mark_exhausted(entry, force=force, blockers=blockers)
+            self._logger.warning(
+                event="thumbnail_generation.retry_exhausted",
+                message="Retry limit reached; no further thumbnail retries will be scheduled.",
+                operation_id=operation_id,
+                media_id=media_id,
+                request_context=request_context,
+                attempts=entry.attempts,
+                max_attempts=self._policy.max_attempts,
+                blockers=blockers,
+            )
+            return RetryScheduleResult(
+                scheduled=False,
+                attempts=entry.attempts,
+                max_attempts=self._policy.max_attempts,
+                reason=decision.reason,
+                keep_record=decision.keep_record,
+                blockers=blockers,
+            )
+
+        try:
+            celery_task_id = self._scheduler.schedule(
+                media_id=media_id,
+                force=force,
+                countdown_seconds=self._countdown_seconds,
+            )
+        except Exception as exc:  # pragma: no cover - スケジューラ例外経路
+            self._logger.warning(
+                event="thumbnail_generation.retry_failed",
+                message="Failed to schedule thumbnail retry.",
+                operation_id=operation_id,
+                media_id=media_id,
+                request_context=request_context,
+                countdown=self._countdown_seconds,
+                error=str(exc),
+            )
+            return None
+        if celery_task_id is None:
+            return None
+
+        self._repository.persist_scheduled(
+            entry,
+            countdown_seconds=self._countdown_seconds,
+            force=force,
+            celery_task_id=celery_task_id,
+            attempt=decision.attempt_number,
+            blockers=blockers,
+        )
+        self._logger.info(
+            event="thumbnail_generation.retry_scheduled",
+            message=f"Playback not ready; retry scheduled in {self._countdown_seconds} seconds.",
+            operation_id=operation_id,
+            media_id=media_id,
+            request_context=request_context,
+            countdown=self._countdown_seconds,
+            celery_task_id=celery_task_id,
+            force=force,
+            attempts=decision.attempt_number,
+            max_attempts=self._policy.max_attempts,
+            blockers=blockers,
+        )
+
+        return RetryScheduleResult(
+            scheduled=True,
+            countdown=self._countdown_seconds,
+            celery_task_id=celery_task_id,
+            attempts=decision.attempt_number,
+            max_attempts=self._policy.max_attempts,
+            blockers=blockers,
+        )
+
+    def clear_success(self, media_id: int) -> None:
+        self._repository.clear_success(media_id)

--- a/application/media_processing/thumbnail_service.py
+++ b/application/media_processing/thumbnail_service.py
@@ -1,0 +1,179 @@
+"""サムネイル生成ユースケース."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from uuid import uuid4
+
+from domain.media_processing import RetryBlockers
+
+from .logger import StructuredMediaTaskLogger
+from .retry_service import RetryScheduleResult, ThumbnailRetryService
+
+
+class ThumbnailGenerationService:
+    """サムネイル生成と再試行制御を調停する."""
+
+    def __init__(
+        self,
+        *,
+        generator: Callable[..., Dict[str, Any]],
+        retry_service: ThumbnailRetryService,
+        logger: StructuredMediaTaskLogger,
+        playback_not_ready_note: str,
+    ) -> None:
+        self._generator = generator
+        self._retry_service = retry_service
+        self._logger = logger
+        self._playback_not_ready_note = playback_not_ready_note
+
+    def generate(
+        self,
+        *,
+        media_id: int,
+        force: bool = False,
+        operation_id: Optional[str] = None,
+        request_context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        op_id = operation_id or str(uuid4())
+        try:
+            result = self._generator(media_id=media_id, force=force)
+        except Exception as exc:  # pragma: no cover - 例外経路は外部依存
+            self._logger.error(
+                event="thumbnail_generation.exception",
+                message=f"Exception during thumbnail generation: {exc}",
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                exc_info=True,
+            )
+            return {"ok": False, "note": "exception", "error": str(exc)}
+
+        generated = result.get("generated", [])
+        skipped = result.get("skipped", [])
+        notes = result.get("notes")
+
+        retry_blockers = RetryBlockers.from_raw(result.get("retry_blockers"))
+        retry_details: Optional[Dict[str, Any]] = None
+        retry_result: Optional[RetryScheduleResult] = None
+
+        if result.get("ok"):
+            self._log_success(
+                media_id=media_id,
+                op_id=op_id,
+                request_context=request_context,
+                generated=generated,
+                skipped=skipped,
+                notes=notes,
+                blockers=retry_blockers,
+            )
+            if notes == self._playback_not_ready_note:
+                retry_result = self._retry_service.schedule_if_allowed(
+                    media_id=media_id,
+                    force=force,
+                    operation_id=op_id,
+                    request_context=request_context,
+                    blockers=retry_blockers.details if retry_blockers else None,
+                )
+        else:
+            self._logger.warning(
+                event="thumbnail_generation.failed",
+                message=result.get("notes", "Thumbnail generation failed."),
+                operation_id=op_id,
+                media_id=media_id,
+                request_context=request_context,
+                notes=result.get("notes"),
+            )
+
+        if retry_result is not None:
+            retry_details = self._merge_retry_details(
+                retry_result=retry_result,
+                blockers=retry_blockers,
+            )
+        elif retry_blockers:
+            retry_details = {"blockers": retry_blockers.details}
+
+        if retry_result and retry_result.scheduled:
+            merged = dict(result)
+            merged["retry_scheduled"] = True
+            if retry_details:
+                merged["retry_details"] = retry_details
+            return merged
+
+        if retry_details:
+            merged = dict(result)
+            merged["retry_details"] = retry_details
+            result = merged
+
+        should_clear = False
+        if retry_result is None:
+            should_clear = True
+        elif not retry_result.scheduled and not retry_result.keep_record:
+            should_clear = True
+
+        if should_clear:
+            self._retry_service.clear_success(media_id)
+
+        return result
+
+    def _log_success(
+        self,
+        *,
+        media_id: int,
+        op_id: str,
+        request_context: Optional[Dict[str, Any]],
+        generated: Any,
+        skipped: Any,
+        notes: Any,
+        blockers: Optional[RetryBlockers],
+    ) -> None:
+        if generated:
+            event = "thumbnail_generation.complete"
+            message = "Thumbnails generated successfully."
+        else:
+            event = "thumbnail_generation.skipped"
+            blocker_reason = blockers.reason if blockers else None
+            if notes:
+                if blocker_reason:
+                    message = f"Thumbnail generation skipped: {notes}. Root cause: {blocker_reason}."
+                else:
+                    message = f"Thumbnail generation skipped: {notes}."
+            else:
+                message = "Thumbnail generation skipped with no thumbnails produced."
+
+        self._logger.info(
+            event=event,
+            message=message,
+            operation_id=op_id,
+            media_id=media_id,
+            request_context=request_context,
+            generated=generated,
+            skipped=skipped,
+            notes=notes,
+            blockers=blockers.details if blockers else None,
+        )
+
+    def _merge_retry_details(
+        self,
+        *,
+        retry_result: RetryScheduleResult,
+        blockers: Optional[RetryBlockers],
+    ) -> Dict[str, Any]:
+        details: Dict[str, Any] = {
+            "scheduled": retry_result.scheduled,
+            "attempts": retry_result.attempts,
+            "max_attempts": retry_result.max_attempts,
+        }
+        if retry_result.countdown is not None:
+            details["countdown"] = retry_result.countdown
+        if retry_result.celery_task_id is not None:
+            details["celery_task_id"] = retry_result.celery_task_id
+        if retry_result.reason is not None:
+            details["reason"] = retry_result.reason
+        if retry_result.blockers:
+            details["blockers"] = dict(retry_result.blockers)
+        elif blockers:
+            details["blockers"] = blockers.details
+        if retry_result.keep_record:
+            details["keep_record"] = True
+        return details

--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -1,770 +1,160 @@
-"""Utilities for post-import media processing steps.
-
-This module centralises common operations that occur after a media item has
-been persisted, such as generating thumbnails for photos or scheduling
-transcoding for videos.  Both picker imports and local imports can leverage
-these helpers so that the behaviour and logging stay consistent.
-"""
+"""メディア後処理タスク群のアプリケーションサービスラッパー."""
 
 from __future__ import annotations
 
-import json
-import logging
-import shutil
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-from uuid import uuid4
+import shutil as _shutil
+from typing import Any, Dict, Optional
 
-from core.db import db
-from core.logging_config import log_task_error, log_task_info, setup_task_logging
-from core.models.photo_models import Media, MediaPlayback
-from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
+from application.media_processing import (
+    MediaPlaybackService,
+    MediaPostProcessingService,
+    StructuredMediaTaskLogger,
+    ThumbnailGenerationService,
+    ThumbnailRetryMonitorService,
+    ThumbnailRetryService,
+)
+from domain.media_processing import ThumbnailRetryPolicy
+from infrastructure.media_processing import (
+    CeleryThumbnailRetryScheduler,
+    SqlAlchemyThumbnailRetryRepository,
+)
+from core.logging_config import setup_task_logging
+from core.models.photo_models import Media
 
-# These imports are intentionally placed after SQLAlchemy models to avoid
-# circular import issues.
 from .thumbs_generate import PLAYBACK_NOT_READY_NOTES, thumbs_generate
 from .transcode import transcode_worker
 
-
-_logger = setup_task_logging(__name__)
-
+_THUMBNAIL_RETRY_TASK_NAME = "thumbnail.retry"
 _THUMBNAIL_RETRY_COUNTDOWN = 300
 _THUMBNAIL_RETRY_MAX_ATTEMPTS = 5
-_THUMBNAIL_RETRY_TASK_NAME = "thumbnail.retry"
+
+_logger = setup_task_logging(__name__)
+shutil = _shutil
+_retry_policy = ThumbnailRetryPolicy(_THUMBNAIL_RETRY_MAX_ATTEMPTS)
+_retry_repository = SqlAlchemyThumbnailRetryRepository()
+_retry_scheduler = CeleryThumbnailRetryScheduler(_logger)
 
 
-def _thumbnail_retry_identity(media_id: int) -> tuple[str, str]:
-    return ("media", str(media_id))
+def _build_structured_logger(logger_override: Optional[Any]) -> StructuredMediaTaskLogger:
+    return StructuredMediaTaskLogger(logger_override or _logger)
 
 
-def _upsert_thumbnail_retry_record(
-    media_id: int,
+def _build_retry_service(logger: StructuredMediaTaskLogger) -> ThumbnailRetryService:
+    return ThumbnailRetryService(
+        policy=_retry_policy,
+        repository=_retry_repository,
+        scheduler=_retry_scheduler,
+        logger=logger,
+        countdown_seconds=_THUMBNAIL_RETRY_COUNTDOWN,
+    )
+
+
+def _build_thumbnail_service(
     *,
-    countdown: int,
-    force: bool,
-    celery_task_id: Optional[str],
-    attempt: int,
-    blockers: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Persist or update retry tracking information for *media_id*."""
-
-    retry_at = datetime.now(timezone.utc) + timedelta(seconds=countdown)
-    record = CeleryTaskRecord.get_or_create(
-        task_name=_THUMBNAIL_RETRY_TASK_NAME,
-        celery_task_id=celery_task_id,
-        object_identity=_thumbnail_retry_identity(media_id),
-    )
-    record.status = CeleryTaskStatus.SCHEDULED
-    record.scheduled_for = retry_at
-    record.started_at = None
-    record.finished_at = None
-    payload: Dict[str, Any] = {"force": force, "attempts": attempt}
-    if blockers is not None:
-        payload["blockers"] = blockers
-    record.set_payload(payload)
-    db.session.commit()
-
-
-def _clear_thumbnail_retry_record(media_id: int) -> None:
-    """Mark retry tracking information for *media_id* as completed."""
-
-    record = (
-        CeleryTaskRecord.query.filter_by(
-            task_name=_THUMBNAIL_RETRY_TASK_NAME,
-            object_type="media",
-            object_id=media_id,
-        )
-        .order_by(CeleryTaskRecord.id.desc())
-        .first()
-    )
-    if record is None:
-        return
-
-    record.status = CeleryTaskStatus.SUCCESS
-    record.scheduled_for = None
-    record.celery_task_id = None
-    record.finished_at = datetime.now(timezone.utc)
-    record.set_payload({})
-    db.session.commit()
-
-
-def _schedule_thumbnail_retry(
-    *,
-    media_id: int,
-    force: bool,
-    countdown: int,
-    logger: logging.Logger,
-    operation_id: str,
-    request_context: Optional[Dict[str, Any]],
-    blockers: Optional[Dict[str, Any]] = None,
-) -> Optional[Dict[str, Any]]:
-    """Schedule a Celery retry for thumbnail generation.
-
-    Returns metadata about the scheduled retry when successful.  When Celery is
-    not available the function simply returns ``None`` without logging to avoid
-    noisy warnings in test environments.
-    """
-
-    try:
-        from cli.src.celery.tasks import thumbs_generate_task
-    except ImportError:
-        return None
-
-    record = CeleryTaskRecord.get_or_create(
-        task_name=_THUMBNAIL_RETRY_TASK_NAME,
-        object_identity=_thumbnail_retry_identity(media_id),
+    logger: StructuredMediaTaskLogger,
+    retry_service: Optional[ThumbnailRetryService] = None,
+) -> ThumbnailGenerationService:
+    retry = retry_service or _build_retry_service(logger)
+    return ThumbnailGenerationService(
+        generator=thumbs_generate,
+        retry_service=retry,
+        logger=logger,
+        playback_not_ready_note=PLAYBACK_NOT_READY_NOTES,
     )
 
-    attempts_raw = record.payload.get("attempts", 0)
-    try:
-        attempts = int(attempts_raw)
-    except (TypeError, ValueError):
-        attempts = 0
 
-    if attempts >= _THUMBNAIL_RETRY_MAX_ATTEMPTS:
-        _structured_task_log(
-            logger,
-            level="warning",
-            event="thumbnail_generation.retry_exhausted",
-            message="Retry limit reached; no further thumbnail retries will be scheduled.",
-            operation_id=operation_id,
-            media_id=media_id,
-            request_context=request_context,
-            attempts=attempts,
-            max_attempts=_THUMBNAIL_RETRY_MAX_ATTEMPTS,
-            blockers=blockers,
-        )
-        record.status = CeleryTaskStatus.FAILED
-        record.scheduled_for = None
-        record.started_at = None
-        record.finished_at = datetime.now(timezone.utc)
-        record.celery_task_id = None
-        exhausted_payload: Dict[str, Any] = {
-            "force": force,
-            "attempts": attempts,
-            "retry_disabled": True,
-        }
-        if blockers is not None:
-            exhausted_payload["blockers"] = blockers
-        record.set_payload(exhausted_payload)
-        db.session.commit()
-        return {
-            "scheduled": False,
-            "reason": "max_attempts",
-            "attempts": attempts,
-            "max_attempts": _THUMBNAIL_RETRY_MAX_ATTEMPTS,
-            "blockers": blockers,
-            "keep_record": True,
-        }
-
-    try:
-        async_result = thumbs_generate_task.apply_async(
-            kwargs={"media_id": media_id, "force": force},
-            countdown=countdown,
-        )
-    except Exception as exc:  # pragma: no cover - network failure path
-        _structured_task_log(
-            logger,
-            level="warning",
-            event="thumbnail_generation.retry_failed",
-            message="Failed to schedule thumbnail retry.",
-            operation_id=operation_id,
-            media_id=media_id,
-            request_context=request_context,
-            countdown=countdown,
-            error=str(exc),
-        )
-        return None
-
-    celery_task_id = getattr(async_result, "id", None)
-    attempt = attempts + 1
-
-    _structured_task_log(
-        logger,
-        level="info",
-        event="thumbnail_generation.retry_scheduled",
-        message=f"Playback not ready; retry scheduled in {countdown} seconds.",
-        operation_id=operation_id,
-        media_id=media_id,
-        request_context=request_context,
-        countdown=countdown,
-        celery_task_id=celery_task_id,
-        force=force,
-        attempts=attempt,
-        max_attempts=_THUMBNAIL_RETRY_MAX_ATTEMPTS,
-        blockers=blockers,
+def _build_playback_service(
+    logger: StructuredMediaTaskLogger,
+    thumbnail_service: Optional[ThumbnailGenerationService] = None,
+) -> MediaPlaybackService:
+    regenerator = None
+    if thumbnail_service is not None:
+        regenerator = thumbnail_service.generate
+    return MediaPlaybackService(
+        worker=transcode_worker,
+        thumbnail_generator=thumbs_generate,
+        thumbnail_regenerator=regenerator,
+        logger=logger,
     )
-    _upsert_thumbnail_retry_record(
-        media_id,
-        countdown=countdown,
-        force=force,
-        celery_task_id=celery_task_id,
-        attempt=attempt,
-        blockers=blockers,
+
+
+def _build_post_processing_service(
+    logger: StructuredMediaTaskLogger,
+) -> MediaPostProcessingService:
+    retry_service = _build_retry_service(logger)
+    thumbnail_service = _build_thumbnail_service(logger=logger, retry_service=retry_service)
+    playback_service = _build_playback_service(logger, thumbnail_service)
+    return MediaPostProcessingService(
+        thumbnail_service=thumbnail_service,
+        playback_service=playback_service,
+        logger=logger,
     )
-    return {
-        "scheduled": True,
-        "countdown": countdown,
-        "celery_task_id": celery_task_id,
-        "force": force,
-        "attempts": attempt,
-        "max_attempts": _THUMBNAIL_RETRY_MAX_ATTEMPTS,
-        "blockers": blockers,
-    }
 
 
-def _structured_task_log(
-    logger: logging.Logger,
-    *,
-    level: str,
-    event: str,
-    message: str,
-    operation_id: str,
-    media_id: int,
-    request_context: Optional[Dict[str, Any]] = None,
-    exc_info: bool = False,
-    **details: Any,
-) -> None:
-    """Emit a structured JSON log entry for background task processing."""
-
-    payload: Dict[str, Any] = {
-        "ts": datetime.now(timezone.utc).isoformat(),
-        "event": event,
-        "level": level.upper(),
-        "message": message,
-        "operationId": operation_id,
-        "mediaId": media_id,
-    }
-
-    if request_context:
-        payload["requestContext"] = request_context
-
-    if details:
-        payload["details"] = details
-
-    serialized = json.dumps(payload, ensure_ascii=False, default=str)
-    extra = {"event": event, "operation_id": operation_id, "media_id": media_id, **details}
-
-    level_lower = level.lower()
-    if level_lower == "info":
-        log_task_info(logger, serialized, event=event, operation_id=operation_id, media_id=media_id, **details)
-    elif level_lower == "warning":
-        logger.warning(serialized, extra=extra)
-    else:
-        # Errors and unexpected levels fall back to the task error helper so the
-        # stack trace (if requested) is persisted in the database logs.
-        log_task_error(
-            logger,
-            serialized,
-            event=event,
-            exc_info=exc_info,
-            operation_id=operation_id,
-            media_id=media_id,
-            **details,
-        )
+def _build_retry_monitor_service(logger: StructuredMediaTaskLogger) -> ThumbnailRetryMonitorService:
+    thumbnail_service = _build_thumbnail_service(logger=logger)
+    return ThumbnailRetryMonitorService(
+        repository=_retry_repository,
+        thumbnail_service=thumbnail_service,
+        logger=logger,
+    )
 
 
 def enqueue_thumbs_generate(
     media_id: int,
     *,
-    logger_override: Optional[logging.Logger] = None,
+    logger_override: Optional[Any] = None,
     operation_id: Optional[str] = None,
     request_context: Optional[Dict[str, Any]] = None,
     force: bool = False,
 ) -> Dict[str, Any]:
-    """Synchronously generate thumbnails for *media_id* with structured logging.
-
-    When the underlying worker reports that playback assets are not yet ready,
-    the helper schedules a Celery retry (if available) using a 5 minute delay.
-
-    Returns the raw result dictionary from :func:`thumbs_generate` (or a
-    synthesized error response when the worker raises an exception).  When a
-    retry is scheduled the returned dictionary includes ``retry_scheduled`` set
-    to ``True``.
-    """
-
-    logger = logger_override or _logger
-    op_id = operation_id or str(uuid4())
-
-    try:
-        result = thumbs_generate(media_id=media_id, force=force)
-    except Exception as exc:  # pragma: no cover - unexpected failure path
-        _structured_task_log(
-            logger,
-            level="error",
-            event="thumbnail_generation.exception",
-            message=f"Exception during thumbnail generation: {exc}",
-            operation_id=op_id,
-            media_id=media_id,
-            request_context=request_context,
-            exc_info=True,
-        )
-        return {"ok": False, "note": "exception", "error": str(exc)}
-
-    generated = result.get("generated", [])
-    skipped = result.get("skipped", [])
-    notes = result.get("notes")
-    retry_scheduled = False
-    retry_metadata: Optional[Dict[str, Any]] = None
-    retry_blockers: Optional[Dict[str, Any]] = None
-    keep_retry_record = False
-
-    if result.get("ok"):
-        if generated:
-            event = "thumbnail_generation.complete"
-            message = "Thumbnails generated successfully."
-        else:
-            event = "thumbnail_generation.skipped"
-            # Provide a clear reason in the log message when nothing was generated
-            raw_blockers = result.get("retry_blockers")
-            retry_blockers = raw_blockers if isinstance(raw_blockers, dict) else None
-            blocker_reason: Optional[str] = None
-            if isinstance(retry_blockers, dict):
-                raw_reason = retry_blockers.get("reason")
-                if raw_reason is not None:
-                    blocker_reason = str(raw_reason)
-            if notes:
-                if blocker_reason:
-                    message = (
-                        f"Thumbnail generation skipped: {notes}. "
-                        f"Root cause: {blocker_reason}."
-                    )
-                else:
-                    message = f"Thumbnail generation skipped: {notes}."
-            else:
-                message = "Thumbnail generation skipped with no thumbnails produced."
-
-        _structured_task_log(
-            logger,
-            level="info",
-            event=event,
-            message=message,
-            operation_id=op_id,
-            media_id=media_id,
-            request_context=request_context,
-            generated=generated,
-            skipped=skipped,
-            notes=notes,
-            blockers=retry_blockers,
-        )
-
-        if notes == PLAYBACK_NOT_READY_NOTES:
-            retry_info = _schedule_thumbnail_retry(
-                media_id=media_id,
-                force=force,
-                countdown=_THUMBNAIL_RETRY_COUNTDOWN,
-                logger=logger,
-                operation_id=op_id,
-                request_context=request_context,
-                blockers=retry_blockers if isinstance(retry_blockers, dict) else None,
-            )
-            if retry_info:
-                if isinstance(retry_info, dict):
-                    retry_metadata = retry_info
-                    if retry_blockers is None and isinstance(
-                        retry_info.get("blockers"), dict
-                    ):
-                        retry_blockers = retry_info["blockers"]
-                    keep_retry_record = retry_info.get("keep_record", False)
-                    scheduled_flag = retry_info.get("scheduled")
-                    if scheduled_flag is None:
-                        retry_scheduled = "countdown" in retry_info
-                    else:
-                        retry_scheduled = bool(scheduled_flag)
-                else:
-                    retry_scheduled = True
-    else:
-        _structured_task_log(
-            logger,
-            level="warning",
-            event="thumbnail_generation.failed",
-            message=result.get("notes", "Thumbnail generation failed."),
-            operation_id=op_id,
-            media_id=media_id,
-            request_context=request_context,
-            notes=result.get("notes"),
-        )
-
-    if retry_scheduled:
-        result = dict(result)
-        result["retry_scheduled"] = True
-        if retry_metadata:
-            result["retry_details"] = retry_metadata
-        if retry_blockers:
-            details = result.setdefault("retry_details", {})
-            details.setdefault("blockers", dict(retry_blockers))
-    else:
-        if retry_metadata:
-            result = dict(result)
-            result["retry_details"] = retry_metadata
-        if retry_blockers:
-            result = dict(result)
-            details = result.setdefault("retry_details", {})
-            details.setdefault("blockers", dict(retry_blockers))
-        if not keep_retry_record:
-            _clear_thumbnail_retry_record(media_id)
-
-    return result
+    logger = _build_structured_logger(logger_override)
+    retry_service = _build_retry_service(logger)
+    thumbnail_service = _build_thumbnail_service(logger=logger, retry_service=retry_service)
+    return thumbnail_service.generate(
+        media_id=media_id,
+        force=force,
+        operation_id=operation_id,
+        request_context=request_context,
+    )
 
 
 def enqueue_media_playback(
     media_id: int,
     *,
-    logger_override: Optional[logging.Logger] = None,
+    logger_override: Optional[Any] = None,
     operation_id: Optional[str] = None,
     request_context: Optional[Dict[str, Any]] = None,
     force_regenerate: bool = False,
 ) -> Dict[str, Any]:
-    """Synchronously prepare video playback assets for *media_id*.
-
-    Returns the result dictionary from :func:`transcode_worker` (or a
-    synthesized error response when the preparation cannot even be attempted).
-    """
-
-    logger = logger_override or _logger
-    op_id = operation_id or str(uuid4())
-
-    if not shutil.which("ffmpeg"):
-        _structured_task_log(
-            logger,
-            level="warning",
-            event="video_transcoding.ffmpeg_missing",
-            message="ffmpeg not available, skipping video transcoding.",
-            operation_id=op_id,
-            media_id=media_id,
-            request_context=request_context,
-        )
-        return {"ok": False, "note": "ffmpeg_missing"}
-
-    try:
-        pb = MediaPlayback.query.filter_by(media_id=media_id, preset="std1080p").first()
-        if not pb:
-            media = Media.query.get(media_id)
-            if not media:
-                _structured_task_log(
-                    logger,
-                    level="error",
-                    event="video_transcoding.media_missing",
-                    message="Media record not found for playback generation.",
-                    operation_id=op_id,
-                    media_id=media_id,
-                    request_context=request_context,
-                    exc_info=False,
-                )
-                return {"ok": False, "note": "media_missing"}
-
-            rel_path = str(Path(media.local_rel_path).with_suffix(".mp4"))
-            pb = MediaPlayback(
-                media_id=media_id,
-                preset="std1080p",
-                rel_path=rel_path,
-                status="pending",
-            )
-            db.session.add(pb)
-            db.session.commit()
-
-        if pb.status in {"done", "processing"}:
-            if force_regenerate and pb.status == "done":
-                _structured_task_log(
-                    logger,
-                    level="info",
-                    event="video_transcoding.force_restart",
-                    message="Playback regeneration forced; restarting transcoding.",
-                    operation_id=op_id,
-                    media_id=media_id,
-                    request_context=request_context,
-                    previous_status=pb.status,
-                )
-                pb.status = "pending"
-                pb.error_msg = None
-                pb.updated_at = datetime.now(timezone.utc)
-                db.session.commit()
-            else:
-                thumb_result: Dict[str, Any] | None = None
-                if pb.status == "done":
-                    thumb_result = enqueue_thumbs_generate(
-                        media_id,
-                        logger_override=logger,
-                        operation_id=op_id,
-                        request_context=request_context,
-                    )
-
-                log_details: Dict[str, Any] = {"playback_status": pb.status}
-                if thumb_result is not None:
-                    log_details.update(
-                        thumbnail_ok=thumb_result.get("ok"),
-                        thumbnail_generated=thumb_result.get("generated"),
-                        thumbnail_skipped=thumb_result.get("skipped"),
-                        thumbnail_notes=thumb_result.get("notes"),
-                    )
-
-                _structured_task_log(
-                    logger,
-                    level="info",
-                    event="video_transcoding.skipped",
-                    message=f"Video playback already {pb.status}.",
-                    operation_id=op_id,
-                    media_id=media_id,
-                    request_context=request_context,
-                    **log_details,
-                )
-
-                result: Dict[str, Any] = {
-                    "ok": pb.status == "done",
-                    "note": f"already_{pb.status}",
-                    "playback_status": pb.status,
-                }
-                if thumb_result is not None:
-                    result["thumbnails"] = thumb_result
-
-                return result
-
-        result = transcode_worker(media_playback_id=pb.id)
-        db.session.refresh(pb)
-        if result.get("ok"):
-            _structured_task_log(
-                logger,
-                level="info",
-                event="video_transcoding.complete",
-                message="Video transcoding completed.",
-                operation_id=op_id,
-                media_id=media_id,
-                request_context=request_context,
-                width=result.get("width"),
-                height=result.get("height"),
-                duration_ms=result.get("duration_ms"),
-                note=result.get("note"),
-                playback_rel_path=pb.rel_path,
-                playback_output_path=result.get("output_path"),
-                poster_rel_path=pb.poster_rel_path,
-                poster_output_path=result.get("poster_path"),
-            )
-        else:
-            _structured_task_log(
-                logger,
-                level="warning",
-                event="video_transcoding.failed",
-                message=result.get("note", "Video transcoding failed."),
-                operation_id=op_id,
-                media_id=media_id,
-                request_context=request_context,
-                width=result.get("width"),
-                height=result.get("height"),
-                duration_ms=result.get("duration_ms"),
-                note=result.get("note"),
-                playback_rel_path=pb.rel_path,
-                playback_output_path=result.get("output_path"),
-                poster_rel_path=pb.poster_rel_path,
-                poster_output_path=result.get("poster_path"),
-            )
-
-        return result
-    except Exception as exc:  # pragma: no cover - unexpected failure path
-        _structured_task_log(
-            logger,
-            level="error",
-            event="video_transcoding.exception",
-            message=f"Exception during video transcoding: {exc}",
-            operation_id=op_id,
-            media_id=media_id,
-            request_context=request_context,
-            exc_info=True,
-        )
-        return {"ok": False, "note": "exception", "error": str(exc)}
+    logger = _build_structured_logger(logger_override)
+    retry_service = _build_retry_service(logger)
+    thumbnail_service = _build_thumbnail_service(logger=logger, retry_service=retry_service)
+    playback_service = _build_playback_service(logger, thumbnail_service)
+    return playback_service.prepare(
+        media_id=media_id,
+        force_regenerate=force_regenerate,
+        operation_id=operation_id,
+        request_context=request_context,
+    )
 
 
 def process_due_thumbnail_retries(
     *,
     limit: int = 50,
-    logger_override: Optional[logging.Logger] = None,
-) -> Dict[str, Any]:
-    """Process pending thumbnail retry records whose schedule has elapsed."""
-
-    logger = logger_override or _logger
-    now = datetime.now(timezone.utc)
-
-    pending = (
-        CeleryTaskRecord.query.filter(
-            CeleryTaskRecord.task_name == _THUMBNAIL_RETRY_TASK_NAME,
-            CeleryTaskRecord.object_type == "media",
-            CeleryTaskRecord.scheduled_for <= now,
-            CeleryTaskRecord.status == CeleryTaskStatus.SCHEDULED,
-        )
-        .order_by(CeleryTaskRecord.scheduled_for)
-        .limit(limit)
-        .all()
-    )
-
-    if not pending:
-        _log_idle_retry_monitor_state(logger)
-        return {
-            "processed": 0,
-            "rescheduled": 0,
-            "cleared": 0,
-            "pending_before": 0,
-        }
-
-    processed = 0
-    rescheduled = 0
-    cleared = 0
-
-    for entry in pending:
-        processed += 1
-        if entry.object_id is None:
-            entry.status = CeleryTaskStatus.CANCELED
-            entry.finished_at = now
-            db.session.commit()
-            continue
-        try:
-            media_id = int(entry.object_id)
-        except (TypeError, ValueError):
-            entry.status = CeleryTaskStatus.CANCELED
-            entry.finished_at = now
-            db.session.commit()
-            continue
-        entry.status = CeleryTaskStatus.RUNNING
-        entry.started_at = now
-        db.session.commit()
-        payload = entry.payload
-        force_flag = bool(payload.get("force", False))
-        result = enqueue_thumbs_generate(
-            media_id,
-            logger_override=logger,
-            operation_id=f"thumbnail-retry-{media_id}",
-            request_context={"source": "retry-monitor"},
-            force=force_flag,
-        )
-        if result.get("retry_scheduled"):
-            rescheduled += 1
-        else:
-            cleared += 1
-
-    _structured_task_log(
-        logger,
-        level="info",
-        event="thumbnail_generation.retry_monitor",
-        message="Processed pending thumbnail retries.",
-        operation_id="thumbnail-retry-monitor",
-        media_id=0,
-        processed=processed,
-        rescheduled=rescheduled,
-        cleared=cleared,
-        pending_before=len(pending),
-    )
-
-    return {
-        "processed": processed,
-        "rescheduled": rescheduled,
-        "cleared": cleared,
-        "pending_before": len(pending),
-    }
-
-
-def _log_idle_retry_monitor_state(logger: logging.Logger) -> None:
-    """Emit additional context when no thumbnail retries are ready to process."""
-
-    disabled_records: List[CeleryTaskRecord] = (
-        CeleryTaskRecord.query.filter(
-            CeleryTaskRecord.task_name == _THUMBNAIL_RETRY_TASK_NAME,
-            CeleryTaskRecord.object_type == "media",
-            CeleryTaskRecord.status == CeleryTaskStatus.FAILED,
-        )
-        .order_by(CeleryTaskRecord.updated_at.desc())
-        .limit(5)
-        .all()
-    )
-
-    pending_alerts: List[Dict[str, Any]] = []
-    records_to_mark: List[CeleryTaskRecord] = []
-
-    for record in disabled_records:
-        payload = record.payload
-        if not payload.get("retry_disabled"):
-            continue
-        if payload.get("monitor_reported"):
-            continue
-
-        blocker_info = payload.get("blockers")
-        media_identifier: Any = record.object_id
-        try:
-            if media_identifier is not None:
-                media_identifier = int(media_identifier)
-        except (TypeError, ValueError):
-            pass
-
-        pending_alerts.append(
-            {
-                "media_id": media_identifier,
-                "attempts": payload.get("attempts"),
-                "blockers": blocker_info,
-            }
-        )
-        records_to_mark.append(record)
-
-    if not pending_alerts:
-        return
-
-    for record in records_to_mark:
-        record.update_payload({"monitor_reported": True})
-    if records_to_mark:
-        db.session.commit()
-
-    _structured_task_log(
-        logger,
-        level="warning",
-        event="thumbnail_generation.retry_monitor_blocked",
-        message=(
-            "No pending thumbnail retries; some media exhausted their retry "
-            "budget and require manual attention."
-        ),
-        operation_id="thumbnail-retry-monitor",
-        media_id=0,
-        disabled=len(pending_alerts),
-        samples=pending_alerts,
-    )
+    logger_override: Optional[Any] = None,
+) -> Dict[str, int]:
+    logger = _build_structured_logger(logger_override)
+    monitor = _build_retry_monitor_service(logger)
+    return monitor.process_due(limit=limit)
 
 
 def process_media_post_import(
     media: Media,
     *,
-    logger_override: Optional[logging.Logger] = None,
+    logger_override: Optional[Any] = None,
     request_context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Execute the appropriate post-import processing pipeline for *media*.
-
-    Returns a dictionary summarising the outcome of the triggered tasks.
-    """
-
-    logger = logger_override or _logger
-    op_id = str(uuid4())
-
-    _structured_task_log(
-        logger,
-        level="info",
-        event="media_post_process.start",
-        message="Starting post-import processing.",
-        operation_id=op_id,
-        media_id=media.id,
-        request_context=request_context,
-        media_type="video" if media.is_video else "photo",
-    )
-
-    results: Dict[str, Any] = {}
-    if media.is_video:
-        results["playback"] = enqueue_media_playback(
-            media.id,
-            logger_override=logger,
-            operation_id=op_id,
-            request_context=request_context,
-        )
-    else:
-        results["thumbnails"] = enqueue_thumbs_generate(
-            media.id,
-            logger_override=logger,
-            operation_id=op_id,
-            request_context=request_context,
-        )
-
-    return results
-
+    logger = _build_structured_logger(logger_override)
+    service = _build_post_processing_service(logger)
+    return service.process(media=media, request_context=request_context)

--- a/domain/media_processing/__init__.py
+++ b/domain/media_processing/__init__.py
@@ -1,0 +1,10 @@
+"""ドメイン層: メディア後処理に関する値オブジェクトとポリシー."""
+
+from .retry_policy import ThumbnailRetryDecision, ThumbnailRetryPolicy
+from .value_objects import RetryBlockers
+
+__all__ = [
+    "RetryBlockers",
+    "ThumbnailRetryDecision",
+    "ThumbnailRetryPolicy",
+]

--- a/domain/media_processing/retry_policy.py
+++ b/domain/media_processing/retry_policy.py
@@ -1,0 +1,48 @@
+"""サムネイル再試行に関するドメインポリシー."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ThumbnailRetryDecision:
+    """再試行の可否を表す値オブジェクト."""
+
+    can_retry: bool
+    attempt_number: int
+    reason: Optional[str] = None
+    keep_record: bool = False
+
+
+class ThumbnailRetryPolicy:
+    """サムネイル生成の再試行回数を管理するドメインポリシー."""
+
+    def __init__(self, max_attempts: int) -> None:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be positive")
+        self._max_attempts = max_attempts
+
+    @property
+    def max_attempts(self) -> int:
+        return self._max_attempts
+
+    def decide(self, attempts_so_far: int) -> ThumbnailRetryDecision:
+        """現在の試行回数から次回のアクションを決定する."""
+
+        if attempts_so_far < 0:
+            raise ValueError("attempts_so_far must be >= 0")
+
+        if attempts_so_far >= self._max_attempts:
+            return ThumbnailRetryDecision(
+                can_retry=False,
+                attempt_number=attempts_so_far,
+                reason="max_attempts",
+                keep_record=True,
+            )
+
+        return ThumbnailRetryDecision(
+            can_retry=True,
+            attempt_number=attempts_so_far + 1,
+        )

--- a/domain/media_processing/value_objects.py
+++ b/domain/media_processing/value_objects.py
@@ -1,0 +1,30 @@
+"""メディア後処理ドメインの値オブジェクト."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class RetryBlockers:
+    """サムネイル再試行を阻害する要因を表す不変値オブジェクト."""
+
+    details: Dict[str, Any]
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> Optional["RetryBlockers"]:
+        """辞書形式の入力から :class:`RetryBlockers` を生成する."""
+
+        if not isinstance(raw, dict):
+            return None
+        return cls(details=dict(raw))
+
+    @property
+    def reason(self) -> Optional[str]:
+        """再試行が止まっている理由 (存在しない場合は ``None``)."""
+
+        raw = self.details.get("reason")
+        if raw is None:
+            return None
+        return str(raw)

--- a/infrastructure/media_processing/__init__.py
+++ b/infrastructure/media_processing/__init__.py
@@ -1,0 +1,10 @@
+"""メディア後処理向けインフラ実装."""
+
+from .repositories import SqlAlchemyThumbnailRetryRepository
+from .scheduler import CeleryThumbnailRetryScheduler, RetrySchedulingError
+
+__all__ = [
+    "CeleryThumbnailRetryScheduler",
+    "RetrySchedulingError",
+    "SqlAlchemyThumbnailRetryRepository",
+]

--- a/infrastructure/media_processing/repositories.py
+++ b/infrastructure/media_processing/repositories.py
@@ -1,0 +1,186 @@
+"""SQLAlchemy を利用したサムネイル再試行リポジトリ."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, Optional, Sequence
+
+from application.media_processing.interfaces import ThumbnailRetryEntry, ThumbnailRetryRepository
+from core.db import db
+from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
+
+_THUMBNAIL_RETRY_TASK_NAME = "thumbnail.retry"
+
+
+def _as_entry(record: CeleryTaskRecord) -> ThumbnailRetryEntry:
+    payload = record.payload or {}
+    attempts_raw = payload.get("attempts", 0)
+    try:
+        attempts = int(attempts_raw)
+    except (TypeError, ValueError):
+        attempts = 0
+    return ThumbnailRetryEntry(
+        id=record.id,
+        media_id=record.object_id,
+        attempts=attempts,
+        payload=dict(payload),
+    )
+
+
+def _load_record(entry: ThumbnailRetryEntry) -> Optional[CeleryTaskRecord]:
+    if entry.id:
+        record = CeleryTaskRecord.query.get(entry.id)
+        if record is not None:
+            return record
+    if entry.media_id is None:
+        return None
+    return (
+        CeleryTaskRecord.query.filter_by(
+            task_name=_THUMBNAIL_RETRY_TASK_NAME,
+            object_type="media",
+            object_id=str(entry.media_id),
+        )
+        .order_by(CeleryTaskRecord.id.desc())
+        .first()
+    )
+
+
+class SqlAlchemyThumbnailRetryRepository(ThumbnailRetryRepository):
+    """CeleryTaskRecord を利用した再試行リポジトリ."""
+
+    def get_or_create(self, media_id: int) -> ThumbnailRetryEntry:
+        record = CeleryTaskRecord.get_or_create(
+            task_name=_THUMBNAIL_RETRY_TASK_NAME,
+            object_identity=("media", str(media_id)),
+        )
+        db.session.flush()
+        return _as_entry(record)
+
+    def persist_scheduled(
+        self,
+        entry: ThumbnailRetryEntry,
+        *,
+        countdown_seconds: int,
+        force: bool,
+        celery_task_id: Optional[str],
+        attempt: int,
+        blockers: Optional[Dict[str, object]] = None,
+    ) -> None:
+        record = _load_record(entry)
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.SCHEDULED
+        record.scheduled_for = datetime.now(timezone.utc) + timedelta(seconds=countdown_seconds)
+        record.started_at = None
+        record.finished_at = None
+        record.celery_task_id = celery_task_id
+        payload: Dict[str, object] = {"force": force, "attempts": attempt}
+        if blockers is not None:
+            payload["blockers"] = blockers
+        record.set_payload(payload)
+        db.session.commit()
+
+    def mark_exhausted(
+        self,
+        entry: ThumbnailRetryEntry,
+        *,
+        force: bool,
+        blockers: Optional[Dict[str, object]] = None,
+    ) -> None:
+        record = _load_record(entry)
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.FAILED
+        record.scheduled_for = None
+        record.started_at = None
+        record.finished_at = datetime.now(timezone.utc)
+        record.celery_task_id = None
+        payload: Dict[str, object] = {"force": force, "attempts": entry.attempts, "retry_disabled": True}
+        if blockers is not None:
+            payload["blockers"] = blockers
+        record.set_payload(payload)
+        db.session.commit()
+
+    def clear_success(self, media_id: int) -> None:
+        record = (
+            CeleryTaskRecord.query.filter_by(
+                task_name=_THUMBNAIL_RETRY_TASK_NAME,
+                object_type="media",
+                object_id=media_id,
+            )
+            .order_by(CeleryTaskRecord.id.desc())
+            .first()
+        )
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.SUCCESS
+        record.scheduled_for = None
+        record.celery_task_id = None
+        record.finished_at = datetime.now(timezone.utc)
+        record.set_payload({})
+        db.session.commit()
+
+    def iter_due(self, limit: int) -> Iterable[ThumbnailRetryEntry]:
+        pending = (
+            CeleryTaskRecord.query.filter(
+                CeleryTaskRecord.task_name == _THUMBNAIL_RETRY_TASK_NAME,
+                CeleryTaskRecord.object_type == "media",
+                CeleryTaskRecord.scheduled_for <= datetime.now(timezone.utc),
+                CeleryTaskRecord.status == CeleryTaskStatus.SCHEDULED,
+            )
+            .order_by(CeleryTaskRecord.scheduled_for)
+            .limit(limit)
+            .all()
+        )
+        for record in pending:
+            yield _as_entry(record)
+
+    def mark_running(self, entry: ThumbnailRetryEntry, *, started_at: datetime) -> None:
+        record = _load_record(entry)
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.RUNNING
+        record.started_at = started_at
+        db.session.commit()
+
+    def mark_canceled(self, entry: ThumbnailRetryEntry, *, finished_at: datetime) -> None:
+        record = _load_record(entry)
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.CANCELED
+        record.finished_at = finished_at
+        db.session.commit()
+
+    def mark_finished(self, entry: ThumbnailRetryEntry, *, finished_at: datetime, success: bool) -> None:
+        record = _load_record(entry)
+        if record is None:
+            return
+        record.status = CeleryTaskStatus.SUCCESS if success else CeleryTaskStatus.FAILED
+        record.finished_at = finished_at
+        record.celery_task_id = None
+        db.session.commit()
+
+    def find_disabled(self, limit: int) -> Iterable[ThumbnailRetryEntry]:
+        records = (
+            CeleryTaskRecord.query.filter(
+                CeleryTaskRecord.task_name == _THUMBNAIL_RETRY_TASK_NAME,
+                CeleryTaskRecord.object_type == "media",
+                CeleryTaskRecord.status == CeleryTaskStatus.FAILED,
+            )
+            .order_by(CeleryTaskRecord.updated_at.desc())
+            .limit(limit)
+            .all()
+        )
+        for record in records:
+            yield _as_entry(record)
+
+    def mark_monitor_reported(self, entries: Sequence[ThumbnailRetryEntry]) -> None:
+        if not entries:
+            return
+        entry_ids = [entry.id for entry in entries]
+        records = CeleryTaskRecord.query.filter(CeleryTaskRecord.id.in_(entry_ids)).all()
+        for record in records:
+            payload = dict(record.payload or {})
+            payload["monitor_reported"] = True
+            record.set_payload(payload)
+        db.session.commit()

--- a/infrastructure/media_processing/scheduler.py
+++ b/infrastructure/media_processing/scheduler.py
@@ -1,0 +1,45 @@
+"""サムネイル再試行スケジューラのCelery実装."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from application.media_processing.interfaces import ThumbnailRetryScheduler
+from core.logging_config import setup_task_logging
+
+
+class RetrySchedulingError(RuntimeError):
+    """再試行スケジュールに失敗したことを表す例外."""
+
+
+class CeleryThumbnailRetryScheduler(ThumbnailRetryScheduler):
+    """Celery を利用したサムネイル再試行スケジューラ."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self._logger = logger or setup_task_logging(__name__)
+
+    def schedule(
+        self,
+        *,
+        media_id: int,
+        force: bool,
+        countdown_seconds: int,
+    ) -> Optional[str]:
+        try:
+            from cli.src.celery.tasks import thumbs_generate_task
+        except ImportError:
+            return None
+
+        try:
+            async_result = thumbs_generate_task.apply_async(
+                kwargs={"media_id": media_id, "force": force},
+                countdown=countdown_seconds,
+            )
+        except Exception as exc:  # pragma: no cover - Celery 呼び出し失敗時
+            self._logger.warning(
+                "Failed to schedule thumbnail retry", exc_info=True, extra={"media_id": media_id, "error": str(exc)}
+            )
+            raise RetrySchedulingError(str(exc)) from exc
+
+        return getattr(async_result, "id", None)

--- a/tests/application/media_processing/test_retry_monitor.py
+++ b/tests/application/media_processing/test_retry_monitor.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List
+
+from application.media_processing.interfaces import ThumbnailRetryEntry, ThumbnailRetryRepository
+from application.media_processing.retry_monitor import ThumbnailRetryMonitorService
+
+
+@dataclass
+class StubLogger:
+    calls: list
+
+    def info(self, **kwargs):
+        self.calls.append(("info", kwargs))
+
+    def warning(self, **kwargs):
+        self.calls.append(("warning", kwargs))
+
+    def error(self, **kwargs):  # pragma: no cover - unused
+        self.calls.append(("error", kwargs))
+
+
+class FakeThumbnailService:
+    def __init__(self, results: Iterable[dict]) -> None:
+        self._results = list(results)
+        self.calls: List[dict] = []
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._results.pop(0)
+
+
+class FakeRepository(ThumbnailRetryRepository):
+    def __init__(self, *, pending: List[ThumbnailRetryEntry], disabled: List[ThumbnailRetryEntry]):
+        self._pending = list(pending)
+        self._disabled = list(disabled)
+        self.running: List[int] = []
+        self.canceled: List[int] = []
+        self.finished: List[tuple] = []
+        self.reported: List[int] = []
+
+    def get_or_create(self, media_id: int):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def persist_scheduled(self, *args, **kwargs):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def mark_exhausted(self, *args, **kwargs):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def clear_success(self, media_id: int):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def iter_due(self, limit: int):
+        return list(self._pending)[:limit]
+
+    def mark_running(self, entry, *, started_at):
+        self.running.append(entry.id)
+
+    def mark_canceled(self, entry, *, finished_at):
+        self.canceled.append(entry.id)
+
+    def mark_finished(self, entry, *, finished_at, success):
+        self.finished.append((entry.id, success))
+
+    def find_disabled(self, limit: int):
+        return list(self._disabled)[:limit]
+
+    def mark_monitor_reported(self, entries):
+        for entry in entries:
+            self.reported.append(entry.id)
+
+
+def test_process_due_handles_successful_retry():
+    entry = ThumbnailRetryEntry(id=1, media_id=5, attempts=0, payload={"force": False})
+    repository = FakeRepository(pending=[entry], disabled=[])
+    service = FakeThumbnailService(results=[{"ok": True}])
+    logger = StubLogger(calls=[])
+    monitor = ThumbnailRetryMonitorService(repository=repository, thumbnail_service=service, logger=logger)
+
+    result = monitor.process_due(limit=10)
+
+    assert result == {"processed": 1, "rescheduled": 0, "cleared": 1, "pending_before": 1}
+    assert repository.running == [1]
+    assert repository.canceled == []
+    assert service.calls[0]["media_id"] == 5
+    assert any(call[0] == "info" for call in logger.calls)
+
+
+def test_process_due_handles_reschedule():
+    entry = ThumbnailRetryEntry(id=2, media_id=7, attempts=1, payload={"force": True})
+    repository = FakeRepository(pending=[entry], disabled=[])
+    service = FakeThumbnailService(results=[{"retry_scheduled": True}])
+    logger = StubLogger(calls=[])
+    monitor = ThumbnailRetryMonitorService(repository=repository, thumbnail_service=service, logger=logger)
+
+    result = monitor.process_due(limit=5)
+
+    assert result["rescheduled"] == 1
+
+
+def test_process_due_logs_when_idle():
+    disabled_entry = ThumbnailRetryEntry(
+        id=3,
+        media_id=9,
+        attempts=5,
+        payload={"retry_disabled": True},
+    )
+    repository = FakeRepository(pending=[], disabled=[disabled_entry])
+    service = FakeThumbnailService(results=[])
+    logger = StubLogger(calls=[])
+    monitor = ThumbnailRetryMonitorService(repository=repository, thumbnail_service=service, logger=logger)
+
+    result = monitor.process_due(limit=2)
+
+    assert result == {"processed": 0, "rescheduled": 0, "cleared": 0, "pending_before": 0}
+    assert repository.reported == [3]
+    assert any(call[0] == "warning" for call in logger.calls)

--- a/tests/application/media_processing/test_retry_service.py
+++ b/tests/application/media_processing/test_retry_service.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+import pytest
+
+from application.media_processing.interfaces import ThumbnailRetryEntry, ThumbnailRetryRepository, ThumbnailRetryScheduler
+from application.media_processing.retry_service import RetryScheduleResult, ThumbnailRetryService
+from domain.media_processing import ThumbnailRetryPolicy
+
+
+@dataclass
+class StubLogger:
+    calls: list
+
+    def info(self, **kwargs):
+        self.calls.append(("info", kwargs))
+
+    def warning(self, **kwargs):
+        self.calls.append(("warning", kwargs))
+
+    def error(self, **kwargs):
+        self.calls.append(("error", kwargs))
+
+
+class FakeRepository(ThumbnailRetryRepository):
+    def __init__(self, *, attempts: int = 0) -> None:
+        self._entry = ThumbnailRetryEntry(id=1, media_id=123, attempts=attempts, payload={})
+        self.persisted: Optional[Dict[str, object]] = None
+        self.exhausted: Optional[Dict[str, object]] = None
+        self.cleared_media: Optional[int] = None
+
+    def get_or_create(self, media_id: int) -> ThumbnailRetryEntry:
+        return self._entry
+
+    def persist_scheduled(self, entry, *, countdown_seconds, force, celery_task_id, attempt, blockers=None):
+        self.persisted = {
+            "entry": entry,
+            "countdown": countdown_seconds,
+            "force": force,
+            "celery_task_id": celery_task_id,
+            "attempt": attempt,
+            "blockers": blockers,
+        }
+        self._entry = self._entry.with_attempts(attempt)
+
+    def mark_exhausted(self, entry, *, force, blockers=None):
+        self.exhausted = {"entry": entry, "force": force, "blockers": blockers}
+
+    def clear_success(self, media_id: int) -> None:
+        self.cleared_media = media_id
+
+    def iter_due(self, limit: int) -> Iterable[ThumbnailRetryEntry]:  # pragma: no cover - not used here
+        return []
+
+    def mark_running(self, entry, *, started_at):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+    def mark_canceled(self, entry, *, finished_at):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+    def mark_finished(self, entry, *, finished_at, success):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+    def find_disabled(self, limit: int):  # pragma: no cover - not used here
+        return []
+
+    def mark_monitor_reported(self, entries):  # pragma: no cover - not used here
+        raise NotImplementedError
+
+
+class FakeScheduler(ThumbnailRetryScheduler):
+    def __init__(self, *, celery_task_id: Optional[str] = "task-id", raise_error: bool = False) -> None:
+        self.celery_task_id = celery_task_id
+        self.raise_error = raise_error
+        self.calls = []
+
+    def schedule(self, *, media_id: int, force: bool, countdown_seconds: int) -> Optional[str]:
+        if self.raise_error:
+            raise RuntimeError("scheduler failure")
+        self.calls.append({"media_id": media_id, "force": force, "countdown": countdown_seconds})
+        return self.celery_task_id
+
+
+@pytest.fixture
+def policy() -> ThumbnailRetryPolicy:
+    return ThumbnailRetryPolicy(max_attempts=3)
+
+
+def test_schedule_retry_success(policy):
+    logger = StubLogger(calls=[])
+    repository = FakeRepository(attempts=0)
+    scheduler = FakeScheduler()
+    service = ThumbnailRetryService(
+        policy=policy,
+        repository=repository,
+        scheduler=scheduler,
+        logger=logger,
+        countdown_seconds=60,
+    )
+
+    result = service.schedule_if_allowed(
+        media_id=123,
+        force=True,
+        operation_id="op-1",
+        request_context={"source": "test"},
+        blockers={"reason": "pending"},
+    )
+
+    assert isinstance(result, RetryScheduleResult)
+    assert result.scheduled is True
+    assert result.countdown == 60
+    assert result.celery_task_id == "task-id"
+    assert result.attempts == 1
+    assert repository.persisted["attempt"] == 1
+    assert repository.persisted["force"] is True
+    assert repository.persisted["blockers"] == {"reason": "pending"}
+    assert scheduler.calls[0]["media_id"] == 123
+    assert any(call[0] == "info" for call in logger.calls)
+
+
+def test_schedule_retry_exhausted(policy):
+    logger = StubLogger(calls=[])
+    repository = FakeRepository(attempts=3)
+    scheduler = FakeScheduler()
+    service = ThumbnailRetryService(
+        policy=policy,
+        repository=repository,
+        scheduler=scheduler,
+        logger=logger,
+        countdown_seconds=60,
+    )
+
+    result = service.schedule_if_allowed(
+        media_id=123,
+        force=False,
+        operation_id="op-2",
+        request_context=None,
+        blockers=None,
+    )
+
+    assert isinstance(result, RetryScheduleResult)
+    assert result.scheduled is False
+    assert result.keep_record is True
+    assert repository.exhausted["force"] is False
+    assert scheduler.calls == []
+    assert any(call[0] == "warning" for call in logger.calls)
+
+
+def test_schedule_retry_handles_scheduler_errors(policy):
+    logger = StubLogger(calls=[])
+    repository = FakeRepository(attempts=0)
+    scheduler = FakeScheduler(raise_error=True)
+    service = ThumbnailRetryService(
+        policy=policy,
+        repository=repository,
+        scheduler=scheduler,
+        logger=logger,
+        countdown_seconds=60,
+    )
+
+    result = service.schedule_if_allowed(
+        media_id=999,
+        force=False,
+        operation_id="op-3",
+        request_context=None,
+        blockers=None,
+    )
+
+    assert result is None
+    assert repository.persisted is None
+    assert any(call[0] == "warning" for call in logger.calls)

--- a/tests/application/media_processing/test_thumbnail_service.py
+++ b/tests/application/media_processing/test_thumbnail_service.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pytest
+
+from application.media_processing.retry_service import RetryScheduleResult
+from application.media_processing.thumbnail_service import ThumbnailGenerationService
+
+
+@dataclass
+class StubLogger:
+    calls: list
+
+    def info(self, **kwargs):
+        self.calls.append(("info", kwargs))
+
+    def warning(self, **kwargs):
+        self.calls.append(("warning", kwargs))
+
+    def error(self, **kwargs):  # pragma: no cover - not triggered in tests
+        self.calls.append(("error", kwargs))
+
+
+class StubRetryService:
+    def __init__(self, result: Optional[RetryScheduleResult] = None) -> None:
+        self.result = result
+        self.calls = []
+        self.cleared = []
+
+    def schedule_if_allowed(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result
+
+    def clear_success(self, media_id: int) -> None:
+        self.cleared.append(media_id)
+
+
+@pytest.fixture
+def logger():
+    return StubLogger(calls=[])
+
+
+def test_generate_schedules_retry(logger):
+    retry_result = RetryScheduleResult(
+        scheduled=True,
+        countdown=120,
+        celery_task_id="celery-1",
+        attempts=2,
+        max_attempts=5,
+        keep_record=False,
+        blockers={"reason": "pending"},
+    )
+    retry_service = StubRetryService(result=retry_result)
+
+    def generator(**kwargs):
+        return {
+            "ok": True,
+            "generated": [],
+            "skipped": [256],
+            "notes": "not-ready",
+            "retry_blockers": {"reason": "pending"},
+        }
+
+    service = ThumbnailGenerationService(
+        generator=generator,
+        retry_service=retry_service,
+        logger=logger,
+        playback_not_ready_note="not-ready",
+    )
+
+    result = service.generate(media_id=101, force=True, operation_id="op", request_context={"x": 1})
+
+    assert result["retry_scheduled"] is True
+    assert result["retry_details"]["celery_task_id"] == "celery-1"
+    assert retry_service.calls[0]["media_id"] == 101
+    assert 101 not in retry_service.cleared
+    assert any(call[0] == "info" for call in logger.calls)
+
+
+def test_generate_clears_retry_when_not_scheduled(logger):
+    retry_service = StubRetryService(result=None)
+
+    def generator(**kwargs):
+        return {
+            "ok": True,
+            "generated": [256],
+            "skipped": [],
+            "notes": "done",
+        }
+
+    service = ThumbnailGenerationService(
+        generator=generator,
+        retry_service=retry_service,
+        logger=logger,
+        playback_not_ready_note="not-ready",
+    )
+
+    result = service.generate(media_id=202, operation_id="op2", request_context=None)
+
+    assert result["ok"] is True
+    assert retry_service.cleared == [202]
+    assert retry_service.calls == []
+
+
+def test_generate_logs_failure(logger):
+    retry_service = StubRetryService(result=None)
+
+    def generator(**kwargs):
+        return {"ok": False, "notes": "failure"}
+
+    service = ThumbnailGenerationService(
+        generator=generator,
+        retry_service=retry_service,
+        logger=logger,
+        playback_not_ready_note="not-ready",
+    )
+
+    result = service.generate(media_id=303, operation_id="op3", request_context=None)
+
+    assert result == {"ok": False, "notes": "failure"}
+    assert retry_service.cleared == [303]
+    assert any(call[0] == "warning" for call in logger.calls)

--- a/tests/domain/media_processing/test_retry_policy.py
+++ b/tests/domain/media_processing/test_retry_policy.py
@@ -1,0 +1,32 @@
+import pytest
+
+from domain.media_processing import ThumbnailRetryPolicy
+
+
+def test_decide_allows_retry_before_limit():
+    policy = ThumbnailRetryPolicy(max_attempts=3)
+
+    decision = policy.decide(1)
+
+    assert decision.can_retry is True
+    assert decision.attempt_number == 2
+    assert decision.reason is None
+    assert decision.keep_record is False
+
+
+def test_decide_blocks_retry_at_limit():
+    policy = ThumbnailRetryPolicy(max_attempts=2)
+
+    decision = policy.decide(2)
+
+    assert decision.can_retry is False
+    assert decision.attempt_number == 2
+    assert decision.reason == "max_attempts"
+    assert decision.keep_record is True
+
+
+def test_decide_validates_negative_attempts():
+    policy = ThumbnailRetryPolicy(max_attempts=2)
+
+    with pytest.raises(ValueError):
+        policy.decide(-1)


### PR DESCRIPTION
## Summary
- extract media post-processing logic into dedicated domain and application service layers
- add infrastructure components for thumbnail retry persistence and scheduling
- update task entrypoints and expand unit coverage for refactored services

## Testing
- pytest tests/domain/media_processing tests/application/media_processing tests/test_media_post_processing.py


------
https://chatgpt.com/codex/tasks/task_e_68e5d636de7c8323975a62f715b79dbd