### PR TITLE
Fix pagination error template placeholder

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -158,7 +158,7 @@
       'pagination.loading.label': "{{ _('Loading...') }}",
       'pagination.loading.message': "{{ _('Loading more items...') }}",
       'pagination.end.message': "{{ _('No more items to display.') }}",
-      'pagination.error.template': "{{ _('Load error: %(message)s') }}",
+      'pagination.error.template': "{{ _('Load error: %(message)s', message='%(message)s') }}",
     });
   </script>
   <script src="{{ url_for('static', filename='js/timezone.js') }}"></script>


### PR DESCRIPTION
## Summary
- ensure the pagination error template translation provides the required placeholder argument to avoid runtime KeyError errors during rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efa177c2d88323966e2cbd34f84edd