### PR TITLE
Fix FFmpeg filter quoting for duplicate video regeneration

### DIFF
--- a/core/tasks/transcode.py
+++ b/core/tasks/transcode.py
@@ -621,8 +621,8 @@ def transcode_worker(*, media_playback_id: int, force: bool = False) -> Dict[str
     if not passthrough:
         crf = settings.transcode_crf
         video_filter = (
-            "scale=min(1920,iw):min(1080,ih):force_original_aspect_ratio=decrease,"
-            "pad=ceil(iw/2)*2:ceil(ih/2)*2"
+            "scale='min(1920,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease,"
+            "pad='ceil(iw/2)*2':'ceil(ih/2)*2'"
         )
 
         cmd = [


### PR DESCRIPTION
## Summary
- update the playback transcode filter to quote scale and pad expressions
- prevent ffmpeg from erroring on duplicate video asset regeneration due to unescaped expressions

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'wiki.test_wiki_services')*

------
https://chatgpt.com/codex/tasks/task_e_68ebb17058208323aebf0f384dd1bdf8