### PR TITLE
Centralize environment configuration lookups

### DIFF
--- a/cli/src/celery/celery_app.py
+++ b/cli/src/celery/celery_app.py
@@ -1,5 +1,4 @@
 import json
-import os
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
@@ -13,6 +12,7 @@ from core.db import db
 from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
 from core.models.job_sync import JobSync
 from core.logging_config import log_task_info
+from core.settings import settings
 from webapp.config import Config
 
 # .envファイルを読み込み
@@ -38,8 +38,8 @@ def create_app():
 # Create Celery instance
 celery = Celery(
     'cli.src.celery.celery_app',
-    broker=os.environ.get("CELERY_BROKER_URL", os.environ.get("REDIS_URL", "redis://localhost:6379/0")),
-    backend=os.environ.get("CELERY_RESULT_BACKEND", os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
+    broker=settings.celery_broker_url,
+    backend=settings.celery_result_backend,
 )
 
 # Configure Celery

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -5,10 +5,7 @@ from typing import Optional, Tuple
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-
-_KEY_ENV = "OAUTH_TOKEN_KEY"
-_KEY_FILE_ENV = "OAUTH_TOKEN_KEY_FILE"
-_FPV_KEY_FILE_ENV = "FPV_OAUTH_TOKEN_KEY_FILE"
+from core.settings import ApplicationSettings, settings
 
 
 def _decode_key(raw: str) -> bytes:
@@ -41,17 +38,17 @@ def validate_oauth_key(raw: str) -> Tuple[bool, str]:
     except Exception as exc:  # pragma: no cover - defensive
         return False, str(exc)
 
-def _load_key(raw: Optional[str] = None) -> bytes:
+def _load_key(raw: Optional[str] = None, *, config: ApplicationSettings = settings) -> bytes:
     """Load 32-byte encryption key from a string, env var, or file."""
 
     if raw is not None:
         return _decode_key(raw)
 
-    key_str = os.environ.get(_KEY_ENV)
+    key_str = config.oauth_token_key
     if key_str:
         return _decode_key(key_str)
 
-    path = os.environ.get(_KEY_FILE_ENV) or os.environ.get(_FPV_KEY_FILE_ENV)
+    path = config.oauth_token_key_file
     if path:
         with open(path, "r") as f:
             return _decode_key(f.read().strip())

--- a/core/db_log_handler.py
+++ b/core/db_log_handler.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import sys
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set
@@ -11,6 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DataError, OperationalError
 
 from .db import db
+from .settings import settings
 
 if TYPE_CHECKING:  # pragma: no cover
     from flask import Flask
@@ -113,8 +113,7 @@ class DBLogHandler(logging.Handler):
 
     def _get_fallback_engine(self) -> Engine:
         if self._fallback_engine is None:
-            uri = os.environ.get("DATABASE_URI") or "sqlite:///application_logs.db"
-            self._fallback_engine = create_engine(uri, future=True)
+            self._fallback_engine = create_engine(settings.logs_database_uri, future=True)
         return self._fallback_engine
 
     def _maybe_use_fallback(self, engine: Engine) -> Engine:

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,0 +1,136 @@
+"""Centralised application settings abstraction.
+
+This module exposes :class:`ApplicationSettings` which consolidates all
+configuration lookups that previously relied on ad-hoc ``os.environ`` access
+throughout the codebase.  The class is intentionally lightweight and treats the
+process environment (or any mapping provided) as the backing store, returning
+value objects and sensible defaults where appropriate.
+
+The global :data:`settings` instance should be used for production code, while
+tests can instantiate their own :class:`ApplicationSettings` with a dedicated
+mapping to validate behaviour in isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Mapping, Optional
+
+@dataclass(frozen=True)
+class _EnvironmentFacade:
+    """Thin wrapper that provides ``Mapping`` compatible access to env vars."""
+
+    source: Mapping[str, str]
+
+    @classmethod
+    def from_environ(cls, env: Optional[Mapping[str, str]] = None) -> "_EnvironmentFacade":
+        return cls(source=os.environ if env is None else env)
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self.source.get(key, default)
+
+
+class ApplicationSettings:
+    """Domain level representation of configuration values.
+
+    The class favours explicit properties instead of generic ``get`` access so
+    that the rest of the application operates on intent-revealing names.  This
+    improves discoverability, documents available configuration knobs and keeps
+    default values in a single location.
+    """
+
+    def __init__(self, env: Optional[Mapping[str, str]] = None) -> None:
+        self._env = _EnvironmentFacade.from_environ(env)
+
+    # ------------------------------------------------------------------
+    # Generic helpers
+    # ------------------------------------------------------------------
+    def _get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self._env.get(key, default)
+
+    # ------------------------------------------------------------------
+    # Storage paths
+    # ------------------------------------------------------------------
+    @property
+    def tmp_directory(self) -> Path:
+        return Path(self._get("FPV_TMP_DIR", "/tmp/fpv_tmp"))
+
+    @property
+    def backup_directory(self) -> Path:
+        return Path(self._get("BACKUP_DIR", "/app/data/backups"))
+
+    @property
+    def nas_originals_directory(self) -> Path:
+        from core.storage_paths import first_existing_storage_path
+
+        base = first_existing_storage_path("FPV_NAS_ORIGINALS_DIR")
+        if base:
+            return Path(base)
+        return Path("/tmp/fpv_orig")
+
+    # ------------------------------------------------------------------
+    # Celery configuration
+    # ------------------------------------------------------------------
+    @property
+    def celery_broker_url(self) -> str:
+        return (
+            self._get("CELERY_BROKER_URL")
+            or self._get("REDIS_URL")
+            or "redis://localhost:6379/0"
+        )
+
+    @property
+    def celery_result_backend(self) -> str:
+        return (
+            self._get("CELERY_RESULT_BACKEND")
+            or self._get("REDIS_URL")
+            or "redis://localhost:6379/0"
+        )
+
+    # ------------------------------------------------------------------
+    # Database configuration
+    # ------------------------------------------------------------------
+    @property
+    def logs_database_uri(self) -> str:
+        return self._get("DATABASE_URI") or "sqlite:///application_logs.db"
+
+    # ------------------------------------------------------------------
+    # OAuth / Google configuration
+    # ------------------------------------------------------------------
+    @property
+    def google_client_id(self) -> str:
+        return self._get("GOOGLE_CLIENT_ID", "") or ""
+
+    @property
+    def google_client_secret(self) -> str:
+        return self._get("GOOGLE_CLIENT_SECRET", "") or ""
+
+    @property
+    def oauth_token_key(self) -> Optional[str]:
+        return self._get("OAUTH_TOKEN_KEY")
+
+    @property
+    def oauth_token_key_file(self) -> Optional[str]:
+        path = self._get("OAUTH_TOKEN_KEY_FILE")
+        if path:
+            return path
+        return self._get("FPV_OAUTH_TOKEN_KEY_FILE")
+
+    # ------------------------------------------------------------------
+    # Media processing configuration
+    # ------------------------------------------------------------------
+    @property
+    def transcode_crf(self) -> int:
+        raw = self._get("FPV_TRANSCODE_CRF")
+        try:
+            return int(raw) if raw is not None else 20
+        except (TypeError, ValueError):
+            return 20
+
+
+# Default settings instance used by the application.
+settings = ApplicationSettings()
+
+__all__ = ["ApplicationSettings", "settings"]

--- a/core/tasks/backup_cleanup.py
+++ b/core/tasks/backup_cleanup.py
@@ -1,14 +1,21 @@
 """バックアップファイルの自動クリーンアップタスク"""
 
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from core.logging_config import setup_task_logging, log_task_error, log_task_info
+from typing import Optional
+
+from core.logging_config import setup_task_logging
+from core.settings import ApplicationSettings, settings
 
 logger = setup_task_logging(__name__)
 
 
-def cleanup_old_backups(backup_dir: str = None, retention_days: int = 30) -> dict:
+def cleanup_old_backups(
+    backup_dir: Optional[str] = None,
+    retention_days: int = 30,
+    *,
+    config: ApplicationSettings = settings,
+) -> dict:
     """
     指定されたディレクトリ内の古いバックアップファイルを削除する
     
@@ -21,11 +28,7 @@ def cleanup_old_backups(backup_dir: str = None, retention_days: int = 30) -> dic
     """
     try:
         # バックアップディレクトリの決定
-        if backup_dir is None:
-            # 環境変数から取得、またはデフォルトパス
-            backup_dir = os.environ.get('BACKUP_DIR', '/app/data/backups')
-        
-        backup_path = Path(backup_dir)
+        backup_path = Path(backup_dir) if backup_dir is not None else config.backup_directory
         
         # ディレクトリが存在しない場合は作成
         if not backup_path.exists():
@@ -111,7 +114,11 @@ def cleanup_old_backups(backup_dir: str = None, retention_days: int = 30) -> dic
         }
 
 
-def get_backup_status(backup_dir: str = None) -> dict:
+def get_backup_status(
+    backup_dir: Optional[str] = None,
+    *,
+    config: ApplicationSettings = settings,
+) -> dict:
     """
     バックアップディレクトリの状況を取得する
     
@@ -122,10 +129,7 @@ def get_backup_status(backup_dir: str = None) -> dict:
         dict: バックアップ状況の詳細
     """
     try:
-        if backup_dir is None:
-            backup_dir = os.environ.get('BACKUP_DIR', '/app/data/backups')
-        
-        backup_path = Path(backup_dir)
+        backup_path = Path(backup_dir) if backup_dir is not None else config.backup_directory
         
         if not backup_path.exists():
             return {

--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 import logging
-import os
 import math
 from pathlib import Path
 import shutil
@@ -31,6 +30,7 @@ from core.db import db
 from core.models.photo_models import Media, MediaPlayback
 from core.storage_paths import ensure_directory, first_existing_storage_path
 from core.logging_config import setup_task_logging
+from core.settings import ApplicationSettings, settings
 from .thumbs_generate import thumbs_generate
 
 # transcode専用ロガーを取得（両方のログハンドラーが設定済み）
@@ -55,8 +55,8 @@ def _play_dir() -> Path:
     return ensure_directory(base)
 
 
-def _tmp_dir() -> Path:
-    tmp = Path(os.environ.get("FPV_TMP_DIR", "/tmp/fpv_tmp"))
+def _tmp_dir(*, config: ApplicationSettings = settings) -> Path:
+    tmp = config.tmp_directory
     tmp.mkdir(parents=True, exist_ok=True)
     return tmp
 
@@ -619,7 +619,7 @@ def transcode_worker(*, media_playback_id: int, force: bool = False) -> Dict[str
             passthrough = False
 
     if not passthrough:
-        crf = int(os.environ.get("FPV_TRANSCODE_CRF", "20"))
+        crf = settings.transcode_crf
         video_filter = (
             "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease,"
             "pad='ceil(iw/2)*2':'ceil(ih/2)*2'"

--- a/tests/test_application_settings.py
+++ b/tests/test_application_settings.py
@@ -1,0 +1,54 @@
+"""ApplicationSettings のユニットテスト"""
+
+from pathlib import Path
+
+from core.settings import ApplicationSettings
+
+
+def test_defaults_are_applied_when_env_missing():
+    settings = ApplicationSettings(env={})
+
+    assert settings.celery_broker_url == "redis://localhost:6379/0"
+    assert settings.celery_result_backend == "redis://localhost:6379/0"
+    assert settings.backup_directory == Path("/app/data/backups")
+    assert settings.tmp_directory == Path("/tmp/fpv_tmp")
+    assert settings.logs_database_uri == "sqlite:///application_logs.db"
+    assert settings.google_client_id == ""
+    assert settings.google_client_secret == ""
+    assert settings.oauth_token_key is None
+    assert settings.oauth_token_key_file is None
+    assert settings.transcode_crf == 20
+
+
+def test_environment_overrides_are_reflected():
+    env = {
+        "CELERY_BROKER_URL": "redis://broker/1",
+        "CELERY_RESULT_BACKEND": "redis://backend/2",
+        "BACKUP_DIR": "/data/backups",
+        "FPV_TMP_DIR": "/var/tmp/fpv",
+        "DATABASE_URI": "sqlite:///logs.db",
+        "GOOGLE_CLIENT_ID": "client",
+        "GOOGLE_CLIENT_SECRET": "secret",
+        "OAUTH_TOKEN_KEY": "base64:QUJDREVGR0hJSktMTU5PUA==",
+        "FPV_TRANSCODE_CRF": "24",
+        "FPV_OAUTH_TOKEN_KEY_FILE": "/secrets/token.key",
+    }
+
+    settings = ApplicationSettings(env=env)
+
+    assert settings.celery_broker_url == "redis://broker/1"
+    assert settings.celery_result_backend == "redis://backend/2"
+    assert settings.backup_directory == Path("/data/backups")
+    assert settings.tmp_directory == Path("/var/tmp/fpv")
+    assert settings.logs_database_uri == "sqlite:///logs.db"
+    assert settings.google_client_id == "client"
+    assert settings.google_client_secret == "secret"
+    assert settings.oauth_token_key == "base64:QUJDREVGR0hJSktMTU5PUA=="
+    assert settings.oauth_token_key_file == "/secrets/token.key"
+    assert settings.transcode_crf == 24
+
+
+def test_transcode_crf_invalid_value_falls_back_to_default():
+    settings = ApplicationSettings(env={"FPV_TRANSCODE_CRF": "invalid"})
+
+    assert settings.transcode_crf == 20


### PR DESCRIPTION
## Summary
- introduce `ApplicationSettings` to encapsulate environment configuration defaults and lookup logic
- refactor Celery bootstrap, crypto, logging, and task modules to consume the shared settings abstraction
- add dedicated unit tests exercising the new settings behaviour and ensure existing task flows use the centralized configuration

## Testing
- pytest tests/test_application_settings.py tests/test_backup_cleanup_tasks.py tests/test_transcode.py tests/test_picker_import_item.py

------
https://chatgpt.com/codex/tasks/task_e_68e674aa35c8832385af190281ce699d