### PR TITLE
Refactor wiki use cases with domain commands and permissions

### DIFF
--- a/domain/wiki/commands.py
+++ b/domain/wiki/commands.py
@@ -1,0 +1,142 @@
+"""Wikiページ操作に利用するドメインコマンドとファクトリ。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from domain.wiki.exceptions import WikiValidationError
+
+
+@dataclass(frozen=True)
+class WikiPageCreationCommand:
+    """ページ作成に必要な値を正規化したコマンド。"""
+
+    title: str
+    content: str
+    slug: str | None
+    parent_id: int | None
+    category_ids: Tuple[int, ...]
+    author_id: int
+
+
+@dataclass(frozen=True)
+class WikiPageUpdateCommand:
+    """ページ更新に必要な値を正規化したコマンド。"""
+
+    slug: str
+    title: str
+    content: str
+    change_summary: str | None
+    category_ids: Tuple[int, ...]
+    editor_id: int
+    has_admin_rights: bool
+
+
+class WikiPageCommandFactory:
+    """入力値を正規化しドメインコマンドへ変換するファクトリ。"""
+
+    def build_creation_command(
+        self,
+        *,
+        title: str,
+        content: str,
+        slug: str | None,
+        parent_id: str | int | None,
+        category_ids: Iterable[str | int | None],
+        author_id: int,
+    ) -> WikiPageCreationCommand:
+        normalized_title = self._normalize_required(title, "タイトルと内容は必須です")
+        normalized_content = self._normalize_required(content, "タイトルと内容は必須です")
+        normalized_slug = self._normalize_slug(slug)
+        normalized_parent = self._parse_optional_int(parent_id, "親ページの指定が不正です")
+        normalized_categories = self._parse_category_ids(category_ids)
+
+        return WikiPageCreationCommand(
+            title=normalized_title,
+            content=normalized_content,
+            slug=normalized_slug,
+            parent_id=normalized_parent,
+            category_ids=normalized_categories,
+            author_id=author_id,
+        )
+
+    def build_update_command(
+        self,
+        *,
+        slug: str,
+        title: str,
+        content: str,
+        change_summary: str | None,
+        category_ids: Iterable[str | int | None],
+        editor_id: int,
+        has_admin_rights: bool,
+    ) -> WikiPageUpdateCommand:
+        normalized_slug = self._normalize_slug_for_lookup(slug)
+        normalized_title = self._normalize_required(title, "タイトルと内容は必須です")
+        normalized_content = self._normalize_required(content, "タイトルと内容は必須です")
+        normalized_summary = self._normalize_optional(change_summary)
+        normalized_categories = self._parse_category_ids(category_ids)
+
+        return WikiPageUpdateCommand(
+            slug=normalized_slug,
+            title=normalized_title,
+            content=normalized_content,
+            change_summary=normalized_summary,
+            category_ids=normalized_categories,
+            editor_id=editor_id,
+            has_admin_rights=has_admin_rights,
+        )
+
+    @staticmethod
+    def _normalize_required(value: str | None, error_message: str) -> str:
+        normalized = (value or "").strip()
+        if not normalized:
+            raise WikiValidationError(error_message)
+        return normalized
+
+    @staticmethod
+    def _normalize_optional(value: str | None) -> str | None:
+        normalized = (value or "").strip()
+        return normalized or None
+
+    @staticmethod
+    def _normalize_slug(value: str | None) -> str | None:
+        normalized = (value or "").strip()
+        return normalized or None
+
+    @staticmethod
+    def _normalize_slug_for_lookup(value: str | None) -> str:
+        return (value or "").strip()
+
+    @staticmethod
+    def _parse_optional_int(value: str | int | None, error_message: str) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:  # pragma: no cover - 型安全のため
+            raise WikiValidationError(error_message) from exc
+
+    def _parse_category_ids(
+        self,
+        values: Iterable[str | int | None],
+        error_message: str = "カテゴリの指定が不正です",
+    ) -> Tuple[int, ...]:
+        result: list[int] = []
+        for value in values or []:
+            if value in (None, ""):
+                continue
+            try:
+                result.append(int(value))  # type: ignore[arg-type]
+            except (TypeError, ValueError) as exc:
+                raise WikiValidationError(error_message) from exc
+        return tuple(result)
+
+
+__all__ = [
+    "WikiPageCommandFactory",
+    "WikiPageCreationCommand",
+    "WikiPageUpdateCommand",
+]
+

--- a/domain/wiki/permissions.py
+++ b/domain/wiki/permissions.py
@@ -1,0 +1,54 @@
+"""Wikiページに関する権限判定のドメインサービス。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from domain.wiki.entities import WikiPage as WikiPageEntity
+
+
+@runtime_checkable
+class SupportsWikiPage(Protocol):
+    """権限判定に必要な最低限のインターフェース。"""
+
+    created_by_id: int
+
+    def can_be_edited_by(self, user_id: int) -> bool:  # pragma: no cover - プロトコル定義
+        ...
+
+
+@dataclass(frozen=True)
+class EditorContext:
+    """ページ編集時の利用者情報を表す値オブジェクト。"""
+
+    user_id: int
+    is_admin: bool = False
+
+    def __post_init__(self) -> None:
+        if self.user_id <= 0:
+            raise ValueError("user_id must be positive")
+
+
+class WikiPagePermissionService:
+    """Wikiページに対する操作権限を判定するドメインサービス。"""
+
+    def can_edit(self, page: SupportsWikiPage | WikiPageEntity, editor: EditorContext) -> bool:
+        """指定したユーザーがページを編集できるか判定する。"""
+
+        if editor.is_admin:
+            return True
+
+        if isinstance(page, WikiPageEntity):
+            return page.can_be_edited_by(editor.user_id)
+
+        if isinstance(page, SupportsWikiPage):
+            can_edit = getattr(page, "can_be_edited_by", None)
+            if callable(can_edit):
+                return bool(can_edit(editor.user_id))
+
+        return getattr(page, "created_by_id", None) == editor.user_id
+
+
+__all__ = ["EditorContext", "WikiPagePermissionService", "SupportsWikiPage"]
+

