### PR TITLE
Refactor auth domain registration flow

### DIFF
--- a/application/auth_service.py
+++ b/application/auth_service.py
@@ -1,5 +1,11 @@
 from typing import List, Optional, TYPE_CHECKING
-from domain.user.entities import User
+
+from domain.user import (
+    EmailAlreadyRegisteredError,
+    RegistrationIntent,
+    User,
+    UserRegistrationService,
+)
 from domain.user.repository import UserRepository
 
 
@@ -8,50 +14,59 @@ if TYPE_CHECKING:
 
 
 class AuthService:
-    def __init__(self, repo: UserRepository):
+    def __init__(
+        self,
+        repo: UserRepository,
+        registrar: UserRegistrationService | None = None,
+    ) -> None:
         self.repo = repo
+        self.registrar = registrar or UserRegistrationService(repo)
 
-    def _prepare_new_account(self, email: str) -> None:
-        existing_user = self.repo.get_by_email(email)
-        if existing_user and existing_user.is_active:
-            raise ValueError("Email already exists")
-
-        if existing_user and not existing_user.is_active:
-            self.repo.delete(existing_user)
+    def _resolve_domain_model(self, user: User | None) -> Optional["UserModel"]:
+        if user is None:
+            return None
+        model = getattr(user, "_model", None)
+        if model is None:
+            model = self.repo.get_model(user)
+            if model is None:
+                return None
+            user.attach_model(model)
+        return model
 
     def authenticate(self, email: str, password: str) -> Optional["UserModel"]:
         user = self.repo.get_by_email(email)
-        if user and user.check_password(password) and user.is_active:
-            # 認証時に取得したORMモデルを再利用できるよう返却する
-            model = getattr(user, "_model", None)
-            if model is None:
-                model = self.repo.get_model(user)
-                if model is None:
-                    return None
-                user.attach_model(model)
-            return model
-        return None
+        if not user or not user.is_active or not user.check_password(password):
+            return None
+
+        return self._resolve_domain_model(user)
 
     def register(self, email: str, password: str, totp_secret: str | None = None, roles: List[str] | None = None) -> User:
-        self._prepare_new_account(email)
-
-        # TOTP設定がある場合はアクティブ、ない場合も従来通りアクティブ
-        is_active = True
-        user = User(email=email, totp_secret=totp_secret, is_active=is_active)
-        user.set_password(password)
-        return self.repo.add(user, roles or [])
+        intent = RegistrationIntent.create(
+            email=email,
+            raw_password=password,
+            roles=roles or (),
+            totp_secret=totp_secret,
+            is_active=True,
+        )
+        try:
+            return self.registrar.register(intent)
+        except EmailAlreadyRegisteredError as exc:
+            raise ValueError(str(exc)) from exc
 
     def register_with_pending_totp(self, email: str, password: str, roles: List[str] | None = None) -> User:
         """TOTP設定待ちのユーザーを登録（非アクティブ状態）"""
-        self._prepare_new_account(email)
-
-        # 非アクティブ状態で登録
-        user = User(email=email, totp_secret=None, is_active=False)
-        user.set_password(password)
-        return self.repo.add(user, roles or [])
+        intent = RegistrationIntent.create(
+            email=email,
+            raw_password=password,
+            roles=roles or (),
+            totp_secret=None,
+            is_active=False,
+        )
+        try:
+            return self.registrar.register(intent)
+        except EmailAlreadyRegisteredError as exc:
+            raise ValueError(str(exc)) from exc
 
     def activate_user_with_totp(self, user: User, totp_secret: str) -> User:
         """ユーザーを TOTP 設定と共にアクティブ化"""
-        user.totp_secret = totp_secret
-        user.is_active = True
-        return self.repo.update(user)
+        return self.registrar.activate_with_totp(user, totp_secret)

--- a/domain/user/__init__.py
+++ b/domain/user/__init__.py
@@ -1,0 +1,13 @@
+"""ユーザードメインの公開インターフェース。"""
+
+from .entities import User
+from .exceptions import EmailAlreadyRegisteredError
+from .services import UserRegistrationService
+from .value_objects import RegistrationIntent
+
+__all__ = [
+    "EmailAlreadyRegisteredError",
+    "RegistrationIntent",
+    "User",
+    "UserRegistrationService",
+]

--- a/domain/user/entities.py
+++ b/domain/user/entities.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional, Any
-from werkzeug.security import generate_password_hash, check_password_hash
+
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 @dataclass
@@ -19,6 +20,17 @@ class User:
 
     def check_password(self, raw: str) -> bool:
         return check_password_hash(self.password_hash, raw)
