### PR TITLE
Reorder TOTP list before registration form

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -108,7 +108,7 @@
       aria-expanded="true"
       aria-label="{{ _('Hide registration form') }}"
     >
-      <i class="bi bi-chevron-double-left" aria-hidden="true"></i>
+      <i class="bi bi-chevron-double-right" aria-hidden="true"></i>
     </button>
   </div>
   <div class="d-flex gap-2">
@@ -122,6 +122,46 @@
 </div>
 
 <div class="totp-layout" id="totp-layout">
+  <div class="totp-list-panel">
+    <div class="card shadow-sm h-100">
+      <div class="card-header d-flex align-items-center justify-content-between">
+        <div>
+          <h2 class="h5 mb-0">{{ _('Registered TOTP entries') }}</h2>
+          <small class="text-muted">{{ _('The list refreshes every second.') }}</small>
+        </div>
+        <div class="input-group" style="max-width: 320px;">
+          <span class="input-group-text"><i class="bi bi-funnel"></i></span>
+          <select class="form-select" id="totp-sort-select">
+            <option value="issuer">{{ _('Sort by issuer') }}</option>
+            <option value="account">{{ _('Sort by account') }}</option>
+            <option value="updated">{{ _('Sort by updated time') }}</option>
+          </select>
+        </div>
+      </div>
+      <div class="table-responsive">
+        <table class="table align-middle mb-0" id="totp-table">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">{{ _('Issuer') }}</th>
+              <th scope="col">{{ _('Account') }}</th>
+              <th scope="col" style="width: 180px;">{{ _('One-time code') }}</th>
+              <th scope="col">{{ _('Time remaining') }}</th>
+              <th scope="col">{{ _('Description') }}</th>
+              <th scope="col" class="text-nowrap">{{ _('Updated at') }}</th>
+              <th scope="col" class="text-end">{{ _('Actions') }}</th>
+            </tr>
+          </thead>
+          <tbody id="totp-table-body">
+            <tr>
+              <td colspan="7" class="text-center py-4 text-muted">
+                <i class="bi bi-arrow-repeat me-2"></i>{{ _('Loading data...') }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
   <div class="totp-create-panel" id="totp-create-panel" aria-hidden="false">
     <div class="card shadow-sm h-100">
       <div class="card-header totp-card-header">
@@ -208,46 +248,6 @@
           </div>
         </div>
       </div>
-      </div>
-    </div>
-  </div>
-  <div class="totp-list-panel">
-    <div class="card shadow-sm h-100">
-      <div class="card-header d-flex align-items-center justify-content-between">
-        <div>
-          <h2 class="h5 mb-0">{{ _('Registered TOTP entries') }}</h2>
-          <small class="text-muted">{{ _('The list refreshes every second.') }}</small>
-        </div>
-        <div class="input-group" style="max-width: 320px;">
-          <span class="input-group-text"><i class="bi bi-funnel"></i></span>
-          <select class="form-select" id="totp-sort-select">
-            <option value="issuer">{{ _('Sort by issuer') }}</option>
-            <option value="account">{{ _('Sort by account') }}</option>
-            <option value="updated">{{ _('Sort by updated time') }}</option>
-          </select>
-        </div>
-      </div>
-      <div class="table-responsive">
-        <table class="table align-middle mb-0" id="totp-table">
-          <thead class="table-light">
-            <tr>
-              <th scope="col">{{ _('Issuer') }}</th>
-              <th scope="col">{{ _('Account') }}</th>
-              <th scope="col" style="width: 180px;">{{ _('One-time code') }}</th>
-              <th scope="col">{{ _('Time remaining') }}</th>
-              <th scope="col">{{ _('Description') }}</th>
-              <th scope="col" class="text-nowrap">{{ _('Updated at') }}</th>
-              <th scope="col" class="text-end">{{ _('Actions') }}</th>
-            </tr>
-          </thead>
-          <tbody id="totp-table-body">
-            <tr>
-              <td colspan="7" class="text-center py-4 text-muted">
-                <i class="bi bi-arrow-repeat me-2"></i>{{ _('Loading data...') }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
       </div>
     </div>
   </div>
@@ -413,7 +413,7 @@
           : '{{ _('Show registration form') }}'
       );
       if (icon) {
-        icon.className = expanded ? 'bi bi-chevron-double-left' : 'bi bi-chevron-double-right';
+        icon.className = expanded ? 'bi bi-chevron-double-right' : 'bi bi-chevron-double-left';
       }
     };
 


### PR DESCRIPTION
## Summary
- move the registered TOTP entries panel before the registration form so it appears first
- adjust the toggle button icon direction to reflect the new panel placement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efaecdcc888323ab0785e36de6f18c