--- a/tests/domain/test_wiki_page_command_factory.py
+++ b/tests/domain/test_wiki_page_command_factory.py
@@ -1,0 +1,124 @@
+from domain.wiki.commands import (
+    WikiPageCommandFactory,
+    WikiPageCreationCommand,
+    WikiPageUpdateCommand,
+)
+from domain.wiki.exceptions import WikiValidationError
+
+
+def test_build_creation_command_normalizes_values() -> None:
+    factory = WikiPageCommandFactory()
+
+    command = factory.build_creation_command(
+        title="  Title  ",
+        content="  Content  ",
+        slug="  custom ",
+        parent_id="42",
+        category_ids=["1", "", 2, None],
+        author_id=10,
+    )
+
+    assert isinstance(command, WikiPageCreationCommand)
+    assert command.title == "Title"
+    assert command.content == "Content"
+    assert command.slug == "custom"
+    assert command.parent_id == 42
+    assert command.category_ids == (1, 2)
+    assert command.author_id == 10
+
+
+def test_build_creation_command_validates_required_fields() -> None:
+    factory = WikiPageCommandFactory()
+
+    try:
+        factory.build_creation_command(
+            title=" ",
+            content="",
+            slug=None,
+            parent_id=None,
+            category_ids=[],
+            author_id=1,
+        )
+    except WikiValidationError as exc:
+        assert "タイトルと内容は必須です" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected validation error")
+
+
+def test_build_creation_command_validates_parent_id() -> None:
+    factory = WikiPageCommandFactory()
+
+    try:
+        factory.build_creation_command(
+            title="Title",
+            content="Content",
+            slug=None,
+            parent_id="invalid",
+            category_ids=[],
+            author_id=1,
+        )
+    except WikiValidationError as exc:
+        assert "親ページの指定が不正です" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected validation error")
+
+
+def test_build_creation_command_validates_category_ids() -> None:
+    factory = WikiPageCommandFactory()
+
+    try:
+        factory.build_creation_command(
+            title="Title",
+            content="Content",
+            slug=None,
+            parent_id=None,
+            category_ids=["invalid"],
+            author_id=1,
+        )
+    except WikiValidationError as exc:
+        assert "カテゴリの指定が不正です" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected validation error")
+
+
+def test_build_update_command_normalizes_values() -> None:
+    factory = WikiPageCommandFactory()
+
+    command = factory.build_update_command(
+        slug="  slug  ",
+        title="  Title  ",
+        content="  Content  ",
+        change_summary=" summary ",
+        category_ids=["1", 2, ""],
+        editor_id=5,
+        has_admin_rights=True,
+    )
+
+    assert isinstance(command, WikiPageUpdateCommand)
+    assert command.slug == "slug"
+    assert command.title == "Title"
+    assert command.content == "Content"
+    assert command.change_summary == "summary"
+    assert command.category_ids == (1, 2)
+    assert command.editor_id == 5
+    assert command.has_admin_rights is True
+
+
+def test_build_update_command_validates_required_fields() -> None:
+    factory = WikiPageCommandFactory()
+
+    try:
+        factory.build_update_command(
+            slug=" ",
+            title="",
+            content="",
+            change_summary=None,
+            category_ids=[],
+            editor_id=1,
+            has_admin_rights=False,
+        )
+    except WikiValidationError as exc:
+        assert "タイトルと内容は必須です" in str(exc) or "ページ識別子は必須です" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected validation error")
+

