### PR TITLE
Fix local import status handling and support canceled sessions

### DIFF
--- a/webapp/api/picker_session_service.py
+++ b/webapp/api/picker_session_service.py
@@ -1079,6 +1079,7 @@ class PickerSessionService:
         try:
             db.session.execute(statement)
         except IntegrityError:
+            db.session.rollback()
             # 他のトランザクションが先に同一キーで登録した場合は既存行をdup扱いに更新
             existing = PickerSelection.query.filter_by(
                 session_id=ps.id, google_media_id=item_id


### PR DESCRIPTION
## Summary
- roll back the session when duplicate selection inserts raise integrity errors so the transaction can continue

## Testing
- pytest tests/test_picker_session_service_local_import.py

------
https://chatgpt.com/codex/tasks/task_e_68ebe9af2294832381ba5651c54cc359