### PR TITLE
Show playback error reason when duplicate video regeneration fails

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -802,13 +802,16 @@ def _regenerate_duplicate_video_thumbnails(
                 status="playback_force_failed",
                 attempts=attempts,
             )
+            display_note = failure_error or failure_note
             failure_result: Dict[str, Any] = {
                 "ok": False,
-                "notes": failure_note,
+                "notes": display_note,
                 "generated": [],
                 "skipped": [],
                 "paths": {},
             }
+            if failure_error and failure_note:
+                failure_result["note"] = failure_note
             if failure_error:
                 failure_result["error"] = failure_error
             return _finalise(failure_result, attempts=attempts)

--- a/tests/test_video_import.py
+++ b/tests/test_video_import.py
@@ -502,7 +502,10 @@ def test_duplicate_video_force_regeneration_logs_error_detail(
     success, reason = local_import_module._regenerate_duplicate_video_thumbnails(media)
 
     assert not success
-    assert reason == "exception"
+    assert (
+        reason
+        == "transcode_worker() got an unexpected keyword argument 'force'"
+    )
     assert captured, "_log_warning が呼び出されていません"
 
     event, message, details = captured[0]


### PR DESCRIPTION
## Summary
- surface the playback error message when forced regeneration of duplicate videos fails
- retain the original note value alongside the error for logging and consumers
- update the duplicate video regression test to expect the surfaced error message

## Testing
- pytest tests/test_video_import.py::test_duplicate_video_force_regeneration_logs_error_detail

------
https://chatgpt.com/codex/tasks/task_e_68e611808cdc83239bd6b53ed7ccd9ac