### PR TITLE
Persist media filters in URL hash for navigation

### DIFF
--- a/webapp/photo_view/templates/photo_view/albums.html
+++ b/webapp/photo_view/templates/photo_view/albums.html
@@ -3,6 +3,7 @@
 {% block title %}{{ _('Albums') }}{% endblock %}
 
 {% block extra_head %}
+<script src="{{ url_for('static', filename='js/filter-state.js') }}"></script>
 <script src="{{ url_for('static', filename='js/pagination.js') }}"></script>
 <style>
   .album-grid {
@@ -678,6 +679,47 @@ document.addEventListener('DOMContentLoaded', () => {
   const albumMediaEmpty = document.getElementById('album-media-empty');
   const albumMediaEnd = document.getElementById('album-media-end');
   const defaultMediaEmptyMessage = albumMediaEmpty ? albumMediaEmpty.textContent : '';
+  const filterStateApi = window.filterState || null;
+  const ALBUM_FILTER_SECTION = 'albums';
+  const ALBUM_SORT_VALUES = new Set(['desc', 'asc', 'custom']);
+  const DEFAULT_ALBUM_SORT = 'desc';
+
+  function applyAlbumFiltersFromState(state) {
+    if (!sortOrder || editorView) {
+      return;
+    }
+
+    const filters = state && typeof state === 'object' ? state : {};
+    const candidate = typeof filters.order === 'string' ? filters.order : '';
+    const normalized = ALBUM_SORT_VALUES.has(candidate) ? candidate : DEFAULT_ALBUM_SORT;
+    sortOrder.value = normalized;
+  }
+
+  function buildAlbumFilterSnapshot() {
+    if (!sortOrder || editorView) {
+      return null;
+    }
+
+    const value = sortOrder.value || DEFAULT_ALBUM_SORT;
+    if (!ALBUM_SORT_VALUES.has(value) || value === DEFAULT_ALBUM_SORT) {
+      return null;
+    }
+
+    return { order: value };
+  }
+
+  function syncAlbumFiltersToHash() {
+    if (!filterStateApi || typeof filterStateApi.writeSection !== 'function') {
+      return;
+    }
+
+    const snapshot = buildAlbumFilterSnapshot();
+    if (snapshot) {
+      filterStateApi.writeSection(ALBUM_FILTER_SECTION, snapshot);
+    } else {
+      filterStateApi.writeSection(ALBUM_FILTER_SECTION, null);
+    }
+  }
 
   const strings = {
     albumCreated: "{{ _('Album created successfully.')|escapejs }}",
@@ -2165,6 +2207,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (sortOrder && sortOrder.value !== 'custom') {
       sortOrder.value = 'custom';
+      syncAlbumFiltersToHash();
     }
 
     showReorderHint(strings.reorderLoading, 'warning');
@@ -2406,6 +2449,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (editorView) {
       return;
     }
+    syncAlbumFiltersToHash();
     if (reorderMode) {
       exitReorderMode();
     } else {
@@ -2420,11 +2464,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (sortOrder) {
-    sortOrder.addEventListener('change', reloadAlbums);
+    sortOrder.addEventListener('change', () => {
+      syncAlbumFiltersToHash();
+      reloadAlbums();
+    });
   }
 
   if (refreshBtn) {
-    refreshBtn.addEventListener('click', reloadAlbums);
+    refreshBtn.addEventListener('click', () => {
+      syncAlbumFiltersToHash();
+      reloadAlbums();
+    });
   }
 
   if (reorderToggleBtn) {
@@ -2575,6 +2625,22 @@ document.addEventListener('DOMContentLoaded', () => {
       openAlbumModal('create');
     }
   } else {
+    const initialAlbumFilters =
+      filterStateApi && typeof filterStateApi.readSection === 'function'
+        ? filterStateApi.readSection(ALBUM_FILTER_SECTION)
+        : null;
+
+    applyAlbumFiltersFromState(initialAlbumFilters);
+    syncAlbumFiltersToHash();
+
+    if (filterStateApi && typeof filterStateApi.subscribeToSection === 'function') {
+      filterStateApi.subscribeToSection(ALBUM_FILTER_SECTION, (state) => {
+        const nextState = state && typeof state === 'object' ? state : {};
+        applyAlbumFiltersFromState(nextState);
+        reloadAlbums();
+      });
+    }
+
     initializeAlbumsScroll();
   }
 });

--- a/webapp/photo_view/templates/photo_view/media_list.html
+++ b/webapp/photo_view/templates/photo_view/media_list.html
@@ -2,6 +2,7 @@
 {% block title %}Media List{% endblock %}
 
 {% block extra_head %}
+<script src="{{ url_for('static', filename='js/filter-state.js') }}"></script>
 <script src="{{ url_for('static', filename='js/pagination.js') }}"></script>
 <style>
   .controls-bar {
@@ -373,6 +374,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const tagFilterSuggestions = document.getElementById('tag-filter-suggestions');
   const selectedTagFiltersContainer = document.getElementById('selected-tag-filters');
   const tagFilterBox = document.getElementById('tag-filter-box');
+  const filterStateApi = window.filterState || null;
+  const FILTER_HASH_SECTION = 'mediaGallery';
+  const FILTER_DEFAULTS = { type: 'all', sort: 'desc' };
+  const VALID_TYPE_FILTERS = new Set(['all', 'photo', 'video']);
+  const VALID_SORT_ORDERS = new Set(['asc', 'desc']);
 
   let infiniteScroll;
   let totalLoaded = 0;
@@ -452,6 +458,94 @@ document.addEventListener('DOMContentLoaded', () => {
 
       selectedTagFiltersContainer.appendChild(chip);
     });
+  }
+
+  function sanitizeTagForState(tag) {
+    if (!tag) {
+      return null;
+    }
+    const tagId = Number(tag.id);
+    if (!Number.isInteger(tagId) || tagId <= 0) {
+      return null;
+    }
+    const rawName = typeof tag.name === 'string' ? tag.name.trim() : '';
+    const fallbackName = `Tag #${tagId}`;
+    const sanitized = {
+      id: tagId,
+      name: rawName.length > 0 ? rawName : fallbackName,
+    };
+    if (typeof tag.attr === 'string' && tag.attr.trim().length > 0) {
+      sanitized.attr = tag.attr.trim();
+    }
+    return sanitized;
+  }
+
+  function restoreFiltersFromState(state) {
+    const filters = state && typeof state === 'object' ? state : {};
+    if (typeof typeFilter !== 'undefined' && typeFilter) {
+      const candidate = typeof filters.type === 'string' ? filters.type : '';
+      typeFilter.value = VALID_TYPE_FILTERS.has(candidate) ? candidate : FILTER_DEFAULTS.type;
+    }
+    if (sortOrder) {
+      const candidate = typeof filters.sort === 'string' ? filters.sort : '';
+      sortOrder.value = VALID_SORT_ORDERS.has(candidate) ? candidate : FILTER_DEFAULTS.sort;
+    }
+
+    if (Array.isArray(filters.tags)) {
+      selectedTagFilters = filters.tags
+        .map((tag) => sanitizeTagForState(tag))
+        .filter(Boolean);
+    } else {
+      selectedTagFilters = [];
+    }
+
+    renderSelectedTagFilters();
+  }
+
+  function buildFilterStateSnapshot() {
+    const snapshot = {};
+
+    if (typeof typeFilter !== 'undefined' && typeFilter) {
+      const value = typeFilter.value || '';
+      if (VALID_TYPE_FILTERS.has(value) && value !== FILTER_DEFAULTS.type) {
+        snapshot.type = value;
+      }
+    }
+
+    if (sortOrder) {
+      const sortValue = sortOrder.value || '';
+      if (VALID_SORT_ORDERS.has(sortValue) && sortValue !== FILTER_DEFAULTS.sort) {
+        snapshot.sort = sortValue;
+      }
+    }
+
+    if (Array.isArray(selectedTagFilters) && selectedTagFilters.length > 0) {
+      snapshot.tags = selectedTagFilters.map((tag) => {
+        const entry = { id: tag.id };
+        if (typeof tag.name === 'string' && tag.name.length > 0) {
+          entry.name = tag.name;
+        }
+        if (typeof tag.attr === 'string' && tag.attr.length > 0) {
+          entry.attr = tag.attr;
+        }
+        return entry;
+      });
+    }
+
+    return snapshot;
+  }
+
+  function syncFiltersToHash() {
+    if (!filterStateApi || typeof filterStateApi.writeSection !== 'function') {
+      return;
+    }
+
+    const snapshot = buildFilterStateSnapshot();
+    if (Object.keys(snapshot).length === 0) {
+      filterStateApi.writeSection(FILTER_HASH_SECTION, null);
+    } else {
+      filterStateApi.writeSection(FILTER_HASH_SECTION, snapshot);
+    }
   }
 
   function hideTagSuggestions() {
@@ -606,7 +700,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return card;
   }
 
-  function restartMediaQuery() {
+  function restartMediaQuery(options = {}) {
+    if (!options.skipHashUpdate) {
+      syncFiltersToHash();
+    }
+
     if (infiniteScroll) {
       infiniteScroll.destroy();
     }
@@ -615,13 +713,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function initializeInfiniteScroll() {
     // Read the current filter settings
-    const typeFilter = document.getElementById('type-filter').value;
-    const sortOrder = document.getElementById('sort-order').value;
+    const typeValue =
+      typeof typeFilter !== 'undefined' && typeFilter && VALID_TYPE_FILTERS.has(typeFilter.value)
+        ? typeFilter.value
+        : FILTER_DEFAULTS.type;
+    const sortValue =
+      sortOrder && VALID_SORT_ORDERS.has(sortOrder.value)
+        ? sortOrder.value
+        : FILTER_DEFAULTS.sort;
 
     // Build the request parameters
-    const parameters = { order: sortOrder };
-    if (typeFilter !== 'all') {
-      parameters.type = typeFilter;
+    const parameters = { order: sortValue };
+    if (typeValue !== FILTER_DEFAULTS.type) {
+      parameters.type = typeValue;
     }
     if (selectedTagFilters.length > 0) {
       parameters.tags = selectedTagFilters.map((tag) => tag.id).join(',');
@@ -694,27 +798,34 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  sizeSlider.addEventListener('input', (event) => {
-    applyGridSize(event.target.value);
-  });
+  if (sizeSlider) {
+    sizeSlider.addEventListener('input', (event) => {
+      applyGridSize(event.target.value);
+    });
+    applyGridSize(sizeSlider.value);
+  }
 
-  applyGridSize(sizeSlider.value);
-  
   // Filter change
   const typeFilter = document.getElementById('type-filter');
-  typeFilter.addEventListener('change', () => {
-    restartMediaQuery();
-  });
+  if (typeFilter) {
+    typeFilter.addEventListener('change', () => {
+      restartMediaQuery();
+    });
+  }
 
   // Sort order change handler
-  sortOrder.addEventListener('change', () => {
-    restartMediaQuery();
-  });
+  if (sortOrder) {
+    sortOrder.addEventListener('change', () => {
+      restartMediaQuery();
+    });
+  }
 
   // Refresh button handler
-  refreshBtn.addEventListener('click', () => {
-    restartMediaQuery();
-  });
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => {
+      restartMediaQuery();
+    });
+  }
 
   if (tagFilterInput) {
     tagFilterInput.addEventListener('input', (event) => {
@@ -750,9 +861,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Initialise infinite scrolling
-  renderSelectedTagFilters();
+  const initialFilters =
+    filterStateApi && typeof filterStateApi.readSection === 'function'
+      ? filterStateApi.readSection(FILTER_HASH_SECTION)
+      : null;
+
+  restoreFiltersFromState(initialFilters);
+  syncFiltersToHash();
   initializeInfiniteScroll();
+
+  if (filterStateApi && typeof filterStateApi.subscribeToSection === 'function') {
+    filterStateApi.subscribeToSection(FILTER_HASH_SECTION, (state) => {
+      const nextState = state && typeof state === 'object' ? state : {};
+      restoreFiltersFromState(nextState);
+      restartMediaQuery({ skipHashUpdate: true });
+    });
+  }
 });
 </script>
 {% endblock %}

--- a/webapp/photo_view/templates/photo_view/session_detail.html
+++ b/webapp/photo_view/templates/photo_view/session_detail.html
@@ -2,6 +2,7 @@
 {% block title %}Session Details{% endblock %}
 
 {% block extra_head %}
+<script src="{{ url_for('static', filename='js/filter-state.js') }}"></script>
 <script src="{{ url_for('static', filename='js/pagination.js') }}"></script>
 {% endblock %}
 
@@ -182,6 +183,63 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectionFilterSearchInput = document.getElementById('selection-filter-search');
   const selectionFilterStatusSelect = document.getElementById('selection-filter-status');
   const selectionFilterResetButton = document.getElementById('selection-filter-reset');
+  const filterStateApi = window.filterState || null;
+  const SESSION_FILTER_SECTION = 'sessionDetail';
+
+  function applySessionFiltersFromState(state) {
+    const filters = state && typeof state === 'object' ? state : {};
+    const matchesSession = filters.sessionId === pickerSessionId;
+
+    if (selectionFilterSearchInput) {
+      const value = matchesSession && typeof filters.search === 'string' ? filters.search : '';
+      selectionFilterSearchInput.value = value;
+    }
+
+    if (selectionFilterStatusSelect) {
+      const statusValue = matchesSession && typeof filters.status === 'string' ? filters.status : '';
+      selectionFilterStatusSelect.value = statusValue;
+    }
+  }
+
+  function buildSessionFilterSnapshot() {
+    if (!pickerSessionId) {
+      return null;
+    }
+
+    const snapshot = { sessionId: pickerSessionId };
+    let hasFilter = false;
+
+    if (selectionFilterSearchInput) {
+      const searchValue = selectionFilterSearchInput.value.trim();
+      if (searchValue.length > 0) {
+        snapshot.search = searchValue;
+        hasFilter = true;
+      }
+    }
+
+    if (selectionFilterStatusSelect) {
+      const statusValue = selectionFilterStatusSelect.value;
+      if (statusValue) {
+        snapshot.status = statusValue;
+        hasFilter = true;
+      }
+    }
+
+    return hasFilter ? snapshot : null;
+  }
+
+  function syncSessionFiltersToHash() {
+    if (!filterStateApi || typeof filterStateApi.writeSection !== 'function') {
+      return;
+    }
+
+    const snapshot = buildSessionFilterSnapshot();
+    if (snapshot) {
+      filterStateApi.writeSection(SESSION_FILTER_SECTION, snapshot);
+    } else {
+      filterStateApi.writeSection(SESSION_FILTER_SECTION, null);
+    }
+  }
   const viewErrorDetailsLabel = '{{ _("View error details") }}';
   const logDownloadDefaultHtml = logDownloadButton ? logDownloadButton.innerHTML : '';
   const logDownloadPreparingLabel = '{{ _("Preparing download...") }}';
@@ -1136,12 +1194,14 @@ document.addEventListener('DOMContentLoaded', () => {
   if (selectionFilterForm) {
     selectionFilterForm.addEventListener('submit', (event) => {
       event.preventDefault();
+      syncSessionFiltersToHash();
       refreshSelections({ forceReset: true });
     });
   }
 
   if (selectionFilterStatusSelect) {
     selectionFilterStatusSelect.addEventListener('change', () => {
+      syncSessionFiltersToHash();
       refreshSelections({ forceReset: true });
     });
   }
@@ -1152,6 +1212,7 @@ document.addEventListener('DOMContentLoaded', () => {
         clearTimeout(selectionFilterSearchDebounce);
       }
       selectionFilterSearchDebounce = setTimeout(() => {
+        syncSessionFiltersToHash();
         refreshSelections({ forceReset: true });
       }, 300);
     });
@@ -1165,6 +1226,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (selectionFilterStatusSelect) {
         selectionFilterStatusSelect.value = '';
       }
+      syncSessionFiltersToHash();
       refreshSelections({ forceReset: true });
     });
   }
@@ -1266,6 +1328,22 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const initialSessionFilters =
+    filterStateApi && typeof filterStateApi.readSection === 'function'
+      ? filterStateApi.readSection(SESSION_FILTER_SECTION)
+      : null;
+
+  applySessionFiltersFromState(initialSessionFilters);
+  syncSessionFiltersToHash();
+
+  if (filterStateApi && typeof filterStateApi.subscribeToSection === 'function') {
+    filterStateApi.subscribeToSection(SESSION_FILTER_SECTION, (state) => {
+      const nextState = state && typeof state === 'object' ? state : {};
+      applySessionFiltersFromState(nextState);
+      refreshSelections({ forceReset: true });
+    });
+  }
 
   setInterval(refreshSelections, 3000);
   refreshSelections();

--- a/webapp/static/js/filter-state.js
+++ b/webapp/static/js/filter-state.js
@@ -1,0 +1,154 @@
+(function (global) {
+  const win = global || window;
+
+  function getLocationComponents() {
+    const { pathname, search, hash } = win.location;
+    const normalizedHash = typeof hash === 'string' && hash.startsWith('#') ? hash.slice(1) : hash || '';
+    return {
+      pathname: pathname || '',
+      search: search || '',
+      hash: normalizedHash,
+    };
+  }
+
+  function getParams() {
+    const { hash } = getLocationComponents();
+    return new URLSearchParams(hash);
+  }
+
+  function applyParams(params) {
+    const nextHash = params.toString();
+    const { pathname, search, hash } = getLocationComponents();
+    if (nextHash === hash) {
+      return;
+    }
+    const baseUrl = `${pathname}${search}`;
+    const nextUrl = nextHash ? `${baseUrl}#${nextHash}` : baseUrl;
+    try {
+      win.history.replaceState(null, '', nextUrl);
+    } catch (error) {
+      // Fallback for environments where replaceState is not available.
+      win.location.replace(nextUrl);
+    }
+  }
+
+  function shouldRemoveValue(value) {
+    if (value === null || value === undefined) {
+      return true;
+    }
+    if (typeof value === 'string') {
+      return value.length === 0;
+    }
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+    if (typeof value === 'object') {
+      return Object.keys(value).length === 0;
+    }
+    return false;
+  }
+
+  function readSection(key) {
+    if (!key) {
+      return null;
+    }
+    const params = getParams();
+    const raw = params.get(key);
+    if (raw === null) {
+      return null;
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      return raw;
+    }
+  }
+
+  function writeSection(key, value) {
+    if (!key) {
+      return;
+    }
+    const params = getParams();
+    if (shouldRemoveValue(value)) {
+      if (params.has(key)) {
+        params.delete(key);
+        applyParams(params);
+      }
+      return;
+    }
+
+    let serialized;
+    try {
+      serialized = JSON.stringify(value);
+    } catch (error) {
+      // If the value cannot be serialized, skip updating the hash.
+      return;
+    }
+
+    if (params.get(key) === serialized) {
+      return;
+    }
+
+    params.set(key, serialized);
+    applyParams(params);
+  }
+
+  function updateSection(key, updater) {
+    if (!key) {
+      return;
+    }
+    if (typeof updater !== 'function') {
+      writeSection(key, updater);
+      return;
+    }
+    const currentValue = readSection(key);
+    const nextValue = updater(currentValue);
+    writeSection(key, nextValue);
+  }
+
+  function clearSection(key) {
+    writeSection(key, null);
+  }
+
+  function subscribeToSection(key, callback, options = {}) {
+    if (!key || typeof callback !== 'function') {
+      return () => {};
+    }
+
+    const handler = () => {
+      callback(readSection(key));
+    };
+
+    win.addEventListener('hashchange', handler);
+
+    if (options.immediate) {
+      handler();
+    }
+
+    return () => {
+      win.removeEventListener('hashchange', handler);
+    };
+  }
+
+  function readAllSections() {
+    const params = getParams();
+    const result = {};
+    params.forEach((value, key) => {
+      try {
+        result[key] = JSON.parse(value);
+      } catch (error) {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+
+  win.filterState = {
+    readSection,
+    writeSection,
+    updateSection,
+    clearSection,
+    subscribeToSection,
+    readAllSections,
+  };
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- add a reusable filter-state helper to synchronize UI filters with the URL hash
- persist Media Gallery tag/type/sort selections via the hash and restore them on load
- mirror the hash-driven behaviour on the session detail and albums pages, updating event handlers accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62924b5bc83239c10e5f74783ef9b