### PR TITLE
refactor: internationalize wiki templates

### DIFF
--- a/features/wiki/presentation/wiki/templates/wiki/admin.html
+++ b/features/wiki/presentation/wiki/templates/wiki/admin.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Wiki管理 - {{ _('AppName') }}{% endblock %}
+{% block title %}{{ _('Wiki Administration') }} - {{ _('AppName') }}{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,20 +11,20 @@
     <div class="row">
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1><i class="fas fa-cogs"></i> Wiki管理</h1>
+                <h1><i class="fas fa-cogs"></i> {{ _('Wiki Administration') }}</h1>
                 <a href="{{ url_for('wiki.index') }}" class="btn btn-outline-secondary">
-                    <i class="fas fa-arrow-left"></i> Wiki トップに戻る
+                    <i class="fas fa-arrow-left"></i> {{ _('Back to Wiki Home') }}
                 </a>
             </div>
 
-            <!-- 統計情報 -->
+            <!-- Statistics -->
             <div class="row mb-4">
                 <div class="col-md-4">
                     <div class="card">
                         <div class="card-body text-center">
                             <i class="fas fa-file-alt fa-2x text-primary mb-2"></i>
                             <h3 class="mb-0">{{ stats.total_pages }}</h3>
-                            <p class="text-muted mb-0">総ページ数</p>
+                            <p class="text-muted mb-0">{{ _('Total Pages') }}</p>
                         </div>
                     </div>
                 </div>
@@ -33,7 +33,7 @@
                         <div class="card-body text-center">
                             <i class="fas fa-tags fa-2x text-success mb-2"></i>
                             <h3 class="mb-0">{{ stats.total_categories }}</h3>
-                            <p class="text-muted mb-0">カテゴリ数</p>
+                            <p class="text-muted mb-0">{{ _('Total Categories') }}</p>
                         </div>
                     </div>
                 </div>
@@ -42,26 +42,26 @@
                         <div class="card-body text-center">
                             <i class="fas fa-clock fa-2x text-info mb-2"></i>
                             <h3 class="mb-0">{{ stats.recent_pages|length }}</h3>
-                            <p class="text-muted mb-0">最近のページ</p>
+                            <p class="text-muted mb-0">{{ _('Recent Pages') }}</p>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <!-- 管理メニュー -->
+            <!-- Administration menu -->
             <div class="row mb-4">
                 <div class="col-md-6">
                     <div class="card">
                         <div class="card-header">
-                            <h5><i class="fas fa-plus"></i> 新規作成</h5>
+                            <h5><i class="fas fa-plus"></i> {{ _('Create New') }}</h5>
                         </div>
                         <div class="card-body">
                             <div class="d-grid gap-2">
                                 <a href="{{ url_for('wiki.create_page') }}" class="btn btn-primary">
-                                    <i class="fas fa-file-alt"></i> 新しいページを作成
+                                    <i class="fas fa-file-alt"></i> {{ _('Create New Page') }}
                                 </a>
                                 <a href="{{ url_for('wiki.create_category') }}" class="btn btn-success">
-                                    <i class="fas fa-tag"></i> 新しいカテゴリを作成
+                                    <i class="fas fa-tag"></i> {{ _('Create New Category') }}
                                 </a>
                             </div>
                         </div>
@@ -70,15 +70,15 @@
                 <div class="col-md-6">
                     <div class="card">
                         <div class="card-header">
-                            <h5><i class="fas fa-list"></i> 管理機能</h5>
+                            <h5><i class="fas fa-list"></i> {{ _('Administration Tools') }}</h5>
                         </div>
                         <div class="card-body">
                             <div class="d-grid gap-2">
                                 <a href="{{ url_for('wiki.categories') }}" class="btn btn-outline-primary">
-                                    <i class="fas fa-tags"></i> カテゴリ管理
+                                    <i class="fas fa-tags"></i> {{ _('Manage Categories') }}
                                 </a>
                                 <a href="{{ url_for('wiki.search') }}" class="btn btn-outline-secondary">
-                                    <i class="fas fa-search"></i> ページ検索
+                                    <i class="fas fa-search"></i> {{ _('Search Pages') }}
                                 </a>
                             </div>
                         </div>
@@ -86,11 +86,11 @@
                 </div>
             </div>
 
-            <!-- 最近のページ -->
+            <!-- Recent pages -->
             {% if stats.recent_pages %}
             <div class="card">
                 <div class="card-header">
-                    <h5><i class="fas fa-clock"></i> 最近更新されたページ</h5>
+                    <h5><i class="fas fa-clock"></i> {{ _('Recently Updated Pages') }}</h5>
                 </div>
                 <div class="card-body">
                     <div class="list-group list-group-flush">
@@ -132,7 +132,7 @@
                 </div>
                 <div class="card-footer">
                     <a href="{{ url_for('wiki.index') }}" class="btn btn-sm btn-outline-primary">
-                        すべてのページを表示
+                        {{ _('View All Pages') }}
                     </a>
                 </div>
             </div>

--- a/features/wiki/presentation/wiki/templates/wiki/categories.html
+++ b/features/wiki/presentation/wiki/templates/wiki/categories.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}カテゴリ一覧 - Wiki{% endblock %}
+{% block title %}{{ _('Category List') }} - Wiki{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,13 +11,13 @@
     <div class="row">
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1>カテゴリ一覧</h1>
+                <h1>{{ _('Category List') }}</h1>
                 <div>
                     <a href="{{ url_for('wiki.create_category') }}" class="btn btn-primary me-2">
-                        <i class="fas fa-plus"></i> 新規カテゴリ
+                        <i class="fas fa-plus"></i> {{ _('New Category') }}
                     </a>
                     <a href="{{ url_for('wiki.index') }}" class="btn btn-outline-secondary">
-                        <i class="fas fa-arrow-left"></i> Wiki トップ
+                        <i class="fas fa-arrow-left"></i> {{ _('Wiki Home') }}
                     </a>
                 </div>
             </div>
@@ -35,7 +35,7 @@
                                 </a>
                             </h6>
                             <span class="badge bg-secondary">
-                                {{ category.page_count }}ページ
+                                {{ _('%(count)s pages', count=category.page_count) }}
                             </span>
                         </div>
                         <div class="card-body">
@@ -45,24 +45,24 @@
                             </p>
                             {% else %}
                             <p class="card-text text-muted fst-italic">
-                                説明なし
+                                {{ _('No description') }}
                             </p>
                             {% endif %}
-                            
+
                             <div class="small text-muted">
-                                <div>スラッグ: {{ category.slug }}</div>
-                                <div>作成日: {{ category.created_at|localtime('%Y/%m/%d') }}</div>
+                                <div>{{ _('Slug: %(slug)s', slug=category.slug) }}</div>
+                                <div>{{ _('Created: %(date)s', date=category.created_at|localtime('%Y/%m/%d')) }}</div>
                             </div>
                         </div>
                         <div class="card-footer">
                             <div class="d-flex justify-content-between">
                                 <a href="{{ url_for('wiki.view_category', slug=category.slug) }}" 
                                    class="btn btn-sm btn-outline-primary">
-                                    <i class="fas fa-eye"></i> 表示
+                                    <i class="fas fa-eye"></i> {{ _('View') }}
                                 </a>
-                                <a href="{{ url_for('wiki.create_page') }}?category={{ category.id }}" 
+                                <a href="{{ url_for('wiki.create_page') }}?category={{ category.id }}"
                                    class="btn btn-sm btn-outline-success">
-                                    <i class="fas fa-plus"></i> ページ作成
+                                    <i class="fas fa-plus"></i> {{ _('Create Page') }}
                                 </a>
                             </div>
                         </div>
@@ -74,12 +74,12 @@
             <div class="card">
                 <div class="card-body text-center py-5">
                     <i class="fas fa-tags fa-3x text-muted mb-3"></i>
-                    <h5 class="text-muted">カテゴリがまだありません</h5>
+                    <h5 class="text-muted">{{ _('There are no categories yet') }}</h5>
                     <p class="text-muted">
-                        最初のカテゴリを作成してページを整理しましょう。
+                        {{ _('Create the first category to organize your pages.') }}
                     </p>
                     <a href="{{ url_for('wiki.create_category') }}" class="btn btn-primary">
-                        <i class="fas fa-plus"></i> カテゴリを作成
+                        <i class="fas fa-plus"></i> {{ _('Create Category') }}
                     </a>
                 </div>
             </div>

--- a/features/wiki/presentation/wiki/templates/wiki/category.html
+++ b/features/wiki/presentation/wiki/templates/wiki/category.html
@@ -14,22 +14,22 @@
                 <div>
                     <h1>
                         <i class="fas fa-tag"></i> {{ category.name }}
-                        <span class="badge bg-secondary">{{ pages|length }}ページ</span>
+                        <span class="badge bg-secondary">{{ _('%(count)s pages', count=pages|length) }}</span>
                     </h1>
                     {% if category.description %}
                     <p class="text-muted">{{ category.description }}</p>
                     {% endif %}
                 </div>
                 <a href="{{ url_for('wiki.index') }}" class="btn btn-outline-secondary">
-                    <i class="fas fa-arrow-left"></i> Wiki トップに戻る
+                    <i class="fas fa-arrow-left"></i> {{ _('Back to Wiki Home') }}
                 </a>
             </div>
 
-            <!-- カテゴリ内ページ一覧 -->
+            <!-- Category pages -->
             {% if pages %}
             <div class="card">
                 <div class="card-header">
-                    <h5>このカテゴリのページ</h5>
+                    <h5>{{ _('Pages in this Category') }}</h5>
                 </div>
                 <div class="card-body p-0">
                     <div class="list-group list-group-flush">
@@ -44,7 +44,7 @@
                                         </a>
                                         {% if page.parent %}
                                         <small class="text-muted">
-                                            ({{ page.parent.title }} の子ページ)
+                                            ({{ _('%(title)s child page', title=page.parent.title) }})
                                         </small>
                                         {% endif %}
                                     </h6>
@@ -54,7 +54,7 @@
                                     <small class="text-muted">
                                         <i class="fas fa-user"></i> {{ page.created_by.display_name if page.created_by else _('Unknown') }}
                                         <span class="mx-2">|</span>
-                                        <i class="fas fa-calendar"></i> 更新: {{ page.updated_at|localtime('%Y/%m/%d %H:%M') }}
+                                        <i class="fas fa-calendar"></i> {{ _('Updated: %(datetime)s', datetime=page.updated_at|localtime('%Y/%m/%d %H:%M')) }}
                                         {% if page.categories|length > 1 %}
                                         <span class="mx-2">|</span>
                                         <i class="fas fa-tags"></i>
@@ -84,29 +84,29 @@
             <div class="card">
                 <div class="card-body text-center py-5">
                     <i class="fas fa-file-alt fa-3x text-muted mb-3"></i>
-                    <h5 class="text-muted">このカテゴリにはまだページがありません</h5>
+                    <h5 class="text-muted">{{ _('There are no pages in this category yet') }}</h5>
                     <p class="text-muted">
-                        最初のページを作成してみましょう。
+                        {{ _('Create the first page to get started.') }}
                     </p>
                     <a href="{{ url_for('wiki.create_page') }}" class="btn btn-primary">
-                        <i class="fas fa-plus"></i> ページを作成
+                        <i class="fas fa-plus"></i> {{ _('Create Page') }}
                     </a>
                 </div>
             </div>
             {% endif %}
 
-            <!-- 関連アクション -->
+            <!-- Related actions -->
             <div class="mt-4">
                 <div class="row">
                     <div class="col-md-6">
                         <div class="card">
                             <div class="card-header">
-                                <h6>このカテゴリで</h6>
+                                <h6>{{ _('Within this Category') }}</h6>
                             </div>
                             <div class="card-body">
-                                <a href="{{ url_for('wiki.create_page') }}?category={{ category.id }}" 
+                                <a href="{{ url_for('wiki.create_page') }}?category={{ category.id }}"
                                    class="btn btn-primary btn-sm me-2">
-                                    <i class="fas fa-plus"></i> 新しいページを作成
+                                    <i class="fas fa-plus"></i> {{ _('Create New Page') }}
                                 </a>
                             </div>
                         </div>
@@ -114,13 +114,13 @@
                     <div class="col-md-6">
                         <div class="card">
                             <div class="card-header">
-                                <h6>カテゴリ情報</h6>
+                                <h6>{{ _('Category Information') }}</h6>
                             </div>
                             <div class="card-body">
                                 <small class="text-muted">
-                                    <div>スラッグ: {{ category.slug }}</div>
-                                    <div>作成日: {{ category.created_at|localtime('%Y/%m/%d') }}</div>
-                                    <div>ページ数: {{ pages|length }}</div>
+                                    <div>{{ _('Slug: %(slug)s', slug=category.slug) }}</div>
+                                    <div>{{ _('Created: %(date)s', date=category.created_at|localtime('%Y/%m/%d')) }}</div>
+                                    <div>{{ _('Number of Pages: %(count)s', count=pages|length) }}</div>
                                 </small>
                             </div>
                         </div>

--- a/features/wiki/presentation/wiki/templates/wiki/create.html
+++ b/features/wiki/presentation/wiki/templates/wiki/create.html
@@ -21,55 +21,55 @@
                 <div class="row">
                     <div class="col-md-8">
                         <div class="mb-3">
-                            <label for="title" class="form-label">タイトル <span class="text-danger">*</span></label>
+                            <label for="title" class="form-label">{{ _('Title') }} <span class="text-danger">*</span></label>
                             <input type="text" class="form-control" id="title" name="title" 
                                    value="{{ request.form.get('title', '') }}" required>
                         </div>
 
                         <div class="mb-3">
-                            <label for="slug" class="form-label">スラッグ</label>
+                            <label for="slug" class="form-label">{{ _('Slug') }}</label>
                             <input type="text" class="form-control" id="slug" name="slug" 
                                    value="{{ request.form.get('slug', '') }}"
-                                   placeholder="自動生成されます（カスタムも可能）">
+                                   placeholder="{{ _('Generated automatically (customizable)') }}">
                             <div class="form-text">
-                                URLで使用される識別子です。英数字、ハイフン、アンダースコアが使用できます。
+                                {{ _('This identifier is used in the URL. Letters, numbers, hyphens, and underscores are allowed.') }}
                             </div>
                         </div>
 
                         <div class="mb-3">
                             <div class="d-flex justify-content-between align-items-center mb-2">
-                                <label for="content" class="form-label">内容 <span class="text-danger">*</span></label>
+                                <label for="content" class="form-label">{{ _('Content') }} <span class="text-danger">*</span></label>
                                 <div class="btn-group btn-group-sm" role="group">
                                     <input type="radio" class="btn-check" name="editor-mode" id="edit-mode" checked>
                                     <label class="btn btn-outline-secondary" for="edit-mode">
-                                        <i class="fas fa-edit"></i> 編集
+                                        <i class="fas fa-edit"></i> {{ _('Edit') }}
                                     </label>
                                     <input type="radio" class="btn-check" name="editor-mode" id="preview-mode">
                                     <label class="btn btn-outline-secondary" for="preview-mode">
-                                        <i class="fas fa-eye"></i> プレビュー
+                                        <i class="fas fa-eye"></i> {{ _('Preview') }}
                                     </label>
                                 </div>
                             </div>
                             
-                            <!-- 編集モード -->
+                            <!-- Edit mode -->
                             <div id="editor-container">
                                 <textarea class="form-control" id="content" name="content" rows="15" required>{{ request.form.get('content', '') }}</textarea>
                             </div>
                             
-                            <!-- プレビューモード -->
+                            <!-- Preview mode -->
                             <div id="preview-container" style="display: none;">
                                 <div class="card">
                                     <div class="card-body">
                                         <div id="preview-content" class="wiki-content">
-                                            <p class="text-muted">プレビューを読み込み中...</p>
+                                            <p class="text-muted">{{ _('Loading preview...') }}</p>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                             
                             <div class="form-text">
-                                Markdownをサポートしています。http:やhttps:で始まるURLは自動的にリンクになります。<br>
-                                <strong>図表サポート:</strong> Mermaidは <code>```mermaid</code> でコードブロックを作成できます。
+                                {{ _('Markdown is supported. URLs starting with http: or https: are automatically linked.') }}<br>
+                                <strong>{{ _('Diagram Support:') }}</strong> {{ _('Use <code>```mermaid</code> to create Mermaid diagrams.') }}
                             </div>
                         </div>
                     </div>
@@ -77,13 +77,13 @@
                     <div class="col-md-4">
                         <div class="card">
                             <div class="card-header">
-                                <h6>設定</h6>
+                                <h6>{{ _('Settings') }}</h6>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <label for="parent_id" class="form-label">親ページ</label>
+                                    <label for="parent_id" class="form-label">{{ _('Parent Page') }}</label>
                                     <select class="form-select" id="parent_id" name="parent_id">
-                                        <option value="">なし（トップレベル）</option>
+                                        <option value="">{{ _('None (top level)') }}</option>
                                         {% for page in pages %}
                                         <option value="{{ page.id }}" 
                                                 {% if request.form.get('parent_id') == page.id|string %}selected{% endif %}>
@@ -92,12 +92,12 @@
                                         {% endfor %}
                                     </select>
                                     <div class="form-text">
-                                        このページを子ページとして配置する親ページを選択
+                                        {{ _('Select a parent page to nest this page beneath it.') }}
                                     </div>
                                 </div>
 
                                 <div class="mb-3">
-                                    <label class="form-label">カテゴリ</label>
+                                    <label class="form-label">{{ _('Categories') }}</label>
                                     {% for category in categories %}
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" 
@@ -111,17 +111,17 @@
                                     {% endfor %}
                                     
                                     {% if not categories %}
-                                    <p class="text-muted small">カテゴリがありません。</p>
+                                    <p class="text-muted small">{{ _('No categories available.') }}</p>
                                     {% endif %}
                                 </div>
 
                                 <div class="d-grid gap-2">
                                     <button type="submit" class="btn btn-primary">
-                                        <i class="fas fa-plus"></i> ページを作成
+                                        <i class="fas fa-plus"></i> {{ _('Create Page') }}
                                     </button>
-                                    <a href="{{ url_for('wiki.index') }}" 
+                                    <a href="{{ url_for('wiki.index') }}"
                                        class="btn btn-outline-secondary">
-                                        キャンセル
+                                        {{ _('Cancel') }}
                                     </a>
                                 </div>
                             </div>
@@ -129,17 +129,17 @@
 
                         <div class="card mt-3">
                             <div class="card-header">
-                                <h6>ヘルプ</h6>
+                                <h6>{{ _('Help') }}</h6>
                             </div>
                             <div class="card-body">
                                 <div class="small">
-                                    <h6>Markdown例:</h6>
-                                    <pre class="small"># 見出し1
-## 見出し2
-**太字**
-*斜体*
-[リンク](URL)
-- リスト項目</pre>
+                                    <h6>{{ _('Markdown Examples:') }}</h6>
+                                    <pre class="small"># {{ _('Heading 1') }}
+## {{ _('Heading 2') }}
+**{{ _('Bold') }}**
+*{{ _('Italic') }}*
+[{{ _('Link') }}](URL)
+- {{ _('List item') }}</pre>
                                 </div>
                             </div>
                         </div>
@@ -151,7 +151,7 @@
 </div>
 
 <script>
-// タイトル入力時に自動でスラッグを生成
+// Automatically generate the slug from the title input
 document.getElementById('title').addEventListener('input', function() {
     const slugField = document.getElementById('slug');
     if (!slugField.value || slugField.value === generateSlug(slugField.dataset.lastTitle || '')) {
@@ -176,7 +176,7 @@ contentTextarea.addEventListener('input', function() {
     this.style.height = this.scrollHeight + 'px';
 });
 
-// プレビュー機能
+// Preview functionality
 const editModeRadio = document.getElementById('edit-mode');
 const previewModeRadio = document.getElementById('preview-mode');
 const editorContainer = document.getElementById('editor-container');
@@ -185,7 +185,7 @@ const previewContent = document.getElementById('preview-content');
 
 let previewTimeout;
 
-// モード切り替え
+// Switch editor/preview mode
 function switchMode() {
     if (editModeRadio.checked) {
         editorContainer.style.display = 'block';
@@ -200,16 +200,16 @@ function switchMode() {
 editModeRadio.addEventListener('change', switchMode);
 previewModeRadio.addEventListener('change', switchMode);
 
-// プレビュー更新
+// Update preview content
 function updatePreview() {
     const content = contentTextarea.value;
     
     if (!content.trim()) {
-        previewContent.innerHTML = '<p class="text-muted">プレビューするコンテンツがありません</p>';
+        previewContent.innerHTML = '<p class="text-muted">{{ _('There is no content to preview') }}</p>';
         return;
     }
-    
-    previewContent.innerHTML = '<p class="text-muted">プレビューを読み込み中...</p>';
+
+    previewContent.innerHTML = '<p class="text-muted">{{ _('Loading preview...') }}</p>';
     
     fetch('{{ url_for("wiki.api_preview") }}', {
         method: 'POST',
@@ -225,16 +225,16 @@ function updatePreview() {
         previewContent.innerHTML = data.html;
     })
     .catch(error => {
-        console.error('プレビューエラー:', error);
-        previewContent.innerHTML = '<p class="text-danger">プレビューの読み込みに失敗しました</p>';
+        console.error('{{ _('Preview error:') }}', error);
+        previewContent.innerHTML = '<p class="text-danger">{{ _('Failed to load preview') }}</p>';
     });
 }
 
-// プレビューモードの時は定期的に更新
+// Refresh regularly while preview mode is active
 contentTextarea.addEventListener('input', function() {
     if (previewModeRadio.checked) {
         clearTimeout(previewTimeout);
-        previewTimeout = setTimeout(updatePreview, 1000); // 1秒後に更新
+        previewTimeout = setTimeout(updatePreview, 1000); // Update after 1 second
     }
 });
 </script>

--- a/features/wiki/presentation/wiki/templates/wiki/create_category.html
+++ b/features/wiki/presentation/wiki/templates/wiki/create_category.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}新規カテゴリ作成 - Wiki{% endblock %}
+{% block title %}{{ _('Create New Category') }} - Wiki{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,9 +11,9 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1>新規カテゴリ作成</h1>
+                <h1>{{ _('Create New Category') }}</h1>
                 <a href="{{ url_for('wiki.categories') }}" class="btn btn-outline-secondary">
-                    <i class="fas fa-arrow-left"></i> カテゴリ一覧に戻る
+                    <i class="fas fa-arrow-left"></i> {{ _('Back to Categories') }}
                 </a>
             </div>
 
@@ -21,56 +21,56 @@
                 <div class="card-body">
                     <form method="POST">
                         <div class="mb-3">
-                            <label for="name" class="form-label">カテゴリ名 <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="name" name="name" 
+                            <label for="name" class="form-label">{{ _('Category Name') }} <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="name" name="name"
                                    value="{{ request.form.get('name', '') }}" required>
                             <div class="form-text">
-                                わかりやすいカテゴリ名を入力してください
+                                {{ _('Choose a descriptive category name.') }}
                             </div>
                         </div>
 
                         <div class="mb-3">
-                            <label for="slug" class="form-label">スラッグ</label>
-                            <input type="text" class="form-control" id="slug" name="slug" 
+                            <label for="slug" class="form-label">{{ _('Slug') }}</label>
+                            <input type="text" class="form-control" id="slug" name="slug"
                                    value="{{ request.form.get('slug', '') }}"
-                                   placeholder="自動生成されます（カスタムも可能）">
+                                   placeholder="{{ _('Generated automatically (customizable)') }}">
                             <div class="form-text">
-                                URLで使用される識別子です。英数字、ハイフン、アンダースコアが使用できます。
+                                {{ _('This identifier is used in the URL. Letters, numbers, hyphens, and underscores are allowed.') }}
                             </div>
                         </div>
 
                         <div class="mb-3">
-                            <label for="description" class="form-label">説明</label>
+                            <label for="description" class="form-label">{{ _('Description') }}</label>
                             <textarea class="form-control" id="description" name="description" rows="3">{{ request.form.get('description', '') }}</textarea>
                             <div class="form-text">
-                                このカテゴリの用途や内容について説明してください（省略可）
+                                {{ _('Describe the purpose or contents of this category (optional).') }}
                             </div>
                         </div>
 
                         <div class="d-flex justify-content-end gap-2">
                             <a href="{{ url_for('wiki.categories') }}" class="btn btn-outline-secondary">
-                                キャンセル
+                                {{ _('Cancel') }}
                             </a>
                             <button type="submit" class="btn btn-primary">
-                                <i class="fas fa-plus"></i> カテゴリを作成
+                                <i class="fas fa-plus"></i> {{ _('Create Category') }}
                             </button>
                         </div>
                     </form>
                 </div>
             </div>
 
-            <!-- ヘルプ -->
+            <!-- Help -->
             <div class="card mt-4">
                 <div class="card-header">
-                    <h6>カテゴリについて</h6>
+                    <h6>{{ _('About Categories') }}</h6>
                 </div>
                 <div class="card-body">
                     <div class="small text-muted">
                         <ul class="mb-0">
-                            <li>カテゴリはWikiページを分類・整理するために使用します</li>
-                            <li>1つのページは複数のカテゴリに属することができます</li>
-                            <li>スラッグはURL生成に使用されるため、わかりやすい英数字で設定してください</li>
-                            <li>作成後もカテゴリの編集は可能です</li>
+                            <li>{{ _('Categories help organize Wiki pages.') }}</li>
+                            <li>{{ _('A single page can belong to multiple categories.') }}</li>
+                            <li>{{ _('Because the slug is used in URLs, choose clear alphanumeric characters.') }}</li>
+                            <li>{{ _('You can edit categories after they are created.') }}</li>
                         </ul>
                     </div>
                 </div>
@@ -80,7 +80,7 @@
 </div>
 
 <script>
-// カテゴリ名入力時に自動でスラッグを生成
+// Automatically generate the slug from the category name
 document.getElementById('name').addEventListener('input', function() {
     const slugField = document.getElementById('slug');
     if (!slugField.value || slugField.value === generateSlug(slugField.dataset.lastTitle || '')) {

--- a/features/wiki/presentation/wiki/templates/wiki/edit.html
+++ b/features/wiki/presentation/wiki/templates/wiki/edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}ページ編集: {{ page.title }} - Wiki{% endblock %}
+{% block title %}{{ _('Edit Page: %(title)s', title=page.title) }} - Wiki{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,9 +11,9 @@
     <div class="row">
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1>ページ編集: {{ page.title }}</h1>
+                <h1>{{ _('Edit Page: %(title)s', title=page.title) }}</h1>
                 <a href="{{ url_for('wiki.view_page', slug=page.slug) }}" class="btn btn-outline-secondary">
-                    <i class="fas fa-arrow-left"></i> ページに戻る
+                    <i class="fas fa-arrow-left"></i> {{ _('Back to Page') }}
                 </a>
             </div>
 
@@ -21,64 +21,64 @@
                 <div class="row">
                     <div class="col-md-8">
                         <div class="mb-3">
-                            <label for="title" class="form-label">タイトル <span class="text-danger">*</span></label>
+                            <label for="title" class="form-label">{{ _('Title') }} <span class="text-danger">*</span></label>
                             <input type="text" class="form-control" id="title" name="title" 
                                    value="{{ page.title }}" required>
                         </div>
 
                         <div class="mb-3">
                             <div class="d-flex justify-content-between align-items-center mb-2">
-                                <label for="content" class="form-label">内容 <span class="text-danger">*</span></label>
+                                <label for="content" class="form-label">{{ _('Content') }} <span class="text-danger">*</span></label>
                                 <div class="btn-group btn-group-sm" role="group">
                                     <input type="radio" class="btn-check" name="editor-mode" id="edit-mode" checked>
                                     <label class="btn btn-outline-secondary" for="edit-mode">
-                                        <i class="fas fa-edit"></i> 編集
+                                        <i class="fas fa-edit"></i> {{ _('Edit') }}
                                     </label>
                                     <input type="radio" class="btn-check" name="editor-mode" id="preview-mode">
                                     <label class="btn btn-outline-secondary" for="preview-mode">
-                                        <i class="fas fa-eye"></i> プレビュー
+                                        <i class="fas fa-eye"></i> {{ _('Preview') }}
                                     </label>
                                 </div>
                             </div>
                             
-                            <!-- 編集モード -->
+                            <!-- Edit mode -->
                             <div id="editor-container">
                                 <textarea class="form-control" id="content" name="content" rows="15" required>{{ page.content }}</textarea>
                             </div>
                             
-                            <!-- プレビューモード -->
+                            <!-- Preview mode -->
                             <div id="preview-container" style="display: none;">
                                 <div class="card">
                                     <div class="card-body">
                                         <div id="preview-content" class="wiki-content">
-                                            <p class="text-muted">プレビューを読み込み中...</p>
+                                            <p class="text-muted">{{ _('Loading preview...') }}</p>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                             
                             <div class="form-text">
-                                Markdownをサポートしています。http:やhttps:で始まるURLは自動的にリンクになります。<br>
-                                <strong>図表サポート:</strong> Mermaidは <code>```mermaid</code> でコードブロックを作成できます。
+                                {{ _('Markdown is supported. URLs starting with http: or https: are automatically linked.') }}<br>
+                                <strong>{{ _('Diagram Support:') }}</strong> {{ _('Use <code>```mermaid</code> to create Mermaid diagrams.') }}
                             </div>
                         </div>
 
                         <div class="mb-3">
-                            <label for="change_summary" class="form-label">変更概要</label>
-                            <input type="text" class="form-control" id="change_summary" name="change_summary" 
-                                   placeholder="どのような変更を行ったかを簡潔に説明してください">
-                            <div class="form-text">履歴で表示される変更の説明です（省略可）</div>
+                            <label for="change_summary" class="form-label">{{ _('Change Summary') }}</label>
+                            <input type="text" class="form-control" id="change_summary" name="change_summary"
+                                   placeholder="{{ _('Briefly describe the changes you made.') }}">
+                            <div class="form-text">{{ _('This description appears in history (optional).') }}</div>
                         </div>
                     </div>
 
                     <div class="col-md-4">
                         <div class="card">
                             <div class="card-header">
-                                <h6>設定</h6>
+                                <h6>{{ _('Settings') }}</h6>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <label class="form-label">カテゴリ</label>
+                                    <label class="form-label">{{ _('Categories') }}</label>
                                     {% for category in categories %}
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" 
@@ -92,7 +92,7 @@
                                     {% endfor %}
                                     
                                     {% if not categories %}
-                                    <p class="text-muted small">カテゴリがありません</p>
+                                    <p class="text-muted small">{{ _('No categories available.') }}</p>
                                     {% endif %}
                                 </div>
 
@@ -107,11 +107,11 @@
 
                                 <div class="d-grid gap-2">
                                     <button type="submit" class="btn btn-primary">
-                                        <i class="fas fa-save"></i> 保存
+                                        <i class="fas fa-save"></i> {{ _('Save') }}
                                     </button>
-                                    <a href="{{ url_for('wiki.view_page', slug=page.slug) }}" 
+                                    <a href="{{ url_for('wiki.view_page', slug=page.slug) }}"
                                        class="btn btn-outline-secondary">
-                                        キャンセル
+                                        {{ _('Cancel') }}
                                     </a>
                                 </div>
                             </div>
@@ -131,7 +131,7 @@ contentTextarea.addEventListener('input', function() {
     this.style.height = this.scrollHeight + 'px';
 });
 
-// プレビュー機能
+// Preview functionality
 const editModeRadio = document.getElementById('edit-mode');
 const previewModeRadio = document.getElementById('preview-mode');
 const editorContainer = document.getElementById('editor-container');
@@ -140,7 +140,7 @@ const previewContent = document.getElementById('preview-content');
 
 let previewTimeout;
 
-// モード切り替え
+// Switch editor/preview mode
 function switchMode() {
     if (editModeRadio.checked) {
         editorContainer.style.display = 'block';
@@ -155,16 +155,16 @@ function switchMode() {
 editModeRadio.addEventListener('change', switchMode);
 previewModeRadio.addEventListener('change', switchMode);
 
-// プレビュー更新
+// Update preview content
 function updatePreview() {
     const content = contentTextarea.value;
     
     if (!content.trim()) {
-        previewContent.innerHTML = '<p class="text-muted">プレビューするコンテンツがありません</p>';
+        previewContent.innerHTML = '<p class="text-muted">{{ _('There is no content to preview') }}</p>';
         return;
     }
-    
-    previewContent.innerHTML = '<p class="text-muted">プレビューを読み込み中...</p>';
+
+    previewContent.innerHTML = '<p class="text-muted">{{ _('Loading preview...') }}</p>';
     
     fetch('{{ url_for("wiki.api_preview") }}', {
         method: 'POST',
@@ -178,24 +178,24 @@ function updatePreview() {
     .then(response => response.json())
     .then(data => {
         previewContent.innerHTML = data.html;
-        // Mermaidを再レンダリング
+        // Re-render Mermaid diagrams
         reRenderMermaid();
     })
     .catch(error => {
-        console.error('プレビューエラー:', error);
-        previewContent.innerHTML = '<p class="text-danger">プレビューの読み込みに失敗しました</p>';
+        console.error('{{ _('Preview error:') }}', error);
+        previewContent.innerHTML = '<p class="text-danger">{{ _('Failed to load preview') }}</p>';
     });
 }
 
-// プレビューモードの時は定期的に更新
+// Refresh regularly while preview mode is active
 contentTextarea.addEventListener('input', function() {
     if (previewModeRadio.checked) {
         clearTimeout(previewTimeout);
-        previewTimeout = setTimeout(updatePreview, 1000); // 1秒後に更新
+        previewTimeout = setTimeout(updatePreview, 1000); // Update after 1 second
     }
 });
 
-// Mermaid初期化
+// Initialize Mermaid
 document.addEventListener('DOMContentLoaded', function() {
     if (typeof mermaid !== 'undefined') {
         mermaid.initialize({
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-// Mermaidソース表示/非表示
+// Toggle Mermaid source visibility
 function toggleMermaidSource(hash) {
     const sourceDiv = document.getElementById('mermaid-source-' + hash);
     const button = event.target.closest('button');
@@ -214,18 +214,18 @@ function toggleMermaidSource(hash) {
     if (sourceDiv.classList.contains('show')) {
         sourceDiv.classList.remove('show');
         button.innerHTML = '<i class="fas fa-code"></i>';
-        button.title = 'ソースコードを表示';
+        button.title = '{{ _('Show source code') }}';
     } else {
         sourceDiv.classList.add('show');
         button.innerHTML = '<i class="fas fa-eye-slash"></i>';
-        button.title = 'ソースコードを非表示';
+        button.title = '{{ _('Hide source code') }}';
     }
 }
 
-// プレビューでMermaidを再レンダリング
+// Re-render Mermaid diagrams within the preview
 function reRenderMermaid() {
     if (typeof mermaid !== 'undefined') {
-        // プレビューエリア内のMermaidを再レンダリング
+        // Re-render Mermaid in the preview area
         const previewContent = document.getElementById('preview-content');
         if (previewContent) {
             const mermaidElements = previewContent.querySelectorAll('.mermaid');
@@ -238,7 +238,7 @@ function reRenderMermaid() {
 </script>
 
 <style>
-/* プレビュー用の図表スタイル */
+/* Preview diagram styles */
 .mermaid-diagram {
     margin: 1rem 0;
     border: 1px solid #dee2e6;
@@ -263,11 +263,11 @@ function reRenderMermaid() {
 .diagram-source {
     background-color: #f8f9fa;
     border-top: 1px solid #dee2e6;
-    display: none !important; /* 確実に非表示にする */
+    display: none !important; /* Ensure the section stays hidden */
 }
 
 .diagram-source.show {
-    display: block !important; /* 表示時のクラス */
+    display: block !important; /* Shown when toggled */
 }
 
 .diagram-source pre {

--- a/features/wiki/presentation/wiki/templates/wiki/history.html
+++ b/features/wiki/presentation/wiki/templates/wiki/history.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ page.title }} の履歴 - Wiki{% endblock %}
+{% block title %}{{ _('History for %(title)s', title=page.title) }} - Wiki{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,22 +11,22 @@
     <div class="row">
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1>{{ page.title }} の履歴</h1>
+                <h1>{{ _('History for %(title)s', title=page.title) }}</h1>
                 <div>
                     <a href="{{ url_for('wiki.view_page', slug=page.slug) }}" 
                        class="btn btn-outline-primary me-2">
-                        <i class="fas fa-eye"></i> ページを表示
+                        <i class="fas fa-eye"></i> {{ _('View Page') }}
                     </a>
                     {% if current_user.is_authenticated and page.created_by_id == current_user.id %}
                     <a href="{{ url_for('wiki.edit_page', slug=page.slug) }}" 
                        class="btn btn-outline-secondary">
-                        <i class="fas fa-edit"></i> 編集
+                        <i class="fas fa-edit"></i> {{ _('Edit') }}
                     </a>
                     {% endif %}
                 </div>
             </div>
 
-            <!-- ページ情報 -->
+            <!-- Page information -->
             <div class="card mb-4">
                 <div class="card-body">
                     <div class="row">
@@ -51,7 +51,7 @@
                 </div>
             </div>
 
-            <!-- 履歴一覧 -->
+            <!-- Revision list -->
             {% if revisions %}
             <div class="card">
                 <div class="card-header">
@@ -106,7 +106,7 @@
                                 </div>
                             </div>
                             
-                            <!-- リビジョン内容（初期は非表示） -->
+                            <!-- Revision content (hidden by default) -->
                             <div id="revision-content-{{ revision.id }}" class="revision-content mt-3" style="display: none;">
                                 <div class="border-top pt-3">
                                     <h6>{{ _('Page content at this point') }}:</h6>
@@ -132,7 +132,7 @@
             </div>
             {% endif %}
 
-            <!-- ナビゲーション -->
+            <!-- Navigation -->
             <div class="mt-4">
                 <a href="{{ url_for('wiki.view_page', slug=page.slug) }}" class="btn btn-primary">
                     <i class="fas fa-arrow-left"></i> {{ _('Back to Page') }}

--- a/features/wiki/presentation/wiki/templates/wiki/index.html
+++ b/features/wiki/presentation/wiki/templates/wiki/index.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="container-fluid">
     <div class="row">
-        <!-- サイドバー -->
+        <!-- Sidebar -->
         <div class="col-md-3">
             <div class="card">
                 <div class="card-header">
@@ -54,7 +54,7 @@
             </div>
         </div>
         
-        <!-- メインコンテンツ -->
+        <!-- Main content -->
         <div class="col-md-9">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h1>Wiki</h1>
@@ -75,7 +75,7 @@
                 </div>
             </div>
             
-            <!-- 検索フォーム -->
+            <!-- Search form -->
             <div class="card mb-4">
                 <div class="card-body">
                     <form method="GET" action="{{ url_for('wiki.search') }}">
@@ -90,7 +90,7 @@
                 </div>
             </div>
             
-            <!-- 最近更新されたページ -->
+            <!-- Recently updated pages -->
             <div class="card">
                 <div class="card-header">
                     <h5>{{ _('Recently Updated Pages') }}</h5>

--- a/features/wiki/presentation/wiki/templates/wiki/page.html
+++ b/features/wiki/presentation/wiki/templates/wiki/page.html
@@ -199,7 +199,7 @@
     overflow-x: auto;
 }
 
-/* 図表関連のスタイル */
+/* Diagram-related styles */
 .mermaid-diagram {
     margin: 1rem 0;
     border: 1px solid #dee2e6;
@@ -224,11 +224,11 @@
 .diagram-source {
     background-color: #f8f9fa;
     border-top: 1px solid #dee2e6;
-    display: none !important; /* 確実に非表示にする */
+    display: none !important; /* Ensure the section stays hidden */
 }
 
 .diagram-source.show {
-    display: block !important; /* 表示時のクラス */
+    display: block !important; /* Shown when toggled */
 }
 
 .diagram-source pre {
@@ -243,7 +243,7 @@
 </style>
 
 <script>
-// Mermaid初期化
+// Initialize Mermaid
 document.addEventListener('DOMContentLoaded', function() {
     if (typeof mermaid !== 'undefined') {
         mermaid.initialize({
@@ -256,7 +256,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 
 
-// Mermaidソース表示/非表示
+// Toggle Mermaid source visibility
 function toggleMermaidSource(hash) {
     const sourceDiv = document.getElementById('mermaid-source-' + hash);
     const button = event.target.closest('button');
@@ -264,11 +264,11 @@ function toggleMermaidSource(hash) {
     if (sourceDiv.classList.contains('show')) {
         sourceDiv.classList.remove('show');
         button.innerHTML = '<i class="fas fa-code"></i>';
-        button.title = 'ソースコードを表示';
+        button.title = '{{ _('Show source code') }}';
     } else {
         sourceDiv.classList.add('show');
         button.innerHTML = '<i class="fas fa-eye-slash"></i>';
-        button.title = 'ソースコードを非表示';
+        button.title = '{{ _('Hide source code') }}';
     }
 }
 </script>

--- a/features/wiki/presentation/wiki/templates/wiki/search.html
+++ b/features/wiki/presentation/wiki/templates/wiki/search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}検索結果{% if query %}: {{ query }}{% endif %} - Wiki{% endblock %}
+{% block title %}{{ _('Search Results') }}{% if query %}: {{ query }}{% endif %} - Wiki{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='wiki/wiki.css') }}">
@@ -11,34 +11,34 @@
     <div class="row">
         <div class="col-md-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
-                <h1>Wiki検索</h1>
+                <h1>{{ _('Wiki Search') }}</h1>
                 <a href="{{ url_for('wiki.index') }}" class="btn btn-outline-secondary">
-                    <i class="fas fa-arrow-left"></i> Wiki トップに戻る
+                    <i class="fas fa-arrow-left"></i> {{ _('Back to Wiki Home') }}
                 </a>
             </div>
 
-            <!-- 検索フォーム -->
+            <!-- Search form -->
             <div class="card mb-4">
                 <div class="card-body">
                     <form method="GET">
                         <div class="input-group">
-                            <input type="text" name="q" class="form-control form-control-lg" 
-                                   placeholder="ページタイトルで検索..." value="{{ query }}" autofocus>
+                            <input type="text" name="q" class="form-control form-control-lg"
+                                   placeholder="{{ _('Search by page title...') }}" value="{{ query }}" autofocus>
                             <button type="submit" class="btn btn-primary">
-                                <i class="fas fa-search"></i> 検索
+                                <i class="fas fa-search"></i> {{ _('Search') }}
                             </button>
                         </div>
                     </form>
                 </div>
             </div>
 
-            <!-- 検索結果 -->
+            <!-- Search results -->
             {% if query %}
             <div class="card">
                 <div class="card-header">
                     <h5>
-                        検索結果: "{{ query }}" 
-                        <span class="badge bg-secondary">{{ pages|length }}件</span>
+                        {{ _('Search Results: "%(query)s"', query=query) }}
+                        <span class="badge bg-secondary">{{ _('%(count)s results', count=pages|length) }}</span>
                     </h5>
                 </div>
                 <div class="card-body">
@@ -77,22 +77,22 @@
                     {% else %}
                     <div class="text-center py-5">
                         <i class="fas fa-search fa-3x text-muted mb-3"></i>
-                        <h5 class="text-muted">検索結果が見つかりませんでした</h5>
+                        <h5 class="text-muted">{{ _('No search results found') }}</h5>
                         <p class="text-muted">
-                            "{{ query }}" に一致するページはありません。<br>
-                            異なるキーワードで検索してみてください。
+                            {{ _('No pages matched "%(query)s".', query=query) }}<br>
+                            {{ _('Try searching with different keywords.') }}
                         </p>
                     </div>
                     {% endif %}
                 </div>
             </div>
             {% else %}
-            <!-- 検索前の状態 -->
+            <!-- Before search -->
             <div class="text-center py-5">
                 <i class="fas fa-search fa-3x text-muted mb-3"></i>
-                <h5 class="text-muted">Wikiページを検索</h5>
+                <h5 class="text-muted">{{ _('Search Wiki Pages') }}</h5>
                 <p class="text-muted">
-                    上の検索ボックスにキーワードを入力してページを検索できます。
+                    {{ _('Enter a keyword in the search box above to find pages.') }}
                 </p>
             </div>
             {% endif %}
@@ -101,7 +101,7 @@
 </div>
 
 <script>
-// 検索ボックスにフォーカス
+// Focus the search box when appropriate
 document.addEventListener('DOMContentLoaded', function() {
     const searchInput = document.querySelector('input[name="q"]');
     if (searchInput && !searchInput.value) {


### PR DESCRIPTION
## Summary
- replace remaining Japanese copy in wiki templates with English defaults that leverage gettext
- internationalize page creation/editing helpers and related preview messaging
- translate search and history views while keeping navigation text consistent across the wiki

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef901b32388323a3b31e4381763e45