### PR TITLE
Add wiki media upload path with hashed filenames

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -25,7 +25,11 @@ class Media(db.Model):
     id = db.Column(BigInt, primary_key=True, autoincrement=True)
     
     # ソース情報
-    source_type = db.Column(db.Enum('local', 'google_photos', name='media_source_type'), nullable=False, default='local')
+    source_type = db.Column(
+        db.Enum('local', 'google_photos', 'wiki-media', name='media_source_type'),
+        nullable=False,
+        default='local',
+    )
     google_media_id = db.Column(db.String(255), nullable=True)  # Google Photos ID
     account_id = db.Column(BigInt, db.ForeignKey('google_account.id'), nullable=True)
     account = db.relationship('GoogleAccount', backref='media_items')

--- a/features/wiki/application/dto.py
+++ b/features/wiki/application/dto.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
+from core.models.photo_models import Media
 from core.models.wiki.models import WikiCategory, WikiPage, WikiRevision
 
 
@@ -126,3 +127,9 @@ class WikiCategoryCreateInput:
 @dataclass(frozen=True)
 class WikiCategoryCreationResult:
     category: WikiCategory
+
+
+@dataclass(frozen=True)
+class WikiMediaUploadResult:
+    results: List[Dict[str, Any]]
+    media: List[Media]

