### PR TITLE
Refactor wiki slug handling into domain service

### DIFF
--- a/domain/wiki/__init__.py
+++ b/domain/wiki/__init__.py
@@ -9,6 +9,7 @@ from .markdown import (
     SingleNewlineProcessor,
     UrlAutoLinker,
 )
+from .slug import Slug, SlugNormalizer, SlugService
 
 __all__ = [
     "HtmlEscaper",
@@ -18,4 +19,7 @@ __all__ = [
     "MermaidDiagramProcessor",
     "SingleNewlineProcessor",
     "UrlAutoLinker",
+    "Slug",
+    "SlugNormalizer",
+    "SlugService",
 ]

--- a/domain/wiki/slug.py
+++ b/domain/wiki/slug.py
@@ -1,0 +1,93 @@
+"""Slug に関するドメインサービスおよび値オブジェクト。"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Slug:
+    """Wiki ドメインで利用するスラッグを表す値オブジェクト。"""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        normalized = (self.value or "").strip()
+        if not normalized:
+            raise ValueError("slug value must not be empty")
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass repr helper
+        return self.value
+
+
+class SlugNormalizer:
+    """テキストからスラッグ文字列を生成する正規化コンポーネント。"""
+
+    _INVALID_PATTERN = re.compile(r"[^\w\s-]", re.UNICODE)
+    _HYPHEN_PATTERN = re.compile(r"[-\s]+")
+
+    def normalize(self, text: str) -> str:
+        if not text:
+            return ""
+
+        normalized = unicodedata.normalize("NFKC", text)
+        normalized = normalized.lower()
+        normalized = self._INVALID_PATTERN.sub("", normalized)
+        normalized = self._HYPHEN_PATTERN.sub("-", normalized)
+        return normalized.strip("-")
+
+
+class SlugService:
+    """スラッグに関するドメインサービス。"""
+
+    _VALID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+    def __init__(self, normalizer: SlugNormalizer | None = None) -> None:
+        self._normalizer = normalizer or SlugNormalizer()
+
+    def generate_from_text(self, text: str) -> Slug:
+        """任意のテキストからスラッグを生成する。"""
+
+        normalized = self._normalizer.normalize(text)
+        if not normalized:
+            raise ValueError("normalized slug must not be empty")
+        return Slug(normalized)
+
+    def from_user_input(self, slug: str) -> Slug:
+        """ユーザー入力済みのスラッグから値オブジェクトを生成する。"""
+
+        candidate = (slug or "").strip()
+        if not candidate:
+            raise ValueError("slug must not be blank")
+        if not self.is_valid(candidate):
+            raise ValueError("slug contains invalid characters")
+        return Slug(candidate)
+
+    def ensure_unique(self, slug: Slug, exists: Callable[[str], bool]) -> Slug:
+        """既存スラッグと重複しないように調整する。"""
+
+        if not exists(slug.value):
+            return slug
+
+        base_value = slug.value
+        counter = 1
+        while True:
+            candidate_value = f"{base_value}-{counter}"
+            if not exists(candidate_value):
+                return Slug(candidate_value)
+            counter += 1
+
+    def generate_unique_from_text(self, text: str, exists: Callable[[str], bool]) -> Slug:
+        """テキストから生成したスラッグに重複対策を施す。"""
+
+        return self.ensure_unique(self.generate_from_text(text), exists)
+
+    @staticmethod
+    def is_valid(slug: str) -> bool:
+        if not slug:
+            return False
+        return bool(SlugService._VALID_PATTERN.match(slug))

--- a/tests/domain/test_slug_service.py
+++ b/tests/domain/test_slug_service.py
@@ -1,0 +1,54 @@
+import pytest
+
+from domain.wiki.slug import Slug, SlugService
+
+
+class TestSlugService:
+    def setup_method(self) -> None:
+        self.service = SlugService()
+
+    def test_generate_from_text_normalizes_unicode(self) -> None:
+        slug = self.service.generate_from_text("Python 入門! ガイド")
+        assert slug.value == "python-入門-ガイド"
+
+    def test_generate_from_text_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            self.service.generate_from_text("!!!")
+
+    def test_from_user_input_validates_pattern(self) -> None:
+        slug = self.service.from_user_input("CustomSlug")
+        assert slug.value == "CustomSlug"
+
+        with pytest.raises(ValueError):
+            self.service.from_user_input("bad slug")
+
+    def test_ensure_unique_appends_counter(self) -> None:
+        existing = {"hello-world", "hello-world-1"}
+
+        def exists(value: str) -> bool:
+            return value in existing
+
+        unique = self.service.ensure_unique(Slug("hello-world"), exists)
+        assert unique.value == "hello-world-2"
+
+    def test_generate_unique_from_text_handles_collision(self) -> None:
+        existing = {"python-guide"}
+
+        def exists(value: str) -> bool:
+            return value in existing
+
+        unique = self.service.generate_unique_from_text("Python Guide", exists)
+        assert unique.value == "python-guide-1"
+
+    @pytest.mark.parametrize(
+        "candidate, expected",
+        [
+            ("valid-slug", True),
+            ("UPPER_and_lower", True),
+            ("with space", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_valid(self, candidate, expected) -> None:
+        assert self.service.is_valid(candidate) is expected


### PR DESCRIPTION
## Summary
- centralize wiki slug normalization and uniqueness checks in a dedicated domain slug service
- inject the slug service into wiki application services and web utilities to remove duplicated slug logic
- add focused unit tests for the slug service and for slug fallback behaviour in wiki services

## Testing
- pytest tests/domain/test_slug_service.py tests/wiki/test_wiki_services.py

------
https://chatgpt.com/codex/tasks/task_e_68edfd463ef883238c7c69ce5ee684c6