### PR TITLE
Fix ffmpeg scaling filter to guarantee even output dimensions

### DIFF
--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -621,8 +621,8 @@ def transcode_worker(*, media_playback_id: int, force: bool = False) -> Dict[str
     if not passthrough:
         crf = settings.transcode_crf
         video_filter = (
-            "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease,"
-            "pad='ceil(iw/2)*2':'ceil(ih/2)*2'"
+            "scale=min(1920,iw):min(1080,ih):force_original_aspect_ratio=decrease,"
+            "pad=ceil(iw/2)*2:ceil(ih/2)*2"
         )
 
         cmd = [


### PR DESCRIPTION
## Summary
- update the transcode worker ffmpeg filter to avoid literal quote characters when invoking ffmpeg
- ensure padding filter consistently rounds dimensions up to even numbers so playback generation succeeds

## Testing
- pytest tests/test_transcode.py::test_worker_returns_error_summary_on_ffmpeg_failure -q

------
https://chatgpt.com/codex/tasks/task_e_68e684327774832384bc94d0edfe4cc5