### PR TITLE
Ensure TOTP setup returns to profile page

### DIFF
--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -109,7 +109,7 @@
               <i class="fas fa-user-edit me-2"></i>{{ _('Edit profile details') }}
             </a>
             {% if not current_user.totp_secret %}
-              <a href="{{ url_for('auth.setup_totp') }}" class="btn btn-outline-warning">
+              <a href="{{ url_for('auth.setup_totp', next=url_for('auth.profile')) }}" class="btn btn-outline-warning">
                 <i class="fas fa-mobile-alt me-2"></i>{{ _('Enable two-factor authentication') }}
               </a>
             {% endif %}

--- a/webapp/auth/templates/auth/setup_totp.html
+++ b/webapp/auth/templates/auth/setup_totp.html
@@ -62,6 +62,7 @@
     </div>
     
     <form method="post" class="login-form">
+      <input type="hidden" name="next" value="{{ next_url or url_for('auth.edit') }}">
       <div class="form-group auth-code-field">
         <label for="token" class="form-label">
           <i class="fas fa-shield-alt"></i>
@@ -83,9 +84,10 @@
     </form>
     
     <div class="forgot-password">
-      <a href="{{ url_for('auth.edit') }}">{{ _('Back to Profile') }}</a>
+      <a href="{{ next_url or url_for('auth.edit') }}">{{ _('Back to Profile') }}</a>
       <span style="margin: 0 10px;">|</span>
       <form method="post" action="{{ url_for('auth.setup_totp_cancel') }}" style="display: inline;">
+        <input type="hidden" name="next" value="{{ next_url or url_for('auth.edit') }}">
         <button type="submit" class="btn-cancel-link">
           <i class="fas fa-times" style="margin-right: 4px;"></i>
           {{ _('Cancel Setup') }}


### PR DESCRIPTION
## Summary
- add a helper to safely resolve optional redirect targets for the TOTP setup flow
- honor the `next` parameter when configuring or cancelling TOTP so users can return to their profile
- include the `next` parameter in profile and setup templates to maintain the desired redirect

## Testing
- pytest tests/test_auth_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68ef5f156ad083238dfda5d88d1eeaf7