### PR TITLE
Adjust TOTP layout to show panels side by side

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -58,8 +58,8 @@
     overflow: hidden;
   }
   .totp-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: 1.5rem;
   }
   .totp-create-panel {
@@ -70,17 +70,18 @@
   }
   .totp-list-panel {
     min-width: 0;
+    flex: 1 1 auto;
   }
   @media (min-width: 992px) {
     .totp-layout {
-      grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+      flex-direction: row;
       align-items: stretch;
     }
     .totp-layout.totp-layout-collapsed {
-      grid-template-columns: minmax(0, 1fr);
       gap: 0;
     }
     .totp-layout .totp-create-panel {
+      flex: 0 0 360px;
       display: block;
     }
     .totp-layout .totp-create-panel.collapsed {


### PR DESCRIPTION
## Summary
- update the TOTP management layout to use a flex row on large screens
- ensure the registration form stays on the left and the registered entries panel grows on the right

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efac9d53308323baff07ef86121ec5