### PR TITLE
Refactor photo_view blueprint URL structure

### DIFF
--- a/features/photonest/presentation/photo_view/__init__.py
+++ b/features/photonest/presentation/photo_view/__init__.py
@@ -1,5 +1,10 @@
 from flask import Blueprint
 
-bp = Blueprint("photo_view", __name__, template_folder="templates")
+bp = Blueprint(
+    "photo_view",
+    __name__,
+    url_prefix="/photo_view",
+    template_folder="templates",
+)
 
 from . import routes  # noqa: F401

--- a/features/photonest/presentation/photo_view/templates/photo_view/album_detail.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/album_detail.html
@@ -675,7 +675,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function navigateToSlideshow(startIndex = 0, options = {}) {
-    const url = new URL(`/photo-view/albums/${albumId}/slideshow`, window.location.origin);
+    const url = new URL(`/photo_view/albums/${albumId}/slideshow`, window.location.origin);
     const params = new URLSearchParams();
 
     const normalizedIndex = Number(startIndex);

--- a/features/photonest/presentation/photo_view/templates/photo_view/album_slideshow.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/album_slideshow.html
@@ -113,8 +113,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const startIndex = Number.parseInt(container.dataset.startIndex || '', 10);
   const autoplay = container.dataset.autoplay !== 'false';
-  const backUrl = container.dataset.backUrl || `/photo-view/albums/${albumId}`;
-  const albumsUrl = container.dataset.albumsUrl || '/photo-view/albums';
+  const backUrl = container.dataset.backUrl || `/photo_view/albums/${albumId}`;
+  const albumsUrl = container.dataset.albumsUrl || '/photo_view/albums';
 
   const strings = {
     untitledAlbum: "{{ _('Untitled Album')|escapejs }}",

--- a/features/photonest/presentation/photo_view/templates/photo_view/albums.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/albums.html
@@ -632,7 +632,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const albumModalElement = document.getElementById('albumModal');
   const editorView = albumModalElement?.dataset.editorMode === 'page';
-  const successRedirectUrl = albumModalElement?.dataset.successUrl || '/photo-view/albums';
+  const successRedirectUrl = albumModalElement?.dataset.successUrl || '/photo_view/albums';
   const editorAlbumIdRaw = albumModalElement?.dataset.albumId || '';
   const editorAlbumId = Number.parseInt(editorAlbumIdRaw, 10);
   const albumModal = albumModalElement
@@ -1877,7 +1877,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    const url = new URL(`/photo-view/albums/${albumId}/slideshow`, window.location.origin);
+    const url = new URL(`/photo_view/albums/${albumId}/slideshow`, window.location.origin);
     const params = new URLSearchParams();
 
     const startIndex = Number(options.startIndex);
@@ -2345,7 +2345,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         return;
       }
-      window.location.href = `/photo-view/albums/${album.id}`;
+      window.location.href = `/photo_view/albums/${album.id}`;
     });
 
     const slideshowButton = card.querySelector('button[data-album-action="slideshow"]');

--- a/features/photonest/presentation/photo_view/templates/photo_view/home.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/home.html
@@ -1018,7 +1018,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <td><small>${formatDateTime(session.createdAt)}</small></td>
       <td><small>${formatDateTime(session.lastProgressAt)}</small></td>
       <td class="session-actions">
-        <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary btn-size-sm">{{ _("View Details") }}</a>
+        <a href="/photo_view?session_id=${session.sessionId}" class="btn btn-sm btn-primary btn-size-sm">{{ _("View Details") }}</a>
         ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success btn-size-sm" onclick="startImport('${session.sessionId}')">{{ _("Start Import") }}</button>` : ''}
         ${stopButtonHtml}
         ${localStatusMessage}
@@ -1241,7 +1241,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const sessionId = payload && payload.session_id;
         if (sessionId) {
           setTimeout(() => {
-            window.location.href = `/photo-view?session_id=${encodeURIComponent(sessionId)}`;
+            window.location.href = `/photo_view?session_id=${encodeURIComponent(sessionId)}`;
           }, 1500);
           return;
         }

--- a/features/photonest/presentation/photo_view/templates/photo_view/media_list.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/media_list.html
@@ -890,7 +890,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Navigate to the media detail page on click
     card.addEventListener('click', () => {
-      window.location.href = `/photo-view/media/${media.id}`;
+      window.location.href = `/photo_view/media/${media.id}`;
     });
     
     return card;

--- a/features/photonest/presentation/photo_view/templates/photo_view/session_detail.html
+++ b/features/photonest/presentation/photo_view/templates/photo_view/session_detail.html
@@ -12,7 +12,7 @@
     <h1 id="session-title" class="mb-1">{{ _("Session Details") }}</h1>
     <p id="session-subtitle" class="text-muted small mb-0 d-none"></p>
   </div>
