### PR TITLE
Limit rel_path recovery to completed playbacks

### DIFF
--- a/application/media_processing/playback_service.py
+++ b/application/media_processing/playback_service.py
@@ -164,18 +164,17 @@ class MediaPlaybackService:
                 if error is not None:
                     return error
             else:
-                needs_rel_path_recovery = playback.rel_path is None
-                if needs_rel_path_recovery and not force_regenerate:
-                    self._logger.warning(
-                        event="video_transcoding.playback_rel_path_missing",
-                        message="Playback rel_path missing; forcing regeneration.",
-                        operation_id=op_id,
-                        media_id=media_id,
-                        request_context=request_context,
-                        playback_id=playback.id,
-                    )
-                else:
-                    needs_rel_path_recovery = False
+                if playback.rel_path is None and playback.status == "done":
+                    needs_rel_path_recovery = True
+                    if not force_regenerate:
+                        self._logger.warning(
+                            event="video_transcoding.playback_rel_path_missing",
+                            message="Playback rel_path missing; forcing regeneration.",
+                            operation_id=op_id,
+                            media_id=media_id,
+                            request_context=request_context,
+                            playback_id=playback.id,
+                        )
 
             if force_regenerate or needs_rel_path_recovery:
                 now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- restrict the rel_path recovery logic to completed playbacks so in-progress jobs are not restarted
- add regression coverage to ensure processing playbacks without rel_path return already_processing without invoking the worker

## Testing
- pytest tests/test_playback_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e6977b19ac8323be1d8c9a8e19bb5b