### PR TITLE
fix: ensure features package is importable

### DIFF
--- a/features/__init__.py
+++ b/features/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for domain-specific feature modules."""
+
+# This file ensures that the `features` directory is treated as a Python package
+# so that modules can be imported via `features.*` dotted paths.


### PR DESCRIPTION
## Summary
- add a module initializer so the `features` package can be imported by Celery tasks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eeea1370a88323865c5e623890c9a2