### PR TITLE
Refactor local import workflow result handling

### DIFF
--- a/domain/local_import/import_result.py
+++ b/domain/local_import/import_result.py
@@ -1,0 +1,155 @@
+"""ローカルインポート結果の値オブジェクト."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class ImportTaskResult:
+    """ローカルインポート処理全体の集計結果を保持する不変に近い値オブジェクト."""
+
+    ok: bool = True
+    processed: int = 0
+    success: int = 0
+    skipped: int = 0
+    failed: int = 0
+    canceled: bool = False
+    session_id: Optional[str] = None
+    celery_task_id: Optional[str] = None
+    errors: List[str] = field(default_factory=list)
+    details: List[Dict[str, Any]] = field(default_factory=list)
+    thumbnail_records: List[Dict[str, Any]] = field(default_factory=list)
+    duplicates: int = 0
+    manually_skipped: int = 0
+    failure_reasons: List[str] = field(default_factory=list)
+    thumbnail_snapshot: Optional[Dict[str, Any]] = None
+    _metadata: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def mark_failed(self) -> None:
+        """エラー発生により ``ok`` フラグを下げる."""
+
+        self.ok = False
+
+    def add_error(self, message: Any, *, mark_failed: bool = True) -> None:
+        """エラーを追加し必要に応じて ``ok`` を ``False`` にする."""
+
+        if mark_failed:
+            self.mark_failed()
+        if message:
+            self.errors.append(str(message))
+
+    def append_detail(self, detail: Dict[str, Any]) -> None:
+        """詳細情報を追加する."""
+
+        if detail:
+            self.details.append(detail)
+
+    def increment_processed(self, *, amount: int = 1) -> None:
+        self.processed += amount
+
+    def increment_success(self, *, amount: int = 1) -> None:
+        self.success += amount
+
+    def increment_skipped(self, *, amount: int = 1) -> None:
+        self.skipped += amount
+
+    def increment_failed(self, *, amount: int = 1, mark_failed: bool = True) -> None:
+        self.failed += amount
+        if mark_failed:
+            self.mark_failed()
+
+    def mark_canceled(self) -> None:
+        self.canceled = True
+
+    def set_session_id(self, session_id: Optional[str]) -> None:
+        self.session_id = session_id
+
+    def set_celery_task_id(self, celery_task_id: Optional[str]) -> None:
+        self.celery_task_id = celery_task_id
+
+    def add_thumbnail_record(self, record: Dict[str, Any]) -> None:
+        if record:
+            self.thumbnail_records.append(record)
+
+    def set_thumbnail_snapshot(self, snapshot: Optional[Dict[str, Any]]) -> None:
+        self.thumbnail_snapshot = snapshot
+
+    def set_duplicates(self, *, duplicates: int, manually_skipped: int) -> None:
+        self.duplicates = duplicates
+        self.manually_skipped = manually_skipped
+
+    def set_failure_reasons(self, reasons: Iterable[str]) -> None:
+        self.failure_reasons = [str(reason) for reason in reasons if reason]
+
+    def metadata(self) -> Dict[str, Any]:
+        return self._metadata
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        self._metadata[key] = value
+
+    def get_metadata(self, key: str, default: Any = None) -> Any:
+        return self._metadata.get(key, default)
+
+    def collect_failure_reasons(self) -> List[str]:
+        """エラー詳細からユニークな失敗理由を抽出する."""
+
+        reasons: List[str] = []
+        seen: set[str] = set()
+
+        for entry in self.errors:
+            if not entry:
+                continue
+            text = str(entry)
+            if text not in seen:
+                reasons.append(text)
+                seen.add(text)
+
+        for detail in self.details:
+            if not isinstance(detail, dict):
+                continue
+            if detail.get("status") != "failed":
+                continue
+            detail_reason = detail.get("reason") or "理由不明"
+            if detail.get("file"):
+                detail_reason = f"{detail['file']}: {detail_reason}"
+            if detail_reason not in seen:
+                reasons.append(detail_reason)
+                seen.add(detail_reason)
+
+        return reasons
+
+    def to_dict(self) -> Dict[str, Any]:
+        """API やテストで利用する辞書形式へ変換する."""
+
+        payload: Dict[str, Any] = {
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "processed": self.processed,
+            "success": self.success,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "details": [dict(detail) for detail in self.details],
+            "session_id": self.session_id,
+            "celery_task_id": self.celery_task_id,
+            "canceled": self.canceled,
+        }
+
+        if self.thumbnail_records:
+            payload["thumbnail_records"] = [dict(entry) for entry in self.thumbnail_records]
+        if self.thumbnail_snapshot is not None:
+            payload["thumbnail_snapshot"] = self.thumbnail_snapshot
+        if self.failure_reasons:
+            payload["failure_reasons"] = list(self.failure_reasons)
+        if self.duplicates:
+            payload["duplicates"] = self.duplicates
+        if self.manually_skipped:
+            payload["manually_skipped"] = self.manually_skipped
+
+        if self._metadata:
+            payload.update(self._metadata)
+
+        return payload
+
+
+__all__ = ["ImportTaskResult"]

--- a/tests/domain/test_local_import_result.py
+++ b/tests/domain/test_local_import_result.py
@@ -1,0 +1,47 @@
+from domain.local_import.import_result import ImportTaskResult
+
+
+def test_import_task_result_add_error_marks_failed():
+    result = ImportTaskResult()
+
+    result.add_error("失敗しました")
+
+    assert result.ok is False
+    assert result.errors == ["失敗しました"]
+
+
+def test_collect_failure_reasons_deduplicates_entries():
+    result = ImportTaskResult()
+    result.add_error("A")
+    result.add_error("A", mark_failed=False)
+    result.append_detail({"status": "failed", "reason": "B", "file": "x.jpg"})
+    result.append_detail({"status": "failed", "reason": "B", "file": "x.jpg"})
+
+    reasons = result.collect_failure_reasons()
+
+    assert reasons == ["A", "x.jpg: B"]
+
+
+def test_to_dict_includes_optional_metadata():
+    result = ImportTaskResult()
+    result.increment_processed()
+    result.increment_success()
+    result.set_session_id("S1")
+    result.set_celery_task_id("C1")
+    result.set_thumbnail_snapshot({"status": "completed"})
+    result.set_duplicates(duplicates=2, manually_skipped=1)
+    result.set_failure_reasons(["reason1"])
+    result.set_metadata("extra", "value")
+
+    payload = result.to_dict()
+
+    assert payload["ok"] is True
+    assert payload["processed"] == 1
+    assert payload["success"] == 1
+    assert payload["session_id"] == "S1"
+    assert payload["celery_task_id"] == "C1"
+    assert payload["thumbnail_snapshot"] == {"status": "completed"}
+    assert payload["duplicates"] == 2
+    assert payload["manually_skipped"] == 1
+    assert payload["failure_reasons"] == ["reason1"]
+    assert payload["extra"] == "value"

--- a/tests/test_local_import_services.py
+++ b/tests/test_local_import_services.py
@@ -10,6 +10,7 @@ from application.local_import.use_case import LocalImportUseCase
 from application.local_import.logger import LocalImportTaskLogger
 from application.local_import.queue import LocalImportQueueProcessor
 from application.local_import import logger as logger_module
+from domain.local_import.import_result import ImportTaskResult
 
 
 class DummyAnalysis:
@@ -228,7 +229,7 @@ def test_queue_processor_handles_cancel_request(monkeypatch):
 
     monkeypatch.setattr(processor, "pending_query", lambda _session: DummyQuery())
 
-    result = {"processed": 0, "success": 0, "skipped": 0, "failed": 0, "details": []}
+    result = ImportTaskResult()
 
     processor.process(
         session,
@@ -240,8 +241,8 @@ def test_queue_processor_handles_cancel_request(monkeypatch):
     )
 
     importer.import_file.assert_not_called()
-    assert result["processed"] == 0
-    assert result["canceled"] is True
+    assert result.processed == 0
+    assert result.canceled is True
 
 
 def test_queue_processor_logs_commit_error(monkeypatch):
@@ -289,7 +290,7 @@ def test_queue_processor_logs_commit_error(monkeypatch):
     )
     monkeypatch.setattr(processor, "pending_query", lambda _session: DummyQuery())
 
-    result = {"processed": 0, "success": 0, "skipped": 0, "failed": 0, "details": []}
+    result = ImportTaskResult()
 
     processor.process(
         session,
@@ -300,8 +301,8 @@ def test_queue_processor_logs_commit_error(monkeypatch):
         celery_task_id="C1",
     )
 
-    assert result["success"] == 1
-    assert result["processed"] == 1
+    assert result.success == 1
+    assert result.processed == 1
     db_session.rollback.assert_called_once()
     logger.error.assert_any_call(
         "local_import.selection.finalize_failed",


### PR DESCRIPTION
## Summary
- Introduced an ImportTaskResult value object to encapsulate local-import outcomes and failure-reason aggregation
- Updated the local import use case and queue processor to collaborate through the new result object, simplifying branching and logging
- Added focused unit tests for the new value object and refreshed queue processor tests to cover the refactor

## Testing
- pytest tests/test_local_import_services.py tests/domain/test_local_import_result.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e1598ee88323b4ac01238a4b1a39