### PR TITLE
Default TOTP registration panel to hidden

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -9,14 +9,16 @@
     justify-content: space-between;
     gap: 1rem;
   }
-  .btn-icon {
+  .totp-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .totp-toolbar .btn {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-    padding: 0;
-    border-radius: 50%;
+    gap: 0.35rem;
   }
   .otp-code {
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
@@ -40,8 +42,14 @@
   .otp-progress {
     height: 8px;
   }
-  .totp-list-actions button + button {
-    margin-left: 0.25rem;
+  .totp-list-actions {
+    display: inline-flex;
+    justify-content: flex-end;
+    gap: 0.25rem;
+  }
+  .totp-list-actions .btn {
+    min-width: 4.5rem;
+    justify-content: center;
   }
   .qr-preview {
     max-width: 200px;
@@ -98,30 +106,35 @@
 {% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
-  <div class="d-flex align-items-center gap-2">
-    <h1 class="h3 mb-0">{{ _('TOTP Management') }}</h1>
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-4">
+  <h1 class="h3 mb-0">{{ _('TOTP Management') }}</h1>
+  <div class="totp-toolbar">
     <button
-      class="btn btn-outline-primary btn-sm btn-icon"
+      class="btn btn-outline-primary btn-sm"
       type="button"
       id="totp-create-toggle"
-      aria-expanded="true"
-      aria-label="{{ _('Hide registration form') }}"
+      aria-expanded="false"
+      aria-label="{{ _('Show registration form') }}"
+      data-label-show="{{ _('Show registration form') }}"
+      data-label-hide="{{ _('Hide registration form') }}"
+      data-icon-show="bi bi-layout-sidebar"
+      data-icon-hide="bi bi-layout-sidebar-inset"
     >
-      <i class="bi bi-chevron-double-right" aria-hidden="true"></i>
+      <i class="bi bi-layout-sidebar" aria-hidden="true" data-role="icon"></i>
+      <span data-role="label">{{ _('Show registration form') }}</span>
     </button>
-  </div>
-  <div class="d-flex gap-2">
     <button type="button" class="btn btn-outline-secondary" id="totp-export-btn">
-      <i class="bi bi-download me-1"></i>{{ _('Export JSON') }}
+      <i class="bi bi-download" aria-hidden="true"></i>
+      <span>{{ _('Export JSON') }}</span>
     </button>
     <button type="button" class="btn btn-outline-primary" id="totp-import-btn">
-      <i class="bi bi-upload me-1"></i>{{ _('Import JSON') }}
+      <i class="bi bi-upload" aria-hidden="true"></i>
+      <span>{{ _('Import JSON') }}</span>
     </button>
   </div>
 </div>
 
-<div class="totp-layout" id="totp-layout">
+<div class="totp-layout totp-layout-collapsed" id="totp-layout">
   <div class="totp-list-panel">
     <div class="card shadow-sm h-100">
       <div class="card-header d-flex align-items-center justify-content-between">
@@ -162,7 +175,7 @@
       </div>
     </div>
   </div>
-  <div class="totp-create-panel" id="totp-create-panel" aria-hidden="false">
+  <div class="totp-create-panel collapsed" id="totp-create-panel" aria-hidden="true">
     <div class="card shadow-sm h-100">
       <div class="card-header totp-card-header">
         <div>
@@ -399,6 +412,7 @@
     }
 
     const icon = toggleButton.querySelector('i');
+    const label = toggleButton.querySelector('[data-role="label"]');
     const mediaQuery = window.matchMedia('(max-width: 991.98px)');
 
     const updateState = (expanded) => {
@@ -413,7 +427,12 @@
           : '{{ _('Show registration form') }}'
       );
       if (icon) {
-        icon.className = expanded ? 'bi bi-chevron-double-right' : 'bi bi-chevron-double-left';
+        icon.className = expanded ? 'bi bi-layout-sidebar-inset' : 'bi bi-layout-sidebar';
+      }
+      if (label) {
+        label.textContent = expanded
+          ? '{{ _('Hide registration form') }}'
+          : '{{ _('Show registration form') }}';
       }
     };
 

--- a/webapp/static/js/totp-manager.js
+++ b/webapp/static/js/totp-manager.js
@@ -11,6 +11,11 @@
   const elements = {
     tableBody: document.getElementById('totp-table-body'),
     sortSelect: document.getElementById('totp-sort-select'),
+    toggleButton: document.getElementById('totp-create-toggle'),
+    toggleIcon: document.querySelector('#totp-create-toggle [data-role="icon"]'),
+    toggleLabel: document.querySelector('#totp-create-toggle [data-role="label"]'),
+    layout: document.getElementById('totp-layout'),
+    createPanel: document.getElementById('totp-create-panel'),
     previewCode: document.getElementById('totp-preview-code'),
     previewProgress: document.getElementById('totp-preview-progress'),
     previewRemaining: document.getElementById('totp-preview-remaining'),
@@ -176,9 +181,11 @@
           </td>
           <td>${description}</td>
           <td class="text-nowrap">${escapeHtml(updatedText)}</td>
-          <td class="text-end totp-list-actions">
-            <button class="btn btn-sm btn-outline-primary" data-action="edit">${t('totp.actions.edit', 'Edit')}</button>
-            <button class="btn btn-sm btn-outline-danger" data-action="delete">${t('totp.actions.delete', 'Delete')}</button>
+          <td class="text-end">
+            <div class="totp-list-actions">
+              <button class="btn btn-sm btn-outline-primary" data-action="edit">${t('totp.actions.edit', 'Edit')}</button>
+              <button class="btn btn-sm btn-outline-danger" data-action="delete">${t('totp.actions.delete', 'Delete')}</button>
+            </div>
           </td>
         </tr>`;
     });
@@ -195,6 +202,52 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#039;');
+  }
+
+  function setCreatePanelVisibility(visible) {
+    if (!elements.createPanel || !elements.toggleButton) {
+      return;
+    }
+
+    const showLabel =
+      elements.toggleButton.getAttribute('data-label-show') ||
+      elements.toggleButton.getAttribute('aria-label') ||
+      'Show registration form';
+    const hideLabel = elements.toggleButton.getAttribute('data-label-hide') || 'Hide registration form';
+    const showIcon = elements.toggleButton.getAttribute('data-icon-show') || 'bi bi-layout-sidebar';
+    const hideIcon = elements.toggleButton.getAttribute('data-icon-hide') || 'bi bi-layout-sidebar-inset';
+
+    elements.toggleButton.setAttribute('aria-expanded', visible ? 'true' : 'false');
+    elements.toggleButton.setAttribute('aria-label', visible ? hideLabel : showLabel);
+
+    if (elements.toggleLabel) {
+      elements.toggleLabel.textContent = visible ? hideLabel : showLabel;
+    }
+
+    if (elements.toggleIcon) {
+      elements.toggleIcon.className = visible ? hideIcon : showIcon;
+      elements.toggleIcon.setAttribute('aria-hidden', 'true');
+    }
+
+    if (visible) {
+      elements.createPanel.classList.remove('collapsed');
+      elements.createPanel.setAttribute('aria-hidden', 'false');
+      if (elements.layout) {
+        elements.layout.classList.remove('totp-layout-collapsed');
+      }
+    } else {
+      elements.createPanel.classList.add('collapsed');
+      elements.createPanel.setAttribute('aria-hidden', 'true');
+      if (elements.layout) {
+        elements.layout.classList.add('totp-layout-collapsed');
+      }
+    }
+  }
+
+  function toggleCreatePanel() {
+    if (!elements.toggleButton) return;
+    const currentState = elements.toggleButton.getAttribute('aria-expanded') === 'true';
+    setCreatePanelVisibility(!currentState);
   }
 
   function sanitizeOtpText(value) {
@@ -442,6 +495,12 @@
         state.sort = event.target.value;
         renderTable();
         refreshOtpDisplay();
+      });
+    }
+
+    if (elements.toggleButton) {
+      elements.toggleButton.addEventListener('click', () => {
+        toggleCreatePanel();
       });
     }
 
@@ -855,6 +914,7 @@
 
   document.addEventListener('DOMContentLoaded', async () => {
     bindEvents();
+    setCreatePanelVisibility(false);
     updatePreviewFromForm();
     await fetchTotpList();
     startTimer();


### PR DESCRIPTION
## Summary
- ensure the TOTP registration form is collapsed by default with accessible aria state
- add client-side toggle handling so the button updates icon, label, and layout classes when showing the form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efb107ddc48323b7a6f34158b89f7e