--- a/tests/domain/test_wiki_permission_service.py
+++ b/tests/domain/test_wiki_permission_service.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from domain.wiki.entities import WikiPage as DomainWikiPage
+from domain.wiki.permissions import EditorContext, WikiPagePermissionService
+
+
+@dataclass
+class SimplePage:
+    created_by_id: int
+
+
+def test_owner_can_edit_without_admin() -> None:
+    service = WikiPagePermissionService()
+    page = SimplePage(created_by_id=10)
+    editor = EditorContext(user_id=10, is_admin=False)
+
+    assert service.can_edit(page, editor) is True
+
+
+def test_non_owner_without_admin_cannot_edit() -> None:
+    service = WikiPagePermissionService()
+    page = SimplePage(created_by_id=10)
+    editor = EditorContext(user_id=5, is_admin=False)
+
+    assert service.can_edit(page, editor) is False
+
+
+def test_admin_can_edit_any_page() -> None:
+    service = WikiPagePermissionService()
+    page = SimplePage(created_by_id=10)
+    editor = EditorContext(user_id=1, is_admin=True)
+
+    assert service.can_edit(page, editor) is True
+
+
+def test_domain_entity_delegates_to_entity_logic() -> None:
+    service = WikiPagePermissionService()
+    entity = DomainWikiPage(
+        id=1,
+        title="title",
+        content="content",
+        slug="slug",
+        created_at=None,
+        updated_at=None,
+        created_by_id=10,
+        updated_by_id=10,
+    )
+    editor = EditorContext(user_id=99, is_admin=False)
+
+    assert service.can_edit(entity, editor) is False
+


### PR DESCRIPTION
## Summary
- extract a domain command factory to normalize wiki page inputs reused by create/update use cases
- introduce a dedicated wiki permission service and use it from edit/update flows for shared policy handling
- add focused unit tests for the new domain components

## Testing
- pytest tests/domain/test_wiki_page_command_factory.py tests/domain/test_wiki_permission_service.py

------
https://chatgpt.com/codex/tasks/task_e_68edff62fef083238d992d0388bdffe1