### PR TITLE
Refactor local import logging and add tests

### DIFF
--- a/domain/local_import/logging.py
+++ b/domain/local_import/logging.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 
 def serialize_details(details: Dict[str, Any]) -> str:
@@ -97,13 +99,29 @@ def existing_media_destination_context(media, originals_dir: Optional[str]) -> D
     return details
 
 
-import os
+@dataclass(frozen=True)
+class LogEntry:
+    """ローカルインポートで扱うログ情報を表現する値オブジェクト。"""
+
+    message: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+    session_id: Optional[str] = None
+    status: Optional[str] = None
+
+    def compose(self, default_status: str) -> Tuple[str, Dict[str, Any], str]:
+        """ログ出力に必要な情報を組み立てる。"""
+
+        payload = with_session(dict(self.details), self.session_id)
+        resolved_status = self.status if self.status is not None else default_status
+        composed_message = compose_message(self.message, payload, resolved_status)
+        return composed_message, payload, resolved_status
 
 
 __all__ = [
     "compose_message",
     "existing_media_destination_context",
     "file_log_context",
+    "LogEntry",
     "serialize_details",
     "with_session",
 ]

--- a/tests/application/local_import/test_logger.py
+++ b/tests/application/local_import/test_logger.py
@@ -1,0 +1,156 @@
+"""application.local_import.logger のテスト."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from application.local_import.logger import LocalImportTaskLogger
+from domain.local_import.logging import compose_message, with_session
+
+
+@pytest.fixture
+def task_logger() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def celery_logger() -> MagicMock:
+    return MagicMock()
+
+
+def _expected_payload(**details: Any) -> Any:
+    return with_session(details, "session")
+
+
+def _expected_message(message: str, status: str, **details: Any) -> str:
+    payload = _expected_payload(**details)
+    return compose_message(message, payload, status)
+
+
+def test_info_logs_to_task_and_celery(monkeypatch, task_logger, celery_logger) -> None:
+    log_task_info = MagicMock()
+    monkeypatch.setattr("application.local_import.logger.log_task_info", log_task_info)
+    logger = LocalImportTaskLogger(task_logger, celery_logger)
+
+    logger.info(
+        "event",
+        "message",
+        session_id="session",
+        user="alice",
+    )
+
+    payload = _expected_payload(user="alice")
+    expected_message = _expected_message("message", "info", user="alice")
+
+    log_task_info.assert_called_once_with(
+        task_logger,
+        expected_message,
+        event="event",
+        status="info",
+        **payload,
+    )
+    celery_logger.info.assert_called_once_with(
+        expected_message,
+        extra={"event": "event", "status": "info", **payload},
+    )
+
+
+def test_warning_logs_with_custom_status(task_logger, celery_logger) -> None:
+    logger = LocalImportTaskLogger(task_logger, celery_logger)
+
+    logger.warning(
+        "event",
+        "message",
+        session_id="session",
+        status="custom",
+        user="alice",
+    )
+
+    payload = _expected_payload(user="alice")
+    expected_message = _expected_message("message", "custom", user="alice")
+
+    task_logger.warning.assert_called_once_with(
+        expected_message,
+        extra={"event": "event", "status": "custom", **payload},
+    )
+    celery_logger.warning.assert_called_once_with(
+        expected_message,
+        extra={"event": "event", "status": "custom", **payload},
+    )
+
+
+def test_error_logs_and_propagates_exception(monkeypatch, task_logger, celery_logger) -> None:
+    log_task_error = MagicMock()
+    monkeypatch.setattr("application.local_import.logger.log_task_error", log_task_error)
+    logger = LocalImportTaskLogger(task_logger, celery_logger)
+
+    logger.error(
+        "event",
+        "message",
+        session_id="session",
+        exc_info=True,
+        user="alice",
+    )
+
+    payload = _expected_payload(user="alice")
+    expected_message = _expected_message("message", "error", user="alice")
+
+    log_task_error.assert_called_once_with(
+        task_logger,
+        expected_message,
+        event="event",
+        status="error",
+        exc_info=True,
+        **payload,
+    )
+    celery_logger.error.assert_called_once_with(
+        expected_message,
+        extra={"event": "event", "status": "error", **payload},
+        exc_info=True,
+    )
+
+
+def test_commit_with_error_logging_reports_and_reraises(monkeypatch, task_logger, celery_logger) -> None:
+    log_task_error = MagicMock()
+    monkeypatch.setattr("application.local_import.logger.log_task_error", log_task_error)
+    logger = LocalImportTaskLogger(task_logger, celery_logger)
+
+    class FailingSession:
+        def commit(self) -> None:
+            raise RuntimeError("boom")
+
+        def rollback(self) -> None:
+            pass
+
+    db = SimpleNamespace(session=FailingSession())
+
+    with pytest.raises(RuntimeError):
+        logger.commit_with_error_logging(
+            db,
+            "event",
+            "message",
+            session_id="session",
+            celery_task_id="celery-id",
+        )
+
+    payload = _expected_payload(celery_task_id="celery-id", error_type="RuntimeError", error_message="boom")
+    expected_message = _expected_message(
+        "message",
+        "error",
+        celery_task_id="celery-id",
+        error_type="RuntimeError",
+        error_message="boom",
+    )
+
+    log_task_error.assert_called_once_with(
+        task_logger,
+        expected_message,
+        event="event",
+        status="error",
+        exc_info=True,
+        **payload,
+    )

--- a/tests/domain/local_import/test_logging.py
+++ b/tests/domain/local_import/test_logging.py
@@ -1,0 +1,36 @@
+"""domain.local_import.logging のテスト."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from domain.local_import.logging import LogEntry
+
+
+def test_log_entry_compose_uses_default_status_when_not_provided() -> None:
+    entry = LogEntry(message="processed", details={"item": "abc"}, session_id="session")
+
+    composed, payload, status = entry.compose("info")
+
+    assert status == "info"
+    assert payload == {"item": "abc", "session_id": "session"}
+    assert "processed" in composed
+    assert "abc" in composed
+
+
+def test_log_entry_compose_preserves_explicit_status() -> None:
+    entry = LogEntry(message="processed", details={}, status="custom")
+
+    _, _, status = entry.compose("info")
+
+    assert status == "custom"
+
+
+def test_log_entry_does_not_mutate_original_details() -> None:
+    original: Mapping[str, str] = {"key": "value"}
+    entry = LogEntry(message="message", details=original)
+
+    _, payload, _ = entry.compose("info")
+
+    assert dict(original) == {"key": "value"}
+    assert payload is not original


### PR DESCRIPTION
## Summary
- introduce the LogEntry value object to consolidate local import log composition
- refactor LocalImportTaskLogger to use a severity abstraction and the new value object, removing duplicated code paths
- add focused unit tests for the logging value object and application logger behaviour

## Testing
- pytest tests/application/local_import/test_logger.py tests/domain/local_import/test_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68edf06a3c6c8323824676e1adac8253