### PR TITLE
Mark duplicate local import selections as finished

### DIFF
--- a/application/local_import/queue.py
+++ b/application/local_import/queue.py
@@ -311,6 +311,11 @@ class LocalImportQueueProcessor:
                     existing_google_id = file_result.get("media_google_id")
                     if existing_google_id:
                         selection.google_media_id = existing_google_id
+                    existing_media_id = file_result.get("media_id")
+                    if existing_media_id is not None:
+                        selection.media_id = existing_media_id
+                    if selection.finished_at is None:
+                        selection.finished_at = datetime.now(timezone.utc)
                 else:
                     selection.status = "failed"
                     selection.error = detail["reason"]

--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -182,6 +182,7 @@ def test_picker_import_item_dup(monkeypatch, app, tmp_path):
         pmi = PickerSelection.query.get(pmi_id)
         assert res["ok"] is True
         assert pmi.status == "dup"
+        assert pmi.finished_at is not None
         assert pmi.locked_by is None
         assert pmi.lock_heartbeat_at is None
         assert Media.query.count() == 1


### PR DESCRIPTION
## Summary
- ensure duplicate local import selections record the existing media id and finished timestamp
- add a regression test asserting duplicate picker imports are marked finished

## Testing
- pytest tests/test_picker_import_item.py::test_picker_import_item_dup

------
https://chatgpt.com/codex/tasks/task_e_68ebf29dd1d48323bfe82af1b82f571e