+
+    def activate(self, *, totp_secret: str | None = None) -> None:
+        """ユーザーを有効化し、必要であれば TOTP を設定する。"""
+        if totp_secret is not None:
+            self.totp_secret = totp_secret
+        self.is_active = True
+
+    def deactivate(self) -> None:
+        """ユーザーを非アクティブにし、TOTP 秘密鍵を破棄する。"""
+        self.is_active = False
+        self.totp_secret = None
 
     def attach_model(self, model: Any | None) -> None:
         """内部的に関連付けるORMモデルを設定する。"""

--- a/domain/user/exceptions.py
+++ b/domain/user/exceptions.py
@@ -1,0 +1,9 @@
+"""ユーザードメインに関する例外定義。"""
+
+
+class EmailAlreadyRegisteredError(Exception):
+    """既に有効なユーザーが存在する場合に発生する例外。"""
+
+    def __init__(self, email: str):
+        super().__init__("Email already exists")
+        self.email = email

--- a/domain/user/services.py
+++ b/domain/user/services.py
@@ -1,0 +1,40 @@
+"""ユーザー登録に関するドメインサービス。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .entities import User
+from .exceptions import EmailAlreadyRegisteredError
+from .repository import UserRepository
+from .value_objects import RegistrationIntent
+
+
+@dataclass
+class UserRegistrationService:
+    """ユーザーの登録ポリシーを担うドメインサービス。"""
+
+    repository: UserRepository
+
+    def register(self, intent: RegistrationIntent) -> User:
+        existing_user = self.repository.get_by_email(intent.email)
+        if existing_user is not None:
+            if existing_user.is_active:
+                raise EmailAlreadyRegisteredError(intent.email)
+            self.repository.delete(existing_user)
+
+        user = self._build_user(intent)
+        return self.repository.add(user, list(intent.roles))
+
+    def activate_with_totp(self, user: User, totp_secret: str) -> User:
+        user.activate(totp_secret=totp_secret)
+        return self.repository.update(user)
+
+    def _build_user(self, intent: RegistrationIntent) -> User:
+        user = User(
+            email=intent.email,
+            totp_secret=intent.totp_secret if intent.is_active else None,
+            is_active=intent.is_active,
+        )
+        user.set_password(intent.raw_password)
+        return user

--- a/domain/user/value_objects.py
+++ b/domain/user/value_objects.py
@@ -1,0 +1,39 @@
+"""ユーザードメインで利用する値オブジェクト。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class RegistrationIntent:
+    """ユーザー登録のリクエスト内容を表す値オブジェクト。"""
+
+    email: str
+    raw_password: str
+    roles: Tuple[str, ...] = ()
+    totp_secret: str | None = None
+    is_active: bool = True
+
+    def __post_init__(self) -> None:
+        normalized_roles = tuple(self.roles)
+        object.__setattr__(self, "roles", normalized_roles)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        email: str,
+        raw_password: str,
+        roles: Iterable[str] | None = None,
+        totp_secret: str | None = None,
+        is_active: bool = True,
+    ) -> "RegistrationIntent":
+        return cls(
+            email=email,
+            raw_password=raw_password,
+            roles=tuple(roles or ()),
+            totp_secret=totp_secret,
+            is_active=is_active,
+        )

