### PR TITLE
Collapse TOTP registration form by default

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -24,6 +24,12 @@
     max-width: 200px;
     max-height: 200px;
   }
+  .totp-collapse-toggle .bi {
+    transition: transform 0.2s ease;
+  }
+  .totp-collapse-toggle[aria-expanded="true"] .bi {
+    transform: rotate(180deg);
+  }
 </style>
 {% endblock %}
 
@@ -48,75 +54,90 @@
           <h2 class="h5 mb-0">{{ _('新規 TOTP 登録') }}</h2>
           <small class="text-muted">{{ _('QR を読み取るか手入力で登録できます') }}</small>
         </div>
-        <span class="badge bg-secondary" id="totp-preview-badge">{{ _('プレビュー待ち') }}</span>
+        <div class="d-flex align-items-center gap-2">
+          <span class="badge bg-secondary" id="totp-preview-badge">{{ _('プレビュー待ち') }}</span>
+          <button
+            class="btn btn-outline-secondary btn-sm totp-collapse-toggle collapsed"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#totp-create-collapse"
+            aria-expanded="false"
+            aria-controls="totp-create-collapse"
+            aria-label="{{ _('新規 TOTP 登録フォームを開閉') }}"
+          >
+            <i class="bi bi-chevron-down"></i>
+          </button>
+        </div>
       </div>
-      <div class="card-body">
-        <form id="totp-create-form" novalidate>
-          <div class="mb-3">
-            <label for="totp-account" class="form-label">{{ _('アカウント') }}</label>
-            <input type="text" id="totp-account" name="account" class="form-control" required>
-          </div>
-          <div class="mb-3">
-            <label for="totp-issuer" class="form-label">{{ _('発行元 (Issuer)') }}</label>
-            <input type="text" id="totp-issuer" name="issuer" class="form-control" required>
-          </div>
-          <div class="mb-3">
-            <label for="totp-secret" class="form-label">{{ _('シークレット') }}</label>
-            <input type="text" id="totp-secret" name="secret" class="form-control" required placeholder="JBSWY3DPEHPK3PXP">
-            <div class="form-text">{{ _('空白やハイフンは自動で除去されます (Base32)') }}</div>
-          </div>
-          <div class="row">
-            <div class="col-6 mb-3">
-              <label for="totp-digits" class="form-label">{{ _('桁数') }}</label>
-              <input type="number" id="totp-digits" name="digits" class="form-control" min="4" max="10" value="6">
+      <div class="collapse" id="totp-create-collapse">
+        <div class="card-body">
+          <form id="totp-create-form" novalidate>
+            <div class="mb-3">
+              <label for="totp-account" class="form-label">{{ _('アカウント') }}</label>
+              <input type="text" id="totp-account" name="account" class="form-control" required>
             </div>
-            <div class="col-6 mb-3">
-              <label for="totp-period" class="form-label">{{ _('有効期間 (秒)') }}</label>
-              <input type="number" id="totp-period" name="period" class="form-control" min="15" max="120" value="30">
+            <div class="mb-3">
+              <label for="totp-issuer" class="form-label">{{ _('発行元 (Issuer)') }}</label>
+              <input type="text" id="totp-issuer" name="issuer" class="form-control" required>
             </div>
