### PR TITLE
Harden TOTP translations and UI helpers

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -47,6 +47,16 @@
     max-width: 200px;
     max-height: 200px;
   }
+  .qr-canvas-offscreen {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+  }
   .totp-layout {
     display: flex;
     flex-direction: column;
@@ -100,10 +110,10 @@
     </button>
   </div>
   <div class="d-flex gap-2">
-    <button class="btn btn-outline-secondary" id="totp-export-btn">
+    <button type="button" class="btn btn-outline-secondary" id="totp-export-btn">
       <i class="bi bi-download me-1"></i>{{ _('Export JSON') }}
     </button>
-    <button class="btn btn-outline-primary" id="totp-import-btn">
+    <button type="button" class="btn btn-outline-primary" id="totp-import-btn">
       <i class="bi bi-upload me-1"></i>{{ _('Import JSON') }}
     </button>
   </div>
@@ -157,7 +167,7 @@
               </button>
             </div>
             <div class="form-text">{{ _('クリップボードの画像から QR を読み取ります') }}</div>
-            <canvas id="totp-qr-canvas" class="d-none"></canvas>
+            <canvas id="totp-qr-canvas" class="qr-canvas-offscreen" aria-hidden="true"></canvas>
             <img id="totp-qr-preview" class="mt-2 rounded shadow-sm d-none qr-preview" alt="QR preview">
           </div>
           <div class="mb-3">
@@ -341,7 +351,7 @@
     'totp.actions.delete': _('Delete'),
     'totp.copy.success': _('Copied the one-time code.'),
     'totp.copy.error': _('Failed to copy the one-time code.'),
-    'totp.remainingSeconds': _('Remaining %(seconds)s seconds'),
+    'totp.remainingSeconds': _('Remaining {seconds} seconds'),
     'totp.preview.active': _('Previewing'),
     'totp.preview.placeholderSeconds': _('-- seconds remaining'),
     'totp.preview.waiting': _('Waiting for preview'),
@@ -364,7 +374,7 @@
     'totp.file.readError': _('Failed to read the file.'),
     'totp.export.success': _('Downloaded the JSON file.'),
     'totp.export.error': _('Failed to export TOTP entries.'),
-    'totp.delete.confirm': _('Delete %(issuer)s / %(account)s?'),
+    'totp.delete.confirm': _('Delete {issuer} / {account}?'),
     'totp.delete.success': _('Deleted the TOTP entry.'),
     'totp.delete.error': _('Failed to delete the TOTP entry.'),
     'totp.qr.decodeError': _('Failed to decode the QR code.'),

--- a/webapp/static/js/totp-manager.js
+++ b/webapp/static/js/totp-manager.js
@@ -49,12 +49,22 @@
     if (!params) {
       return template;
     }
-    return template.replace(/%\(([^)]+)\)s/g, (match, token) => {
+
+    let rendered = template.replace(/\{([^{}]+)\}/g, (match, token) => {
       if (Object.prototype.hasOwnProperty.call(params, token)) {
         return params[token];
       }
       return '';
     });
+
+    rendered = rendered.replace(/%\(([^)]+)\)s/g, (match, token) => {
+      if (Object.prototype.hasOwnProperty.call(params, token)) {
+        return params[token];
+      }
+      return '';
+    });
+
+    return rendered;
   }
 
   function normalizeSecret(secret) {
@@ -284,7 +294,7 @@
       const remainingEl = row.querySelector('[data-role="remaining"]');
       if (otpEl) otpEl.textContent = code;
       if (remainingEl) {
-        remainingEl.textContent = t('totp.remainingSeconds', 'Remaining %(seconds)s seconds', { seconds: remaining });
+        remainingEl.textContent = t('totp.remainingSeconds', 'Remaining {seconds} seconds', { seconds: remaining });
       }
       if (progressEl) {
         const ratio = period ? ((period - remaining) / period) * 100 : 0;
@@ -321,7 +331,7 @@
       if (remaining <= 0) remaining = period;
       if (elements.previewCode) elements.previewCode.textContent = code;
       if (elements.previewRemaining) {
-        elements.previewRemaining.textContent = t('totp.remainingSeconds', 'Remaining %(seconds)s seconds', { seconds: remaining });
+        elements.previewRemaining.textContent = t('totp.remainingSeconds', 'Remaining {seconds} seconds', { seconds: remaining });
       }
       if (elements.previewProgress) {
         const ratio = ((period - remaining) / period) * 100;
@@ -686,7 +696,10 @@
   }
 
   async function confirmDelete(item) {
-    const message = t('totp.delete.confirm', 'Delete %(issuer)s / %(account)s?', { issuer: item.issuer, account: item.account });
+    const message = t('totp.delete.confirm', 'Delete {issuer} / {account}?', {
+      issuer: item.issuer,
+      account: item.account,
+    });
     if (!window.confirm(message)) {
       return;
     }


### PR DESCRIPTION
## Summary
- switch TOTP front-end i18n strings to brace-style placeholders and allow the client helper to render both brace and percent formats safely
- keep the hidden QR canvas offscreen without disabling rendering and mark toolbar buttons as non-submit actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68efa386c78c83239b6bca9daa80e0e7