### PR TITLE
Add shared concurrency control for picker APIs

### DIFF
--- a/webapp/api/concurrency.py
+++ b/webapp/api/concurrency.py
@@ -1,0 +1,154 @@
+"""Concurrency control utilities for API endpoints.
+
+このモジュールはAPI毎に同時実行数を制御するための共通処理を提供する。
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from functools import wraps
+from threading import Lock
+from typing import Callable, Optional, TypeVar, Any, cast
+
+from flask import current_app, jsonify
+
+
+class ConcurrencyLimitExceeded(RuntimeError):
+    """Raised when the concurrency limiter cannot acquire a slot."""
+
+    def __init__(self, retry_after: float) -> None:
+        super().__init__("Concurrency limit exceeded")
+        self.retry_after = retry_after
+
+
+@dataclass(frozen=True)
+class ConcurrencyConfig:
+    """Configuration keys used by :class:`ConcurrencyLimiter`."""
+
+    limit_key: str
+    retry_key: Optional[str] = None
+    default_limit: int = 3
+    default_retry: float = 1.0
+
+
+class ConcurrencyLimiter(AbstractContextManager["ConcurrencyLimiter"]):
+    """Track active calls and enforce a configurable concurrency ceiling."""
+
+    def __init__(self, config: ConcurrencyConfig) -> None:
+        self._config = config
+        self._active = 0
+        self._guard = Lock()
+
+    # --- Internal helpers -------------------------------------------------
+    def _configured_limit(self) -> int:
+        raw_limit = current_app.config.get(
+            self._config.limit_key, self._config.default_limit
+        )
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            limit = self._config.default_limit
+        if limit <= 0:
+            limit = 1
+        return limit
+
+    def _configured_retry(self) -> float:
+        retry_key = self._config.retry_key
+        raw_retry = (
+            current_app.config.get(retry_key)
+            if retry_key
+            else self._config.default_retry
+        )
+        try:
+            retry = float(raw_retry)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            retry = self._config.default_retry
+        if retry < 0:
+            retry = 0.0
+        return retry
+
+    # --- Public API -------------------------------------------------------
+    def acquire(self) -> bool:
+        """Attempt to acquire a concurrency slot without blocking."""
+
+        with self._guard:
+            limit = self._configured_limit()
+            if self._active >= limit:
+                return False
+            self._active += 1
+            return True
+
+    def release(self) -> None:
+        """Release a previously acquired slot (if any)."""
+
+        with self._guard:
+            if self._active > 0:
+                self._active -= 1
+
+    # Context manager support ---------------------------------------------
+    def __enter__(self) -> "ConcurrencyLimiter":
+        if not self.acquire():
+            raise ConcurrencyLimitExceeded(self.retry_after_seconds())
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> Optional[bool]:  # pragma: no cover -
+        self.release()
+        return None
+
+    # Utility accessors ----------------------------------------------------
+    def retry_after_seconds(self) -> float:
+        return self._configured_retry()
+
+    def retry_after_header(self, retry_after: Optional[float] = None) -> Optional[str]:
+        value = self.retry_after_seconds() if retry_after is None else retry_after
+        try:
+            seconds = max(0, int(round(float(value))))
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+        return str(seconds)
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def limit_concurrency(limiter: ConcurrencyLimiter) -> Callable[[F], F]:
+    """Decorator that enforces concurrency for an API endpoint."""
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):  # type: ignore[misc]
+            try:
+                with limiter:
+                    return func(*args, **kwargs)
+            except ConcurrencyLimitExceeded as exc:
+                payload = {"error": "rate_limited", "retryAfter": exc.retry_after}
+                response = jsonify(payload)
+                header_value = limiter.retry_after_header(exc.retry_after)
+                if header_value is not None:
+                    response.headers["Retry-After"] = header_value
+                return response, 429
+
+        return cast(F, wrapper)
+
+    return decorator
+
+
+def create_limiter(
+    prefix: str,
+    *,
+    limit_suffix: str = "_MAX_CONCURRENCY",
+    retry_suffix: str = "_RETRY_AFTER_SECONDS",
+    default_limit: int = 3,
+    default_retry: float = 1.0,
+) -> ConcurrencyLimiter:
+    """Convenience factory that derives config keys from a prefix."""
+
+    config = ConcurrencyConfig(
+        limit_key=f"{prefix}{limit_suffix}",
+        retry_key=f"{prefix}{retry_suffix}" if retry_suffix else None,
+        default_limit=default_limit,
+        default_retry=default_retry,
+    )
+    return ConcurrencyLimiter(config)
+

--- a/webapp/api/picker_session_service.py
+++ b/webapp/api/picker_session_service.py
@@ -26,54 +26,26 @@ from core.models.photo_models import (
 from core.models.log import Log
 from ..auth.utils import refresh_google_token, RefreshTokenError, log_requests_and_send
 from core.tasks.local_import import build_thumbnail_task_snapshot
+from .concurrency import (
+    ConcurrencyLimitExceeded,
+    create_limiter,
+)
 
 
 _locks: Dict[str, Lock] = {}
 _locks_guard = Lock()
 
-_media_items_active = 0
-_media_items_active_guard = Lock()
-
-
-def _media_items_limit() -> int:
-    """Return configured maximum concurrent media item fetches."""
-
-    raw_limit = current_app.config.get("PICKER_MEDIA_ITEMS_MAX_CONCURRENCY", 3)
-    try:
-        limit = int(raw_limit)
-    except (TypeError, ValueError):
-        limit = 3
-    if limit <= 0:
-        limit = 1
-    return limit
-
-
-def _retry_delay_seconds() -> float:
-    raw_delay = current_app.config.get("PICKER_MEDIA_ITEMS_RETRY_DELAY_SECONDS", 1.0)
-    try:
-        delay = float(raw_delay)
-    except (TypeError, ValueError):
-        delay = 1.0
-    if delay < 0:
-        delay = 0.0
-    return delay
+_media_items_concurrency = create_limiter(
+    "PICKER_MEDIA_ITEMS", retry_suffix="_RETRY_DELAY_SECONDS"
+)
 
 
 def _acquire_media_items_slot() -> bool:
-    global _media_items_active
-    limit = _media_items_limit()
-    with _media_items_active_guard:
-        if _media_items_active >= limit:
-            return False
-        _media_items_active += 1
-        return True
+    return _media_items_concurrency.acquire()
 
 
 def _release_media_items_slot() -> None:
-    global _media_items_active
-    with _media_items_active_guard:
-        if _media_items_active > 0:
-            _media_items_active -= 1
+    _media_items_concurrency.release()
 
 
 def _coerce_selected_count(raw: object) -> Optional[int]:
@@ -844,22 +816,22 @@ class PickerSessionService:
     # --- Media Items ------------------------------------------------------
     @staticmethod
     def media_items(session_id: str, cursor: Optional[str] = None) -> Tuple[dict, int]:
-        if not _acquire_media_items_slot():
-            retry_after = _retry_delay_seconds()
+        try:
+            with _media_items_concurrency:
+                lock = _get_lock(session_id)
+                if not lock.acquire(blocking=False):
+                    return {"error": "busy"}, 409
+                try:
+                    return PickerSessionService._media_items_locked(session_id, cursor)
+                finally:
+                    lock.release()
+                    _release_lock(session_id, lock)
+        except ConcurrencyLimitExceeded as exc:
+            retry_after = exc.retry_after
             return {
                 "error": "rate_limited",
                 "retryAfter": retry_after,
             }, 429
-        lock = _get_lock(session_id)
-        if not lock.acquire(blocking=False):
-            _release_media_items_slot()
-            return {"error": "busy"}, 409
-        try:
-            return PickerSessionService._media_items_locked(session_id, cursor)
-        finally:
-            lock.release()
-            _release_lock(session_id, lock)
-            _release_media_items_slot()
 
     @staticmethod
     def _media_items_locked(session_id: str, cursor: Optional[str]) -> Tuple[dict, int]:


### PR DESCRIPTION
## Summary
- add reusable concurrency limiter utilities for API endpoints
- update picker session service and routes to enforce consistent rate limits and Retry-After handling
- cover the new list endpoint limiter with a regression test

## Testing
- pytest tests/test_picker_session_api.py::test_media_items_rate_limited tests/test_picker_session_api.py::test_picker_sessions_list_rate_limited -q

------
https://chatgpt.com/codex/tasks/task_e_68e5e5d3bdb88323a0765702d8bee42a