### PR TITLE
Handle playback regen without update_paths and add mp4 coverage

### DIFF
--- a/application/media_processing/playback_service.py
+++ b/application/media_processing/playback_service.py
@@ -136,7 +136,12 @@ class MediaPlaybackService:
                     return error
 
             if force_regenerate:
-                playback.update_paths(None, None)
+                if hasattr(playback, "update_paths"):
+                    playback.update_paths(None, None)
+                else:
+                    playback.rel_path = None
+                    playback.poster_rel_path = None
+                    playback.updated_at = datetime.now(timezone.utc)
                 db.session.commit()
                 result = self._worker(media_playback_id=playback.id, force=True)
                 db.session.refresh(playback)

--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -153,6 +153,13 @@ class MediaPlayback(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
 
+    def update_paths(self, rel_path: str | None, poster_rel_path: str | None) -> None:
+        """再生用およびポスター用のパスを更新する."""
+
+        self.rel_path = rel_path
+        self.poster_rel_path = poster_rel_path
+        self.updated_at = datetime.now(timezone.utc)
+
 
 class MediaItem(db.Model):
     id = db.Column(db.String(255), primary_key=True)

--- a/tests/test_playback_service.py
+++ b/tests/test_playback_service.py
@@ -1,0 +1,76 @@
+import logging
+import shutil
+from datetime import datetime, timezone
+from typing import Dict, Any
+
+import pytest
+
+from application.media_processing.logger import StructuredMediaTaskLogger
+from application.media_processing.playback_service import MediaPlaybackService
+from core.models.photo_models import Media, MediaPlayback
+from webapp.extensions import db
+
+
+@pytest.mark.usefixtures("app_context")
+def test_force_regenerate_resets_mp4_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MP4 の再生アセットでも強制再生成時にパスが初期化される。"""
+
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ffmpeg")
+
+    media = Media(
+        source_type="local",
+        local_rel_path="2025/10/08/sample.mp4",
+        filename="sample.mp4",
+        mime_type="video/mp4",
+        is_video=True,
+        has_playback=True,
+    )
+    db.session.add(media)
+    db.session.commit()
+
+    playback = MediaPlayback(
+        media_id=media.id,
+        preset="std1080p",
+        rel_path="2025/10/08/sample.mp4",
+        poster_rel_path="2025/10/08/sample.jpg",
+        status="done",
+    )
+    db.session.add(playback)
+    db.session.commit()
+
+    observed: list[Dict[str, Any]] = []
+
+    def _fake_worker(*, media_playback_id: int, force: bool = False) -> Dict[str, Any]:
+        pb = MediaPlayback.query.get(media_playback_id)
+        observed.append(
+            {
+                "rel_path": pb.rel_path,
+                "poster_rel_path": pb.poster_rel_path,
+                "force": force,
+            }
+        )
+        pb.rel_path = "2025/10/08/sample_regen.mp4"
+        pb.poster_rel_path = "2025/10/08/sample_regen.jpg"
+        pb.status = "done"
+        pb.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return {"ok": True, "note": "regenerated"}
+
+    logger = StructuredMediaTaskLogger(logging.getLogger("test.playback"))
+    service = MediaPlaybackService(
+        worker=_fake_worker,
+        thumbnail_generator=None,
+        logger=logger,
+    )
+
+    result = service.prepare(media_id=media.id, force_regenerate=True, operation_id="test-op")
+
+    assert result["ok"] is True
+    assert observed
+    assert observed[0]["rel_path"] is None
+    assert observed[0]["poster_rel_path"] is None
+    assert observed[0]["force"] is True
+
+    refreshed = MediaPlayback.query.get(playback.id)
+    assert refreshed.rel_path == "2025/10/08/sample_regen.mp4"
+    assert refreshed.poster_rel_path == "2025/10/08/sample_regen.jpg"


### PR DESCRIPTION
## Summary
- add a defensive fallback in the playback service so force regenerations reset paths even without the new helper
- add a regression test covering MP4 force-regeneration to ensure paths are cleared before re-encoding

## Testing
- pytest tests/test_playback_service.py -q
- pytest tests/test_local_import_duplicate_refresh.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e61265c3f08323bc7428ad895172fb