-          </div>
-          <div class="mb-3">
-            <label for="totp-description" class="form-label">{{ _('説明 (任意)') }}</label>
-            <textarea id="totp-description" name="description" class="form-control" rows="2"></textarea>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">{{ _('QR コードから読み込む') }}</label>
-            <input type="file" accept="image/*" id="totp-qr-upload" class="form-control">
-            <div class="d-flex gap-2 mt-2">
-              <button type="button" class="btn btn-outline-secondary btn-sm" id="totp-qr-paste-btn">
-                <i class="bi bi-clipboard-plus me-1"></i>{{ _('クリップボードから貼り付け') }}
+            <div class="mb-3">
+              <label for="totp-secret" class="form-label">{{ _('シークレット') }}</label>
+              <input type="text" id="totp-secret" name="secret" class="form-control" required placeholder="JBSWY3DPEHPK3PXP">
+              <div class="form-text">{{ _('空白やハイフンは自動で除去されます (Base32)') }}</div>
+            </div>
+            <div class="row">
+              <div class="col-6 mb-3">
+                <label for="totp-digits" class="form-label">{{ _('桁数') }}</label>
+                <input type="number" id="totp-digits" name="digits" class="form-control" min="4" max="10" value="6">
+              </div>
+              <div class="col-6 mb-3">
+                <label for="totp-period" class="form-label">{{ _('有効期間 (秒)') }}</label>
+                <input type="number" id="totp-period" name="period" class="form-control" min="15" max="120" value="30">
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="totp-description" class="form-label">{{ _('説明 (任意)') }}</label>
+              <textarea id="totp-description" name="description" class="form-control" rows="2"></textarea>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">{{ _('QR コードから読み込む') }}</label>
+              <input type="file" accept="image/*" id="totp-qr-upload" class="form-control">
+              <div class="d-flex gap-2 mt-2">
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="totp-qr-paste-btn">
+                  <i class="bi bi-clipboard-plus me-1"></i>{{ _('クリップボードから貼り付け') }}
+                </button>
+              </div>
+              <div class="form-text">{{ _('クリップボードの画像から QR を読み取ります') }}</div>
+              <canvas id="totp-qr-canvas" class="d-none"></canvas>
+              <img id="totp-qr-preview" class="mt-2 rounded shadow-sm d-none qr-preview" alt="QR preview">
+            </div>
+            <div class="mb-3">
+              <label for="totp-otpauth" class="form-label">{{ _('otpauth URI (任意)') }}</label>
+              <input type="text" id="totp-otpauth" class="form-control" placeholder="otpauth://totp/Example:alice@example.com?...">
+              <div class="form-text">{{ _('URI を貼り付けて「URI を展開」を押すとフォームへ展開します') }}</div>
+            </div>
+            <div class="d-flex justify-content-between">
+              <button type="button" class="btn btn-outline-secondary" id="totp-parse-uri-btn">
+                <i class="bi bi-link-45deg me-1"></i>{{ _('URI を展開') }}
+              </button>
+              <button type="submit" class="btn btn-primary">
+                <i class="bi bi-plus-circle me-1"></i>{{ _('登録') }}
               </button>
             </div>
-            <div class="form-text">{{ _('クリップボードの画像から QR を読み取ります') }}</div>
-            <canvas id="totp-qr-canvas" class="d-none"></canvas>
-            <img id="totp-qr-preview" class="mt-2 rounded shadow-sm d-none qr-preview" alt="QR preview">
-          </div>
-          <div class="mb-3">
-            <label for="totp-otpauth" class="form-label">{{ _('otpauth URI (任意)') }}</label>
-            <input type="text" id="totp-otpauth" class="form-control" placeholder="otpauth://totp/Example:alice@example.com?...">
-            <div class="form-text">{{ _('URI を貼り付けて「URI を展開」を押すとフォームへ展開します') }}</div>
-          </div>
-          <div class="d-flex justify-content-between">
-            <button type="button" class="btn btn-outline-secondary" id="totp-parse-uri-btn">
-              <i class="bi bi-link-45deg me-1"></i>{{ _('URI を展開') }}
-            </button>
-            <button type="submit" class="btn btn-primary">
-              <i class="bi bi-plus-circle me-1"></i>{{ _('登録') }}
-            </button>
-          </div>
-        </form>
-      </div>
-      <div class="card-footer">
-        <div class="d-flex align-items-center justify-content-between">
-          <div>
-            <small class="text-muted d-block">{{ _('現在のプレビュー') }}</small>
-            <div class="otp-code" id="totp-preview-code">------</div>
-          </div>
-          <div class="w-50">
-            <div class="progress otp-progress">
-              <div class="progress-bar" id="totp-preview-progress" role="progressbar" style="width: 0%"></div>
+          </form>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex align-items-center justify-content-between">
+            <div>
+              <small class="text-muted d-block">{{ _('現在のプレビュー') }}</small>
+              <div class="otp-code" id="totp-preview-code">------</div>
             </div>
-            <small class="text-muted" id="totp-preview-remaining">{{ _('残り -- 秒') }}</small>
+            <div class="w-50">
+              <div class="progress otp-progress">
+                <div class="progress-bar" id="totp-preview-progress" role="progressbar" style="width: 0%"></div>
+              </div>
+              <small class="text-muted" id="totp-preview-remaining">{{ _('残り -- 秒') }}</small>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a collapse toggle to the TOTP registration card so the form is hidden by default
- keep the preview badge visible and add an expanding chevron with rotation styling

## Testing
- pytest tests/test_api_totp_management.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ef5fc0a6c48323abe6a675267a4011