-  <a href="/photo-view" class="btn btn-outline-secondary btn-sm">
+  <a href="/photo_view" class="btn btn-outline-secondary btn-sm">
     <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
   </a>
 </div>
@@ -152,13 +152,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const pickerSessionId = resolveSessionId();
   if (!pickerSessionId) {
-    window.location.href = '/photo-view';
+    window.location.href = '/photo_view';
     return;
   }
 
   if (/^\d+$/.test(pickerSessionId)) {
     console.warn('Numeric session ID detected, redirecting to sessions list');
-    window.location.href = '/photo-view';
+    window.location.href = '/photo_view';
     return;
   }
 
@@ -647,7 +647,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const safeDisplayName = escapeHtml(displayName);
     const canDisplayLink = selection.mediaId && ['imported', 'dup'].includes(selection.status);
     const fileCellContent = canDisplayLink
-      ? `<a href="/photo-view/media/${selection.mediaId}" class="text-decoration-none">${safeDisplayName}</a>`
+      ? `<a href="/photo_view/media/${selection.mediaId}" class="text-decoration-none">${safeDisplayName}</a>`
       : safeDisplayName;
     const errorMessageHtml = selection.error
       ? `<div class="text-danger small">${escapeHtml(selection.error)}</div>`
@@ -928,7 +928,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const resp = await window.apiClient.get(`/api/picker/session/${encodeURIComponent(pickerSessionId)}`);
       if (resp.status === 404) {
-        window.location.href = '/photo-view';
+        window.location.href = '/photo_view';
         return null;
       }
       if (resp.status === 401 || resp.status === 302) {

--- a/tests/manual_test_local_import.py
+++ b/tests/manual_test_local_import.py
@@ -126,5 +126,5 @@ if __name__ == "__main__":
     print("\n使用方法:")
     print("1. 環境変数 LOCAL_IMPORT_DIR に取り込み元ディレクトリを設定")
     print("2. 環境変数 FPV_NAS_ORIGINALS_DIR に保存先ディレクトリを設定")
-    print("3. Web管理画面 (/photo-view/settings) からインポート実行")
+    print("3. Web管理画面 (/photo_view/settings) からインポート実行")
     print("4. または Celery タスクから実行: local_import_task_celery.delay()")

--- a/tests/test_local_import.py
+++ b/tests/test_local_import.py
@@ -469,5 +469,5 @@ if __name__ == "__main__":
     print("\n使用方法:")
     print("1. 環境変数 LOCAL_IMPORT_DIR に取り込み元ディレクトリを設定")
     print("2. 環境変数 FPV_NAS_ORIGINALS_DIR に保存先ディレクトリを設定")
-    print("3. Web管理画面 (/photo-view/settings) からインポート実行")
+    print("3. Web管理画面 (/photo_view/settings) からインポート実行")
     print("4. または Celery タスクから実行: local_import_task_celery.delay()")

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -468,7 +468,7 @@ class TestSessionDetailUI:
             session_id = result['session_id']
         
         # セッション詳細ページ呼び出し
-        response = client.get(f'/photo-view?session_id={session_id}')
+        response = client.get(f'/photo_view?session_id={session_id}')
         assert response.status_code == 200
         
         html = response.get_data(as_text=True)
@@ -496,7 +496,7 @@ class TestSessionDetailUI:
             session_id = result['session_id']
         
         # ホームページ呼び出し
-        response = client.get('/photo-view')
+        response = client.get('/photo_view')
         assert response.status_code == 200
         
         html = response.get_data(as_text=True)

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -482,7 +482,7 @@ def create_app():
     app.register_blueprint(admin_bp, url_prefix="/admin")
 
     from features.photonest.presentation.photo_view import bp as photo_view_bp
-    app.register_blueprint(photo_view_bp, url_prefix="/photo-view")
+    app.register_blueprint(photo_view_bp)
 
     from .api import bp as api_bp
     app.register_blueprint(api_bp, url_prefix="/api")


### PR DESCRIPTION
## Summary
- add a `/photo_view` URL prefix to the `photo_view` blueprint and register it without an extra prefix
- update photo view templates and client-side navigation to point at the new `/photo_view/...` routes
- align local import UI tests and helper scripts with the updated route locations

## Testing
- pytest features/photonest/presentation/photo_view/tests *(fails: directory not found)*
- pytest tests/test_local_import_ui.py::TestSessionDetailAPI::test_session_logs_api_returns_zip_events -q --log-cli-level=ERROR
- pytest tests/test_local_import_ui.py::TestSessionDetailUI::test_home_page_shows_local_import_sessions -q --log-cli-level=ERROR

------
https://chatgpt.com/codex/tasks/task_e_68eeda9e64008323b8cd750d2ca75f4c