### PR TITLE
Enable click-to-copy for TOTP codes

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -14,6 +14,20 @@
     font-size: 1.75rem;
     letter-spacing: 0.3rem;
   }
+  .otp-copyable {
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    transition: background-color 0.15s ease-in-out;
+  }
+  .otp-copyable:hover,
+  .otp-copyable:focus {
+    background-color: rgba(13, 110, 253, 0.1);
+  }
+  .otp-copyable:focus {
+    outline: none;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+  }
   .otp-progress {
     height: 8px;
   }
@@ -110,7 +124,14 @@
         <div class="d-flex align-items-center justify-content-between">
           <div>
             <small class="text-muted d-block">{{ _('現在のプレビュー') }}</small>
-            <div class="otp-code" id="totp-preview-code">------</div>
+            <div
+              class="otp-code otp-copyable"
+              id="totp-preview-code"
+              role="button"
+              tabindex="0"
+              aria-label="{{ _('ワンタイムコードをコピー') }}"
+              title="{{ _('クリックでコピー') }}"
+            >------</div>
           </div>
           <div class="w-50">
             <div class="progress otp-progress">


### PR DESCRIPTION
## Summary
- make the TOTP preview and list codes clickable with clear affordances
- copy the active one-time code to the clipboard and show a toast notification on success

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68ef5e5cf8e8832399d99c9d5eb41469