### PR TITLE
Log playback asset paths when skipping regeneration

### DIFF
--- a/tests/test_media_post_processing.py
+++ b/tests/test_media_post_processing.py
@@ -130,6 +130,10 @@ def test_enqueue_media_playback_generates_thumbnails_for_completed_playback(app,
         assert result["ok"] is True
         assert result["note"] == "already_done"
         assert result["playback_status"] == "done"
+        expected_output = (play_dir / playback.rel_path).as_posix()
+        expected_poster = (play_dir / poster_rel).as_posix()
+        assert result["output_path"] == expected_output
+        assert result["poster_path"] == expected_poster
         assert "thumbnails" in result
         assert result["thumbnails"].get("ok") is True
 


### PR DESCRIPTION
## Summary
- resolve the playback storage base directory inside the media playback service
- include absolute playback and poster paths whenever regeneration is skipped or succeeds without new assets
- extend the media post processing test to assert that the resolved paths are returned

## Testing
- pytest tests/test_media_post_processing.py::test_enqueue_media_playback_generates_thumbnails_for_completed_playback

------
https://chatgpt.com/codex/tasks/task_e_68e625861d1883238b61f8cd5b7b0576