### PR TITLE
Move committed uploads into Import subdirectory

### DIFF
--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -14,10 +14,12 @@ def client(app_context, tmp_path):
     app = app_context
     app.config['UPLOAD_TMP_DIR'] = str(tmp_path / 'tmp')
     app.config['UPLOAD_DESTINATION_DIR'] = str(tmp_path / 'dest')
+    app.config['UPLOAD_IMPORT_SUBDIR'] = 'Import'
     app.config['UPLOAD_MAX_SIZE'] = 1024 * 1024
 
     (tmp_path / 'tmp').mkdir(parents=True, exist_ok=True)
     (tmp_path / 'dest').mkdir(parents=True, exist_ok=True)
+    (tmp_path / 'dest' / 'Import').mkdir(parents=True, exist_ok=True)
 
     with app.app_context():
         user = User(email='upload@example.com')
@@ -154,6 +156,8 @@ def test_commit_upload_moves_files(client, auth_headers):
     with app.app_context():
         user = User.query.filter_by(email='upload@example.com').first()
         dest_dir = Path(app.config['UPLOAD_DESTINATION_DIR']) / str(user.id)
+        for part in upload_service._destination_import_subdir_parts():
+            dest_dir = dest_dir / part
         stored_file = dest_dir / 'commit.png'
         assert stored_file.exists()
         assert stored_file.read_bytes() == file_content
@@ -269,6 +273,8 @@ def test_commit_upload_uses_actual_move_destination(client, auth_headers, monkey
     with app.app_context():
         user = User.query.filter_by(email='upload@example.com').first()
         dest_dir = Path(app.config['UPLOAD_DESTINATION_DIR']) / str(user.id)
+        for part in upload_service._destination_import_subdir_parts():
+            dest_dir = dest_dir / part
         stored_file = dest_dir / 'movie_stored.mov'
         assert stored_file.exists()
         assert stored_file.read_bytes() == file_content

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -73,6 +73,7 @@ class Config:
     FPV_URL_TTL_ORIGINAL = int(os.environ.get("FPV_URL_TTL_ORIGINAL", "600"))
     UPLOAD_TMP_DIR = os.environ.get("UPLOAD_TMP_DIR", "/app/data/tmp/upload")
     UPLOAD_DESTINATION_DIR = os.environ.get("UPLOAD_DESTINATION_DIR", "/app/data/uploads")
+    UPLOAD_IMPORT_SUBDIR = os.environ.get("UPLOAD_IMPORT_SUBDIR", "Import")
     UPLOAD_MAX_SIZE = int(os.environ.get("UPLOAD_MAX_SIZE", str(100 * 1024 * 1024)))
     FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_CONTAINER_DIR") or os.environ.get(
         "FPV_NAS_THUMBS_DIR", ""

--- a/webapp/services/upload_service.py
+++ b/webapp/services/upload_service.py
@@ -76,6 +76,30 @@ def _destination_base_dir() -> Path:
     return Path(current_app.config.get("UPLOAD_DESTINATION_DIR", "/app/data/uploads"))
 
 
+def _destination_import_subdir_parts() -> tuple[str, ...]:
+    """Return sanitized path parts for the import subdirectory configuration."""
+
+    raw_value = current_app.config.get("UPLOAD_IMPORT_SUBDIR", "Import")
+    if raw_value is None:
+        return ()
+
+    # Normalize the configured value into safe relative path parts.
+    text = str(raw_value).strip()
+    if not text:
+        return ()
+
+    parts: list[str] = []
+    for part in Path(text).parts:
+        if part in {"", ".", "/"}:
+            continue
+        if part == "..":
+            # Prevent directory traversal outside of the destination base.
+            continue
+        parts.append(part)
+
+    return tuple(parts)
+
+
 def _max_upload_size() -> int:
     return int(current_app.config.get("UPLOAD_MAX_SIZE", 100 * 1024 * 1024))
 
@@ -255,6 +279,9 @@ def commit_uploads(session_id: str, user_id: Optional[int], temp_file_ids: Itera
 
     session_dir = _determine_session_dir(session_id)
     destination_dir = _destination_base_dir() / str(user_id)
+    import_subdir_parts = _destination_import_subdir_parts()
+    if import_subdir_parts:
+        destination_dir = destination_dir.joinpath(*import_subdir_parts)
     _ensure_directory(destination_dir)
     try:
         destination_dir_resolved = destination_dir.resolve()


### PR DESCRIPTION
## Summary
- add configuration for the upload Import subdirectory
- update commit handling to place files inside the Import folder per user
- adjust upload API tests for the new storage location

## Testing
- pytest tests/test_upload_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ebcf7f6fcc8323b45c9de91dad6929