### PR TITLE
Adjust wiki page history button layout

### DIFF
--- a/features/wiki/presentation/wiki/templates/wiki/page.html
+++ b/features/wiki/presentation/wiki/templates/wiki/page.html
@@ -93,15 +93,12 @@
                         {% endif %}
                     </p>
                 </div>
-                <div>
+                <div class="d-flex align-items-center gap-2">
                     {% if current_user.can('wiki:write') and (page.created_by_id == current_user.id or current_user.can('wiki:admin')) %}
-                    <a href="{{ url_for('wiki.edit_page', slug=page.slug) }}" class="btn btn-secondary">
+                    <a href="{{ url_for('wiki.edit_page', slug=page.slug) }}" class="btn btn-secondary btn-sm">
                         <i class="fas fa-edit"></i> {{ _('Edit') }}
                     </a>
                     {% endif %}
-                    <a href="{{ url_for('wiki.page_history', slug=page.slug) }}" class="btn btn-outline-secondary">
-                        <i class="fas fa-history"></i> {{ _('History') }}
-                    </a>
                 </div>
             </div>
             
@@ -171,6 +168,11 @@
                     <i class="fas fa-arrow-up"></i> {{ _('Parent Page') }}: {{ page.parent.title }}
                 </a>
                 {% endif %}
+            </div>
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ url_for('wiki.page_history', slug=page.slug) }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fas fa-history"></i> {{ _('History') }}
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- move the wiki history action to the bottom-right of the wiki page view
- apply the small button style to the edit control for consistent sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef3c120e24832392fc0eb3876e9313