--- a/migrations/versions/31b1901dba43_base.py
+++ b/migrations/versions/31b1901dba43_base.py
@@ -179,7 +179,7 @@ def upgrade():
 
     op.create_table('media',
     sa.Column('id', sa.BigInteger().with_variant(sa.Integer(), 'sqlite'), autoincrement=True, nullable=False),
-    sa.Column('source_type', sa.Enum('local', 'google_photos', name='media_source_type'), nullable=False),
+    sa.Column('source_type', sa.Enum('local', 'google_photos', 'wiki-media', name='media_source_type'), nullable=False),
     sa.Column('google_media_id', sa.String(length=255), nullable=True),
     sa.Column('account_id', sa.BigInteger().with_variant(sa.Integer(), 'sqlite'), nullable=True),
     sa.Column('local_rel_path', sa.String(length=255), nullable=True),

--- a/tests/test_wiki_upload_api.py
+++ b/tests/test_wiki_upload_api.py
@@ -1,0 +1,158 @@
+import hashlib
+import io
+from pathlib import Path
+
+import pytest
+
+from core.models.photo_models import Media
+from core.models.user import Permission, Role, User
+from webapp.extensions import db
+from webapp.services.token_service import TokenService
+
+
+def _ensure_permission(user: User, code: str, role_name: str = "wiki-uploader") -> None:
+    perm = Permission.query.filter_by(code=code).first()
+    if not perm:
+        perm = Permission(code=code)
+        db.session.add(perm)
+        db.session.flush()
+
+    role = Role.query.filter_by(name=role_name).first()
+    if not role:
+        role = Role(name=role_name)
+        db.session.add(role)
+        db.session.flush()
+
+    if perm not in role.permissions:
+        role.permissions.append(perm)
+
+    if role not in user.roles:
+        user.roles.append(role)
+
+    db.session.commit()
+
+
+@pytest.fixture
+def wiki_client(app_context, tmp_path):
+    app = app_context
+    app.config['UPLOAD_TMP_DIR'] = str(tmp_path / 'tmp')
+    app.config['WIKI_UPLOAD_DIR'] = str(tmp_path / 'wiki')
+    app.config['UPLOAD_MAX_SIZE'] = 1024 * 1024
+
+    (tmp_path / 'tmp').mkdir(parents=True, exist_ok=True)
+    (tmp_path / 'wiki').mkdir(parents=True, exist_ok=True)
+
+    with app.app_context():
+        user = User(email='wiki@example.com')
+        user.set_password('password')
+        db.session.add(user)
+        db.session.flush()
+        _ensure_permission(user, 'wiki:write')
+
+    return app.test_client()
+
+
+@pytest.fixture
+def wiki_auth_headers(wiki_client):
+    app = wiki_client.application
+    with app.app_context():
+        user = User.query.filter_by(email='wiki@example.com').first()
+        token = TokenService.generate_access_token(user)
+    return {'Authorization': f'Bearer {token}'}
+
+
+@pytest.fixture
+def wiki_client_no_perm(app_context, tmp_path):
+    app = app_context
+    app.config['UPLOAD_TMP_DIR'] = str(tmp_path / 'tmp_no_perm')
+    app.config['WIKI_UPLOAD_DIR'] = str(tmp_path / 'wiki_no_perm')
+    app.config['UPLOAD_MAX_SIZE'] = 1024 * 1024
+
+    (tmp_path / 'tmp_no_perm').mkdir(parents=True, exist_ok=True)
+    (tmp_path / 'wiki_no_perm').mkdir(parents=True, exist_ok=True)
+
+    with app.app_context():
+        user = User(email='wiki-noperm@example.com')
+        user.set_password('password')
+        db.session.add(user)
+        db.session.commit()
+
+    return app.test_client()
+
+
+@pytest.fixture
+def wiki_auth_headers_no_perm(wiki_client_no_perm):
+    app = wiki_client_no_perm.application
+    with app.app_context():
+        user = User.query.filter_by(email='wiki-noperm@example.com').first()
+        token = TokenService.generate_access_token(user)
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_wiki_upload_creates_media_record(wiki_client, wiki_auth_headers):
+    file_content = b'WikiImage'
+
+    prepare_resp = wiki_client.post(
+        '/api/upload/prepare',
+        data={'file': (io.BytesIO(file_content), 'diagram.png')},
+        headers=wiki_auth_headers,
+        content_type='multipart/form-data',
+    )
+    assert prepare_resp.status_code == 200
+    prepared = prepare_resp.get_json()
+
+    commit_resp = wiki_client.post(
+        '/api/upload/commit',
+        json={'destination': 'wiki', 'files': [{'tempFileId': prepared['tempFileId']}]},
+        headers=wiki_auth_headers,
+    )
+    assert commit_resp.status_code == 200
+    payload = commit_resp.get_json()
+
+    uploaded = payload['uploaded'][0]
+    assert uploaded['status'] == 'success'
+    assert uploaded['hashSha256'] == hashlib.sha256(file_content).hexdigest()
+
+    media_items = payload.get('media') or []
+    assert len(media_items) == 1
+    media_payload = media_items[0]
+    assert media_payload['sourceType'] == 'wiki-media'
+    assert media_payload['hashSha256'] == uploaded['hashSha256']
+
+    wiki_dir = Path(wiki_client.application.config['WIKI_UPLOAD_DIR'])
+    stored_file = (
+        wiki_dir / Path(uploaded['relativePath'])
+        if uploaded.get('relativePath')
+        else wiki_dir / Path(uploaded['storedPath']).name
+    )
+    assert stored_file.exists()
+    assert stored_file.read_bytes() == file_content
+
+    with wiki_client.application.app_context():
+        media = Media.query.get(media_payload['id'])
+        assert media is not None
+        assert media.source_type == 'wiki-media'
+        assert media.local_rel_path == media_payload['localRelPath']
+        assert media.hash_sha256 == uploaded['hashSha256']
+
+
+def test_wiki_upload_requires_permission(wiki_client_no_perm, wiki_auth_headers_no_perm):
+    file_content = b'NoPerm'
+
+    prepare_resp = wiki_client_no_perm.post(
+        '/api/upload/prepare',
+        data={'file': (io.BytesIO(file_content), 'restricted.png')},
+        headers=wiki_auth_headers_no_perm,
+        content_type='multipart/form-data',
+    )
+    assert prepare_resp.status_code == 200
+    prepared = prepare_resp.get_json()
+
+    commit_resp = wiki_client_no_perm.post(
+        '/api/upload/commit',
+        json={'destination': 'wiki', 'files': [{'tempFileId': prepared['tempFileId']}]},
+        headers=wiki_auth_headers_no_perm,
+    )
+    assert commit_resp.status_code == 403
+    payload = commit_resp.get_json()
+    assert payload['error'] == 'forbidden'

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -76,6 +76,7 @@ class Config:
     UPLOAD_TMP_DIR = os.environ.get("UPLOAD_TMP_DIR", "/app/data/tmp/upload")
     UPLOAD_DESTINATION_DIR = os.environ.get("UPLOAD_DESTINATION_DIR", "/app/data/uploads")
     UPLOAD_MAX_SIZE = int(os.environ.get("UPLOAD_MAX_SIZE", str(100 * 1024 * 1024)))
+    WIKI_UPLOAD_DIR = os.environ.get("WIKI_UPLOAD_DIR", "/app/data/wiki")
     FPV_NAS_THUMBS_DIR = os.environ.get("FPV_NAS_THUMBS_CONTAINER_DIR") or os.environ.get(
         "FPV_NAS_THUMBS_DIR", ""
     )
@@ -123,6 +124,7 @@ class TestConfig(Config):
     SQLALCHEMY_BINDS = {}
     UPLOAD_TMP_DIR = "/tmp/test_upload/tmp"
     UPLOAD_DESTINATION_DIR = "/tmp/test_upload/dest"
+    WIKI_UPLOAD_DIR = "/tmp/test_upload/wiki"
 
 
 class _ReloadSafeModule(ModuleType):


### PR DESCRIPTION
## Summary
- update the shared upload service to hash filenames, handle collisions, and support committing prepared files into arbitrary directories
- add a wiki-specific upload flow that stores files under the wiki data directory and records `media` rows with the new `wiki-media` source type
- expand configuration/migrations and tests to cover the hashed naming behaviour and the wiki media upload API

## Testing
- pytest tests/test_upload_api.py tests/test_wiki_upload_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ef5cfa5d8483239e3960ef0585a5c3