### PR TITLE
Improve TOTP management layout and English defaults

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ _('TOTP 管理') }}{% endblock %}
+{% block title %}{{ _('TOTP Management') }}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -58,38 +58,39 @@
     overflow: hidden;
   }
   .totp-layout {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 1.5rem;
   }
   .totp-create-panel {
-    transition: max-width 0.3s ease, flex-basis 0.3s ease, opacity 0.3s ease;
+    transition: opacity 0.3s ease;
   }
   .totp-create-panel.collapsed {
     display: none;
   }
+  .totp-list-panel {
+    min-width: 0;
+  }
   @media (min-width: 992px) {
     .totp-layout {
-      flex-direction: row;
+      grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
       align-items: stretch;
     }
     .totp-layout.totp-layout-collapsed {
+      grid-template-columns: minmax(0, 1fr);
       gap: 0;
     }
-    .totp-create-panel {
+    .totp-layout .totp-create-panel {
       display: block;
-      flex: 0 0 360px;
-      max-width: 360px;
     }
-    .totp-create-panel.collapsed {
+    .totp-layout .totp-create-panel.collapsed {
       display: block;
-      flex-basis: 0 !important;
-      max-width: 0 !important;
       opacity: 0;
       visibility: hidden;
+      pointer-events: none;
     }
-    .totp-list-panel {
-      flex: 1 1 auto;
+    .totp-layout.totp-layout-collapsed .totp-create-panel {
+      display: none;
     }
   }
 </style>
@@ -98,13 +99,13 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
   <div class="d-flex align-items-center gap-2">
-    <h1 class="h3 mb-0">{{ _('TOTP 管理') }}</h1>
+    <h1 class="h3 mb-0">{{ _('TOTP Management') }}</h1>
     <button
       class="btn btn-outline-primary btn-sm btn-icon"
       type="button"
       id="totp-create-toggle"
       aria-expanded="true"
-      aria-label="{{ _('新規 TOTP 登録フォームを閉じる') }}"
+      aria-label="{{ _('Hide registration form') }}"
     >
       <i class="bi bi-chevron-double-left" aria-hidden="true"></i>
     </button>
@@ -124,63 +125,63 @@
     <div class="card shadow-sm h-100">
       <div class="card-header totp-card-header">
         <div>
-          <h2 class="h5 mb-0">{{ _('新規 TOTP 登録') }}</h2>
-          <small class="text-muted">{{ _('QR を読み取るか手入力で登録できます') }}</small>
+          <h2 class="h5 mb-0">{{ _('Register New TOTP') }}</h2>
+          <small class="text-muted">{{ _('Register by scanning a QR code or entering the details manually.') }}</small>
         </div>
-        <span class="badge bg-secondary" id="totp-preview-badge">{{ _('プレビュー待ち') }}</span>
+        <span class="badge bg-secondary" id="totp-preview-badge">{{ _('Waiting for preview') }}</span>
       </div>
       <div class="card-body">
         <form id="totp-create-form" novalidate>
           <div class="mb-3">
-            <label for="totp-account" class="form-label">{{ _('アカウント') }}</label>
+            <label for="totp-account" class="form-label">{{ _('Account') }}</label>
             <input type="text" id="totp-account" name="account" class="form-control" required>
           </div>
           <div class="mb-3">
-            <label for="totp-issuer" class="form-label">{{ _('発行元 (Issuer)') }}</label>
+            <label for="totp-issuer" class="form-label">{{ _('Issuer') }}</label>
             <input type="text" id="totp-issuer" name="issuer" class="form-control" required>
           </div>
           <div class="mb-3">
-            <label for="totp-secret" class="form-label">{{ _('シークレット') }}</label>
+            <label for="totp-secret" class="form-label">{{ _('Secret') }}</label>
             <input type="text" id="totp-secret" name="secret" class="form-control" required placeholder="JBSWY3DPEHPK3PXP">
-            <div class="form-text">{{ _('空白やハイフンは自動で除去されます (Base32)') }}</div>
+            <div class="form-text">{{ _('Spaces and hyphens are removed automatically (Base32).') }}</div>
           </div>
           <div class="row">
             <div class="col-6 mb-3">
-              <label for="totp-digits" class="form-label">{{ _('桁数') }}</label>
+              <label for="totp-digits" class="form-label">{{ _('Digits') }}</label>
               <input type="number" id="totp-digits" name="digits" class="form-control" min="4" max="10" value="6">
             </div>
             <div class="col-6 mb-3">
-              <label for="totp-period" class="form-label">{{ _('有効期間 (秒)') }}</label>
+              <label for="totp-period" class="form-label">{{ _('Period (seconds)') }}</label>
               <input type="number" id="totp-period" name="period" class="form-control" min="15" max="120" value="30">
             </div>
           </div>
           <div class="mb-3">
-            <label for="totp-description" class="form-label">{{ _('説明 (任意)') }}</label>
+            <label for="totp-description" class="form-label">{{ _('Description (optional)') }}</label>
             <textarea id="totp-description" name="description" class="form-control" rows="2"></textarea>
           </div>
           <div class="mb-3">
-            <label class="form-label">{{ _('QR コードから読み込む') }}</label>
+            <label class="form-label">{{ _('Read from QR code') }}</label>
             <input type="file" accept="image/*" id="totp-qr-upload" class="form-control">
             <div class="d-flex gap-2 mt-2">
               <button type="button" class="btn btn-outline-secondary btn-sm" id="totp-qr-paste-btn">
-                <i class="bi bi-clipboard-plus me-1"></i>{{ _('クリップボードから貼り付け') }}
+                <i class="bi bi-clipboard-plus me-1"></i>{{ _('Paste from clipboard') }}
               </button>
             </div>
-            <div class="form-text">{{ _('クリップボードの画像から QR を読み取ります') }}</div>
+            <div class="form-text">{{ _('Reads a QR code from an image in your clipboard.') }}</div>
             <canvas id="totp-qr-canvas" class="qr-canvas-offscreen" aria-hidden="true"></canvas>
             <img id="totp-qr-preview" class="mt-2 rounded shadow-sm d-none qr-preview" alt="QR preview">
           </div>
           <div class="mb-3">
-            <label for="totp-otpauth" class="form-label">{{ _('otpauth URI (任意)') }}</label>
+            <label for="totp-otpauth" class="form-label">{{ _('otpauth URI (optional)') }}</label>
             <input type="text" id="totp-otpauth" class="form-control" placeholder="otpauth://totp/Example:alice@example.com?...">
-            <div class="form-text">{{ _('URI を貼り付けて「URI を展開」を押すとフォームへ展開します') }}</div>
+            <div class="form-text">{{ _('Paste the URI and press "Parse URI" to populate the form.') }}</div>
           </div>
           <div class="d-flex justify-content-between">
             <button type="button" class="btn btn-outline-secondary" id="totp-parse-uri-btn">
-              <i class="bi bi-link-45deg me-1"></i>{{ _('URI を展開') }}
+              <i class="bi bi-link-45deg me-1"></i>{{ _('Parse URI') }}
             </button>
             <button type="submit" class="btn btn-primary">
-              <i class="bi bi-plus-circle me-1"></i>{{ _('登録') }}
+              <i class="bi bi-plus-circle me-1"></i>{{ _('Register') }}
             </button>
           </div>
         </form>
@@ -188,21 +189,21 @@
       <div class="card-footer">
         <div class="d-flex align-items-center justify-content-between">
           <div>
-            <small class="text-muted d-block">{{ _('現在のプレビュー') }}</small>
+            <small class="text-muted d-block">{{ _('Current preview') }}</small>
             <div
               class="otp-code otp-copyable"
               id="totp-preview-code"
               role="button"
               tabindex="0"
-              aria-label="{{ _('ワンタイムコードをコピー') }}"
-              title="{{ _('クリックでコピー') }}"
+              aria-label="{{ _('Copy one-time code') }}"
+              title="{{ _('Click to copy') }}"
             >------</div>
           </div>
           <div class="w-50">
             <div class="progress otp-progress">
               <div class="progress-bar" id="totp-preview-progress" role="progressbar" style="width: 0%"></div>
             </div>
-            <small class="text-muted" id="totp-preview-remaining">{{ _('残り -- 秒') }}</small>
+            <small class="text-muted" id="totp-preview-remaining">{{ _('-- seconds remaining') }}</small>
           </div>
         </div>
       </div>
@@ -213,15 +214,15 @@
     <div class="card shadow-sm h-100">
       <div class="card-header d-flex align-items-center justify-content-between">
         <div>
-          <h2 class="h5 mb-0">{{ _('登録済み TOTP 一覧') }}</h2>
-          <small class="text-muted">{{ _('一覧は 1 秒ごとに自動更新されます') }}</small>
+          <h2 class="h5 mb-0">{{ _('Registered TOTP entries') }}</h2>
+          <small class="text-muted">{{ _('The list refreshes every second.') }}</small>
         </div>
         <div class="input-group" style="max-width: 320px;">
           <span class="input-group-text"><i class="bi bi-funnel"></i></span>
           <select class="form-select" id="totp-sort-select">
-            <option value="issuer">{{ _('発行元順') }}</option>
-            <option value="account">{{ _('アカウント順') }}</option>
-            <option value="updated">{{ _('更新日時順') }}</option>
+            <option value="issuer">{{ _('Sort by issuer') }}</option>
+            <option value="account">{{ _('Sort by account') }}</option>
+            <option value="updated">{{ _('Sort by updated time') }}</option>
           </select>
         </div>
       </div>
@@ -229,19 +230,19 @@
         <table class="table align-middle mb-0" id="totp-table">
           <thead class="table-light">
             <tr>
-              <th scope="col">{{ _('発行元') }}</th>
-              <th scope="col">{{ _('アカウント') }}</th>
-              <th scope="col" style="width: 180px;">{{ _('ワンタイムコード') }}</th>
-              <th scope="col">{{ _('残り時間') }}</th>
-              <th scope="col">{{ _('説明') }}</th>
-              <th scope="col" class="text-nowrap">{{ _('更新日時') }}</th>
-              <th scope="col" class="text-end">{{ _('操作') }}</th>
+              <th scope="col">{{ _('Issuer') }}</th>
+              <th scope="col">{{ _('Account') }}</th>
+              <th scope="col" style="width: 180px;">{{ _('One-time code') }}</th>
+              <th scope="col">{{ _('Time remaining') }}</th>
+              <th scope="col">{{ _('Description') }}</th>
+              <th scope="col" class="text-nowrap">{{ _('Updated at') }}</th>
+              <th scope="col" class="text-end">{{ _('Actions') }}</th>
             </tr>
           </thead>
           <tbody id="totp-table-body">
             <tr>
               <td colspan="7" class="text-center py-4 text-muted">
-                <i class="bi bi-arrow-repeat me-2"></i>{{ _('データ取得中...') }}
+                <i class="bi bi-arrow-repeat me-2"></i>{{ _('Loading data...') }}
               </td>
             </tr>
           </tbody>
@@ -257,41 +258,41 @@
     <div class="modal-content">
       <form id="totp-edit-form">
         <div class="modal-header">
-          <h5 class="modal-title">{{ _('TOTP を編集') }}</h5>
+          <h5 class="modal-title">{{ _('Edit TOTP') }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <input type="hidden" id="totp-edit-id">
           <div class="row g-3">
             <div class="col-md-6">
-              <label class="form-label" for="totp-edit-account">{{ _('アカウント') }}</label>
+              <label class="form-label" for="totp-edit-account">{{ _('Account') }}</label>
               <input type="text" class="form-control" id="totp-edit-account" required>
             </div>
             <div class="col-md-6">
-              <label class="form-label" for="totp-edit-issuer">{{ _('発行元 (Issuer)') }}</label>
+              <label class="form-label" for="totp-edit-issuer">{{ _('Issuer') }}</label>
               <input type="text" class="form-control" id="totp-edit-issuer" required>
             </div>
             <div class="col-md-6">
-              <label class="form-label" for="totp-edit-digits">{{ _('桁数') }}</label>
+              <label class="form-label" for="totp-edit-digits">{{ _('Digits') }}</label>
               <input type="number" class="form-control" id="totp-edit-digits" min="4" max="10">
             </div>
             <div class="col-md-6">
-              <label class="form-label" for="totp-edit-period">{{ _('有効期間 (秒)') }}</label>
+              <label class="form-label" for="totp-edit-period">{{ _('Period (seconds)') }}</label>
               <input type="number" class="form-control" id="totp-edit-period" min="15" max="120">
             </div>
             <div class="col-12">
-              <label class="form-label" for="totp-edit-description">{{ _('説明 (任意)') }}</label>
+              <label class="form-label" for="totp-edit-description">{{ _('Description (optional)') }}</label>
               <textarea class="form-control" id="totp-edit-description" rows="2"></textarea>
             </div>
             <div class="col-12">
-              <label class="form-label" for="totp-edit-secret">{{ _('シークレットを更新 (任意)') }}</label>
-              <input type="text" class="form-control" id="totp-edit-secret" placeholder="{{ _('空欄のままにすると変更しません') }}">
+              <label class="form-label" for="totp-edit-secret">{{ _('Update secret (optional)') }}</label>
+              <input type="text" class="form-control" id="totp-edit-secret" placeholder="{{ _('Leave blank to keep the current secret.') }}">
             </div>
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('キャンセル') }}</button>
-          <button type="submit" class="btn btn-primary">{{ _('保存') }}</button>
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
+          <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
         </div>
       </form>
     </div>
@@ -304,17 +305,17 @@
     <div class="modal-content">
       <form id="totp-import-form">
         <div class="modal-header">
-          <h5 class="modal-title">{{ _('TOTP をインポート') }}</h5>
+          <h5 class="modal-title">{{ _('Import TOTPs') }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <p class="text-muted small">{{ _('JSON ファイルを貼り付けるか選択してください。重複がある場合は確認後に続行します。') }}</p>
+          <p class="text-muted small">{{ _('Paste or choose a JSON file. Duplicates will be reviewed before continuing.') }}</p>
           <div class="mb-3">
-            <label class="form-label" for="totp-import-file">{{ _('JSON ファイル') }}</label>
+            <label class="form-label" for="totp-import-file">{{ _('JSON file') }}</label>
             <input type="file" accept="application/json" class="form-control" id="totp-import-file">
           </div>
           <div class="mb-3">
-            <label class="form-label" for="totp-import-text">{{ _('JSON を直接貼り付け') }}</label>
+            <label class="form-label" for="totp-import-text">{{ _('Paste JSON directly') }}</label>
             <textarea class="form-control" id="totp-import-text" rows="10" placeholder='[
   {
     "account": "alice@example.com",
@@ -325,13 +326,13 @@
           </div>
           <div class="form-check">
             <input class="form-check-input" type="checkbox" id="totp-import-force">
-            <label class="form-check-label" for="totp-import-force">{{ _('重複があっても上書きする') }}</label>
+            <label class="form-check-label" for="totp-import-force">{{ _('Overwrite even if duplicates exist') }}</label>
           </div>
           <div class="alert alert-warning d-none mt-3" id="totp-import-conflicts"></div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('閉じる') }}</button>
-          <button type="submit" class="btn btn-primary">{{ _('インポート実行') }}</button>
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
+          <button type="submit" class="btn btn-primary">{{ _('Run import') }}</button>
         </div>
       </form>
     </div>
@@ -407,8 +408,8 @@
       toggleButton.setAttribute(
         'aria-label',
         expanded
-          ? '{{ _('新規 TOTP 登録フォームを閉じる') }}'
-          : '{{ _('新規 TOTP 登録フォームを開く') }}'
+          ? '{{ _('Hide registration form') }}'
+          : '{{ _('Show registration form') }}'
       );
       if (icon) {
         icon.className = expanded ? 'bi bi-chevron-double-left' : 'bi bi-chevron-double-right';

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -84,7 +84,7 @@
               <li><a class="dropdown-item" href="{{ url_for('admin.permissions') }}">{{ _('Permissions') }}</a></li>
               {% endif %}
               {% if current_user.can('totp:view') %}
-              <li><a class="dropdown-item" href="{{ url_for('totp.index') }}">{{ _('TOTP 管理') }}</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('totp.index') }}">{{ _('TOTP Management') }}</a></li>
               {% endif %}
               {% if show_system_manage %}
               <li><hr class="dropdown-divider"></li>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -51,7 +51,7 @@
           {% if current_user.can('totp:view') %}
           <div class="col-md-4 mb-3">
             <a href="{{ url_for('totp.index') }}" class="btn btn-warning btn-lg w-100">
-              <i class="bi bi-shield-lock"></i><br>{{ _('TOTP 管理') }}
+              <i class="bi bi-shield-lock"></i><br>{{ _('TOTP Management') }}
             </a>
           </div>
           {% endif %}

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -2180,3 +2180,185 @@ msgstr "Wikiページを検索"
 #: features/wiki/presentation/wiki/templates/wiki/search.html:95
 msgid "Enter a keyword in the search box above to find pages."
 msgstr "ページを探すには上の検索欄にキーワードを入力してください。"
+
+#: features/totp/presentation/templates/totp/index.html
+#: webapp/templates/base.html
+#: webapp/templates/index.html
+msgid "TOTP Management"
+msgstr "TOTP 管理"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Register New TOTP"
+msgstr "新規 TOTP 登録"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Register by scanning a QR code or entering the details manually."
+msgstr "QR を読み取るか手入力で登録できます。"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Account"
+msgstr "アカウント"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Issuer"
+msgstr "発行元"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Secret"
+msgstr "シークレット"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Spaces and hyphens are removed automatically (Base32)."
+msgstr "空白やハイフンは自動で除去されます (Base32)"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Digits"
+msgstr "桁数"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Period (seconds)"
+msgstr "有効期間 (秒)"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Description (optional)"
+msgstr "説明 (任意)"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Read from QR code"
+msgstr "QR コードから読み込む"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Paste from clipboard"
+msgstr "クリップボードから貼り付け"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Reads a QR code from an image in your clipboard."
+msgstr "クリップボードの画像から QR を読み取ります。"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "otpauth URI (optional)"
+msgstr "otpauth URI (任意)"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Paste the URI and press \"Parse URI\" to populate the form."
+msgstr "URI を貼り付けて「URI を展開」を押すとフォームへ展開します。"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Parse URI"
+msgstr "URI を展開"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Current preview"
+msgstr "現在のプレビュー"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Registered TOTP entries"
+msgstr "登録済み TOTP 一覧"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "The list refreshes every second."
+msgstr "一覧は 1 秒ごとに自動更新されます。"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Sort by issuer"
+msgstr "発行元順"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Sort by account"
+msgstr "アカウント順"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Sort by updated time"
+msgstr "更新日時順"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "One-time code"
+msgstr "ワンタイムコード"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Time remaining"
+msgstr "残り時間"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Updated at"
+msgstr "更新日時"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Loading data..."
+msgstr "データ取得中..."
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Edit TOTP"
+msgstr "TOTP を編集"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Update secret (optional)"
+msgstr "シークレットを更新 (任意)"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Leave blank to keep the current secret."
+msgstr "空欄のままにすると変更しません"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Import TOTPs"
+msgstr "TOTP をインポート"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Paste or choose a JSON file. Duplicates will be reviewed before continuing."
+msgstr "JSON ファイルを貼り付けるか選択してください。重複がある場合は確認後に続行します。"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "JSON file"
+msgstr "JSON ファイル"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Paste JSON directly"
+msgstr "JSON を直接貼り付け"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Overwrite even if duplicates exist"
+msgstr "重複があっても上書きする"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Close"
+msgstr "閉じる"
+
+
+#: features/totp/presentation/templates/totp/index.html
+msgid "Run import"
+msgstr "インポート実行"
+


### PR DESCRIPTION
## Summary
- convert the TOTP management view and navigation labels to English source strings with updated Japanese translations
- adjust the page layout so the registration form and list sit side-by-side on wide screens and the list expands when the form is hidden

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68efa8ec41c0832399277d063a85b8c9