### PR TITLE
Align TOTP actions column to the left

### DIFF
--- a/features/totp/presentation/templates/totp/index.html
+++ b/features/totp/presentation/templates/totp/index.html
@@ -44,7 +44,7 @@
   }
   .totp-list-actions {
     display: inline-flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 0.25rem;
   }
   .totp-list-actions .btn {
@@ -157,7 +157,7 @@
               <th scope="col">{{ _('Time remaining') }}</th>
               <th scope="col">{{ _('Description') }}</th>
               <th scope="col" class="text-nowrap">{{ _('Updated at') }}</th>
-              <th scope="col" class="text-end">{{ _('Actions') }}</th>
+              <th scope="col" class="text-start">{{ _('Actions') }}</th>
             </tr>
           </thead>
           <tbody id="totp-table-body">

--- a/webapp/static/js/totp-manager.js
+++ b/webapp/static/js/totp-manager.js
@@ -176,7 +176,7 @@
           </td>
           <td>${description}</td>
           <td class="text-nowrap">${escapeHtml(updatedText)}</td>
-          <td class="text-end">
+          <td class="text-start">
             <div class="totp-list-actions">
               <button class="btn btn-sm btn-outline-primary" data-action="edit">${t('totp.actions.edit', 'Edit')}</button>
               <button class="btn btn-sm btn-outline-danger" data-action="delete">${t('totp.actions.delete', 'Delete')}</button>


### PR DESCRIPTION
## Summary
- align the Actions column header in the TOTP management table to the left
- left-align the edit/delete action buttons for each TOTP entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efb794f9008323a0d007f5aa26d0e6