### PR TITLE
Improve TOTP management toolbar and action buttons

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -9,14 +9,16 @@
     justify-content: space-between;
     gap: 1rem;
   }
-  .btn-icon {
+  .totp-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .totp-toolbar .btn {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-    padding: 0;
-    border-radius: 50%;
+    gap: 0.35rem;
   }
   .otp-code {
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
@@ -40,8 +42,14 @@
   .otp-progress {
     height: 8px;
   }
-  .totp-list-actions button + button {
-    margin-left: 0.25rem;
+  .totp-list-actions {
+    display: inline-flex;
+    justify-content: flex-end;
+    gap: 0.25rem;
+  }
+  .totp-list-actions .btn {
+    min-width: 4.5rem;
+    justify-content: center;
   }
   .qr-preview {
     max-width: 200px;
@@ -98,25 +106,26 @@
 {% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
-  <div class="d-flex align-items-center gap-2">
-    <h1 class="h3 mb-0">{{ _('TOTP Management') }}</h1>
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-4">
+  <h1 class="h3 mb-0">{{ _('TOTP Management') }}</h1>
+  <div class="totp-toolbar">
     <button
-      class="btn btn-outline-primary btn-sm btn-icon"
+      class="btn btn-outline-primary btn-sm"
       type="button"
       id="totp-create-toggle"
       aria-expanded="true"
       aria-label="{{ _('Hide registration form') }}"
     >
-      <i class="bi bi-chevron-double-right" aria-hidden="true"></i>
+      <i class="bi bi-layout-sidebar-inset" aria-hidden="true"></i>
+      <span data-role="label">{{ _('Hide registration form') }}</span>
     </button>
-  </div>
-  <div class="d-flex gap-2">
     <button type="button" class="btn btn-outline-secondary" id="totp-export-btn">
-      <i class="bi bi-download me-1"></i>{{ _('Export JSON') }}
+      <i class="bi bi-download" aria-hidden="true"></i>
+      <span>{{ _('Export JSON') }}</span>
     </button>
     <button type="button" class="btn btn-outline-primary" id="totp-import-btn">
-      <i class="bi bi-upload me-1"></i>{{ _('Import JSON') }}
+      <i class="bi bi-upload" aria-hidden="true"></i>
+      <span>{{ _('Import JSON') }}</span>
     </button>
   </div>
 </div>
@@ -399,6 +408,7 @@
     }
 
     const icon = toggleButton.querySelector('i');
+    const label = toggleButton.querySelector('[data-role="label"]');
     const mediaQuery = window.matchMedia('(max-width: 991.98px)');
 
     const updateState = (expanded) => {
@@ -413,7 +423,12 @@
           : '{{ _('Show registration form') }}'
       );
       if (icon) {
-        icon.className = expanded ? 'bi bi-chevron-double-right' : 'bi bi-chevron-double-left';
+        icon.className = expanded ? 'bi bi-layout-sidebar-inset' : 'bi bi-layout-sidebar';
+      }
+      if (label) {
+        label.textContent = expanded
+          ? '{{ _('Hide registration form') }}'
+          : '{{ _('Show registration form') }}';
       }
     };
 

--- a/webapp/static/js/totp-manager.js
+++ b/webapp/static/js/totp-manager.js
@@ -176,9 +176,11 @@
           </td>
           <td>${description}</td>
           <td class="text-nowrap">${escapeHtml(updatedText)}</td>
-          <td class="text-end totp-list-actions">
-            <button class="btn btn-sm btn-outline-primary" data-action="edit">${t('totp.actions.edit', 'Edit')}</button>
-            <button class="btn btn-sm btn-outline-danger" data-action="delete">${t('totp.actions.delete', 'Delete')}</button>
+          <td class="text-end">
+            <div class="totp-list-actions">
+              <button class="btn btn-sm btn-outline-primary" data-action="edit">${t('totp.actions.edit', 'Edit')}</button>
+              <button class="btn btn-sm btn-outline-danger" data-action="delete">${t('totp.actions.delete', 'Delete')}</button>
+            </div>
           </td>
         </tr>`;
     });


### PR DESCRIPTION
## Summary
- reposition the TOTP registration toggle into the toolbar and show contextual text
- refresh the toolbar styling so action buttons share spacing and icon layout
- wrap table action buttons so Edit/Delete widths align for a consistent appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efb107ddc48323b7a6f34158b89f7e