--- a/tests/domain/test_user_registration_service.py
+++ b/tests/domain/test_user_registration_service.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import create_autospec
+
+from domain.user import (
+    EmailAlreadyRegisteredError,
+    RegistrationIntent,
+    User,
+    UserRegistrationService,
+)
+from domain.user.repository import UserRepository
+
+
+def _build_service(repo=None) -> UserRegistrationService:
+    repository = repo or create_autospec(UserRepository, instance=True)
+    return UserRegistrationService(repository)
+
+
+def test_register_new_user_sets_password_and_roles():
+    repo = create_autospec(UserRepository, instance=True)
+    repo.get_by_email.return_value = None
+    repo.add.side_effect = lambda user, roles: user
+
+    service = _build_service(repo)
+    intent = RegistrationIntent.create(
+        email="new@example.com",
+        raw_password="secret",
+        roles=["guest", "editor"],
+        totp_secret="TOTP",
+        is_active=True,
+    )
+
+    user = service.register(intent)
+
+    assert user.email == "new@example.com"
+    assert user.is_active is True
+    assert user.totp_secret == "TOTP"
+    assert user.check_password("secret")
+    repo.add.assert_called_once()
+    _, roles = repo.add.call_args[0]
+    assert roles == ["guest", "editor"]
+
+
+def test_register_raises_when_active_user_exists():
+    existing_user = User(email="dup@example.com", is_active=True)
+    existing_user.password_hash = "existing"
+
+    repo = create_autospec(UserRepository, instance=True)
+    repo.get_by_email.return_value = existing_user
+
+    service = _build_service(repo)
+    intent = RegistrationIntent.create(
+        email="dup@example.com",
+        raw_password="secret",
+    )
+
+    with pytest.raises(EmailAlreadyRegisteredError):
+        service.register(intent)
+    repo.delete.assert_not_called()
+    repo.add.assert_not_called()
+
+
+def test_register_replaces_inactive_user():
+    existing_user = User(email="inactive@example.com", is_active=False)
+    existing_user.password_hash = "existing"
+
+    repo = create_autospec(UserRepository, instance=True)
+    repo.get_by_email.return_value = existing_user
+    repo.add.side_effect = lambda user, roles: user
+
+    service = _build_service(repo)
+    intent = RegistrationIntent.create(
+        email="inactive@example.com",
+        raw_password="new-secret",
+        roles=["guest"],
+    )
+
+    user = service.register(intent)
+
+    repo.delete.assert_called_once_with(existing_user)
+    assert user.email == "inactive@example.com"
+    assert user.is_active is True
+    assert user.check_password("new-secret")
+
+
+def test_activate_with_totp_updates_user():
+    user = User(email="pending@example.com", is_active=False)
+    user.password_hash = "hashed"
+
+    repo = create_autospec(UserRepository, instance=True)
+    repo.update.side_effect = lambda updated_user: updated_user
+
+    service = _build_service(repo)
+
+    updated_user = service.activate_with_totp(user, "NEWTOTP")
+
+    assert updated_user.is_active is True
+    assert updated_user.totp_secret == "NEWTOTP"
+    repo.update.assert_called_once_with(user)

--- a/tests/test_auth_service_repository_integration.py
+++ b/tests/test_auth_service_repository_integration.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from application.auth_service import AuthService
+from domain.user import UserRegistrationService
 from core.db import db
 from core.models.user import Role, User as UserModel
 from infrastructure.user_repository import SqlAlchemyUserRepository
@@ -24,7 +25,8 @@ def session():
 @pytest.fixture
 def auth_service(session):
     repo = SqlAlchemyUserRepository(session)
-    return AuthService(repo)
+    registrar = UserRegistrationService(repo)
+    return AuthService(repo, registrar)
 
 
 def _create_role(session, name: str = "guest") -> Role:

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -51,6 +51,7 @@ from ..auth.routes import _sync_active_role
 from .pagination import PaginationParams, paginate_and_respond
 from flask_login import current_user
 from application.auth_service import AuthService
+from domain.user import UserRegistrationService
 from infrastructure.user_repository import SqlAlchemyUserRepository
 from ..services.token_service import TokenService
 from ..auth.totp import verify_totp
@@ -72,7 +73,8 @@ from core.tasks.media_post_processing import enqueue_thumbs_generate
 
 
 user_repo = SqlAlchemyUserRepository(db.session)
-auth_service = AuthService(user_repo)
+user_registration_service = UserRegistrationService(user_repo)
+auth_service = AuthService(user_repo, user_registration_service)
 
 
 VALID_TAG_ATTRS = {"person", "place", "thing"}

--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -22,13 +22,15 @@ from .totp import new_totp_secret, verify_totp, provisioning_uri, qr_code_data_u
 from core.models.picker_session import PickerSession
 from .utils import refresh_google_token, log_requests_and_send, RefreshTokenError
 from application.auth_service import AuthService
+from domain.user import UserRegistrationService
 from infrastructure.user_repository import SqlAlchemyUserRepository
 from ..timezone import resolve_timezone, convert_to_timezone
 from ..services.token_service import TokenService
 
 
 user_repo = SqlAlchemyUserRepository(db.session)
-auth_service = AuthService(user_repo)
+user_registration_service = UserRegistrationService(user_repo)
+auth_service = AuthService(user_repo, user_registration_service)
 
 
 PROFILE_TIMEZONES = [


### PR DESCRIPTION
## Summary
- extract a dedicated user registration domain service and supporting value object
- simplify AuthService by delegating business rules to the domain layer and sharing ORM model resolution
- expand unit tests to cover domain registration behaviour while updating integration coverage

## Testing
- pytest tests/domain/test_user_registration_service.py tests/test_auth_service_repository_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e67d4fced48323955a6fd636e7fce7