### PR TITLE
Ensure media post-processing reuses playback enqueue function

### DIFF
--- a/application/media_processing/logger.py
+++ b/application/media_processing/logger.py
@@ -129,3 +129,9 @@ class StructuredMediaTaskLogger:
                 exc_info=exc_info,
                 **details,
             )
+
+    @property
+    def base_logger(self) -> logging.Logger:
+        """内部で利用する生の :class:`logging.Logger` を公開する。"""
+
+        return self._logger

--- a/core/tasks/media_post_processing.py
+++ b/core/tasks/media_post_processing.py
@@ -83,10 +83,9 @@ def _build_post_processing_service(
 ) -> MediaPostProcessingService:
     retry_service = _build_retry_service(logger)
     thumbnail_service = _build_thumbnail_service(logger=logger, retry_service=retry_service)
-    playback_service = _build_playback_service(logger, thumbnail_service)
     return MediaPostProcessingService(
         thumbnail_service=thumbnail_service,
-        playback_service=playback_service,
+        playback_invoker=enqueue_media_playback,
         logger=logger,
     )
 


### PR DESCRIPTION
## Summary
- expose the underlying logger on StructuredMediaTaskLogger so callers can reuse it
- update MediaPostProcessingService to invoke a provided playback enqueue callable that can be mocked for MP4 handling
- wire MediaPostProcessingService through core/tasks/media_post_processing to pass the enqueue_media_playback helper

## Testing
- pytest tests/test_video_import.py::test_local_import_mp4_video tests/test_video_import.py::test_local_import_mov_video -q

------
https://chatgpt.com/codex/tasks/task_e_68e5e4f8846c8323b9985a56440f34ac