### PR TITLE
Fix default upload directories to use /app/data

### DIFF
--- a/webapp/config.py
+++ b/webapp/config.py
@@ -71,8 +71,8 @@ class Config:
     FPV_URL_TTL_THUMB = int(os.environ.get("FPV_URL_TTL_THUMB", "600"))
     FPV_URL_TTL_PLAYBACK = int(os.environ.get("FPV_URL_TTL_PLAYBACK", "600"))
     FPV_URL_TTL_ORIGINAL = int(os.environ.get("FPV_URL_TTL_ORIGINAL", "600"))
-    UPLOAD_TMP_DIR = os.environ.get("UPLOAD_TMP_DIR", "/data/tmp/upload")
-    UPLOAD_DESTINATION_DIR = os.environ.get("UPLOAD_DESTINATION_DIR", "/data/uploads")
+    UPLOAD_TMP_DIR = os.environ.get("UPLOAD_TMP_DIR", "/app/data/tmp/upload")
+    UPLOAD_DESTINATION_DIR = os.environ.get("UPLOAD_DESTINATION_DIR", "/app/data/uploads")
     UPLOAD_MAX_SIZE = int(os.environ.get("UPLOAD_MAX_SIZE", str(100 * 1024 * 1024)))
     FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_CONTAINER_DIR") or os.environ.get(
         "FPV_NAS_THUMBS_DIR", ""

--- a/webapp/services/upload_service.py
+++ b/webapp/services/upload_service.py
@@ -69,11 +69,11 @@ def _ensure_directory(path: Path) -> None:
 
 
 def _tmp_base_dir() -> Path:
-    return Path(current_app.config.get("UPLOAD_TMP_DIR", "/data/tmp/upload"))
+    return Path(current_app.config.get("UPLOAD_TMP_DIR", "/app/data/tmp/upload"))
 
 
 def _destination_base_dir() -> Path:
-    return Path(current_app.config.get("UPLOAD_DESTINATION_DIR", "/data/uploads"))
+    return Path(current_app.config.get("UPLOAD_DESTINATION_DIR", "/app/data/uploads"))
 
 
 def _max_upload_size() -> int:


### PR DESCRIPTION
## Summary
- align the default upload temp and destination directories with the /app/data mount point to avoid permission issues when environment variables are unset

## Testing
- pytest tests/test_upload_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ebb32ec23883238a87e63388ecde67