### PR TITLE
Localize service account validation messaging

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -9,6 +9,7 @@ from .celery_task import CeleryTaskRecord, CeleryTaskStatus
 from .picker_session import PickerSession
 from .picker_import_task import PickerImportTask
 from .totp import TOTPCredential
+from .service_account import ServiceAccount
 
 __all__ = [
     'User',
@@ -25,4 +26,5 @@ __all__ = [
     'PickerSession',
     'PickerImportTask',
     'TOTPCredential',
+    'ServiceAccount',
 ]

--- a/core/models/service_account.py
+++ b/core/models/service_account.py
@@ -1,0 +1,74 @@
+"""Service account model for JWT based machine authentication."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, List
+
+from core.db import db
+
+# Align BIGINT usage with other models to keep SQLite compatibility
+BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ServiceAccount(db.Model):
+    __tablename__ = "service_account"
+
+    service_account_id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
+    description = db.Column(db.String(255), nullable=True)
+    public_key = db.Column(db.Text, nullable=False)
+    scope_names = db.Column(db.String(1000), nullable=False, default="")
+    active_flg = db.Column(db.Boolean, nullable=False, default=True)
+    reg_dttm = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=_utc_now,
+        server_default=db.func.now(),
+    )
+    mod_dttm = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=_utc_now,
+        onupdate=_utc_now,
+        server_default=db.func.now(),
+    )
+
+    def set_scopes(self, scopes: Iterable[str]) -> None:
+        normalized: List[str] = []
+        seen = set()
+        for scope in scopes:
+            if not scope:
+                continue
+            if scope in seen:
+                continue
+            normalized.append(scope)
+            seen.add(scope)
+        self.scope_names = ",".join(normalized)
+
+    @property
+    def scopes(self) -> List[str]:
+        if not self.scope_names:
+            return []
+        return [scope for scope in (s.strip() for s in self.scope_names.split(",")) if scope]
+
+    def is_active(self) -> bool:
+        return bool(self.active_flg)
+
+    def as_dict(self) -> dict:
+        return {
+            "service_account_id": self.service_account_id,
+            "name": self.name,
+            "description": self.description,
+            "public_key": self.public_key,
+            "scope_names": self.scope_names,
+            "active_flg": self.active_flg,
+            "reg_dttm": self.reg_dttm.isoformat() if self.reg_dttm else None,
+            "mod_dttm": self.mod_dttm.isoformat() if self.mod_dttm else None,
+        }
+
+
+__all__ = ["ServiceAccount"]

--- a/migrations/versions/d1f6a0f9035e_add_service_account_table.py
+++ b/migrations/versions/d1f6a0f9035e_add_service_account_table.py
@@ -1,0 +1,48 @@
+"""Add service_account table for machine authenticated access."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd1f6a0f9035e'
+down_revision = 'cc5f8f58c7d4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    timestamp = sa.DateTime().with_variant(sa.DateTime(fsp=6), 'mysql')
+    op.create_table(
+        'service_account',
+        sa.Column(
+            'service_account_id',
+            sa.BigInteger().with_variant(sa.Integer(), 'sqlite'),
+            nullable=False,
+            autoincrement=True,
+        ),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('description', sa.String(length=255), nullable=True),
+        sa.Column('public_key', sa.Text(), nullable=False),
+        sa.Column('scope_names', sa.String(length=1000), nullable=False, server_default=''),
+        sa.Column('active_flg', sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            'reg_dttm',
+            timestamp,
+            nullable=False,
+            server_default=sa.text('UTC_TIMESTAMP(6)'),
+        ),
+        sa.Column(
+            'mod_dttm',
+            timestamp,
+            nullable=False,
+            server_default=sa.text('UTC_TIMESTAMP(6)'),
+            mysql_on_update=sa.text('UTC_TIMESTAMP(6)'),
+        ),
+        sa.PrimaryKeyConstraint('service_account_id'),
+        sa.UniqueConstraint('name'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('service_account')

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -56,6 +56,7 @@ def seed_permissions():
         {'id': 16, 'code': 'media:recover'},
         {'id': 17, 'code': 'totp:view'},
         {'id': 18, 'code': 'totp:write'},
+        {'id': 19, 'code': 'service_account:manage'},
     ]
     
     for perm_data in permissions_data:
@@ -74,7 +75,7 @@ def seed_role_permissions():
         # admin (role_id=1) - all permissions
         (1, 1), (1, 2), (1, 3), (1, 4), (1, 5),
         (1, 6), (1, 7), (1, 8), (1, 9), (1, 10),
-        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18),
+        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18), (1, 19),
         # manager (role_id=2) - limited permissions
         (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15), (2, 16),
         # member (role_id=3) - view only

--- a/tests/test_service_account_jwt.py
+++ b/tests/test_service_account_jwt.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from core.db import db
+from webapp.auth.service_account_auth import (
+    ServiceAccountJWTError,
+    ServiceAccountTokenValidator,
+)
+from webapp.services.service_account_service import ServiceAccountService
+
+
+def _generate_es256_key_pair():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return private_pem, public_pem
+
+
+def _generate_rs256_key_pair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return private_pem, public_pem
+
+
+def _create_account(app, name: str, public_key: str, scopes: str):
+    allowed = [scope.strip() for scope in scopes.split(",") if scope.strip()]
+    return ServiceAccountService.create_account(
+        name=name,
+        description="",
+        public_key=public_key,
+        scope_names=scopes,
+        active=True,
+        allowed_scopes=allowed,
+    )
+
+
+def _issue_token(
+    private_pem: bytes,
+    *,
+    name: str,
+    audience: str,
+    scopes: str,
+    lifetime_minutes: int = 5,
+    algorithm: str = "ES256",
+):
+    now = datetime.now(timezone.utc)
+    payload = {
+        "iss": name,
+        "sub": name,
+        "aud": audience,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=lifetime_minutes)).timestamp()),
+        "scope": scopes,
+    }
+    return jwt.encode(payload, private_pem, algorithm=algorithm)
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_success_es256(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    _create_account(app_context, "maintenance-bot", public_pem, "maintenance:read,maintenance:write")
+
+    token = _issue_token(private_pem, name="maintenance-bot", audience="familink:maintenance", scopes="maintenance:read maintenance:write")
+
+    account, claims = ServiceAccountTokenValidator.verify(
+        token,
+        audience="familink:maintenance",
+        required_scopes=["maintenance:read"],
+    )
+
+    assert account.name == "maintenance-bot"
+    assert claims["aud"] == "familink:maintenance"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_invalid_scope(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    _create_account(app_context, "scope-bot", public_pem, "maintenance:read")
+    token = _issue_token(private_pem, name="scope-bot", audience="familink:maintenance", scopes="maintenance:read")
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:write"])
+
+    assert exc.value.code == "InvalidScope"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_expired(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    _create_account(app_context, "expired-bot", public_pem, "maintenance:read")
+    now = datetime.now(timezone.utc)
+    payload = {
+        "iss": "expired-bot",
+        "sub": "expired-bot",
+        "aud": "familink:maintenance",
+        "iat": int((now - timedelta(minutes=20)).timestamp()),
+        "exp": int((now - timedelta(minutes=10)).timestamp()),
+        "scope": "maintenance:read",
+    }
+    token = jwt.encode(payload, private_pem, algorithm="ES256")
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
+
+    assert exc.value.code == "ExpiredToken"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_unknown_account(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    # アカウント未登録
+    token = _issue_token(private_pem, name="ghost-bot", audience="familink:maintenance", scopes="maintenance:read")
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
+
+    assert exc.value.code == "UnknownAccount"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_disabled_account(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    account = _create_account(app_context, "disabled-bot", public_pem, "maintenance:read")
+    account.active_flg = False
+    db.session.commit()
+
+    token = _issue_token(private_pem, name="disabled-bot", audience="familink:maintenance", scopes="maintenance:read")
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
+
+    assert exc.value.code == "DisabledAccount"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_lifetime_limit(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    _create_account(app_context, "long-bot", public_pem, "maintenance:read")
+    token = _issue_token(private_pem, name="long-bot", audience="familink:maintenance", scopes="maintenance:read", lifetime_minutes=15)
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
+
+    assert exc.value.code == "ExpiredToken"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_success_rs256(app_context):
+    private_pem, public_pem = _generate_rs256_key_pair()
+    _create_account(app_context, "rsa-bot", public_pem, "maintenance:read")
+    token = _issue_token(
+        private_pem,
+        name="rsa-bot",
+        audience="familink:maintenance",
+        scopes="maintenance:read",
+        algorithm="RS256",
+    )
+
+    account, _ = ServiceAccountTokenValidator.verify(
+        token,
+        audience="familink:maintenance",
+        required_scopes=["maintenance:read"],
+    )
+
+    assert account.name == "rsa-bot"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_public_key_normalization(app_context):
+    private_pem, public_pem = _generate_es256_key_pair()
+    pem_body = "".join(public_pem.splitlines()[1:-1])  # PEMヘッダ・フッタを除外
+    account = ServiceAccountService.create_account(
+        name="normalize-bot",
+        description=None,
+        public_key=pem_body,
+        scope_names="maintenance:read",
+        active=True,
+        allowed_scopes=["maintenance:read"],
+    )
+
+    assert "BEGIN PUBLIC KEY" in account.public_key
+    assert account.public_key.strip().startswith("-----BEGIN PUBLIC KEY-----")
+    assert account.public_key.strip().endswith("-----END PUBLIC KEY-----")

--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -26,6 +26,13 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
   {% endif %}
   {% if current_user.can('role:manage') %}
   <li class="nav-item">

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -15,6 +15,13 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.show_config') }}">
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}

--- a/webapp/admin/templates/admin/google_accounts.html
+++ b/webapp/admin/templates/admin/google_accounts.html
@@ -24,6 +24,13 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/permissions.html
+++ b/webapp/admin/templates/admin/permissions.html
@@ -20,6 +20,13 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/roles.html
+++ b/webapp/admin/templates/admin/roles.html
@@ -20,6 +20,13 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -1,0 +1,392 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Service Accounts') }}{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center justify-content-between mb-4">
+  <div>
+    <h1 class="h3 mb-1">{{ _('Service Accounts') }}</h1>
+    <p class="text-muted mb-0">{{ _('Manage machine-to-machine credentials and scopes.') }}</p>
+  </div>
+  <button class="btn btn-primary" id="btn-new-account">
+    <i class="bi bi-plus-circle"></i>
+    <span>{{ _('New Service Account') }}</span>
+  </button>
+</div>
+
+<ul class="nav nav-tabs mb-4">
+  {% if current_user.can('user:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.user') }}">
+      <i class="fas fa-users"></i> {{ _('User Management') }}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
+      <i class="fab fa-google"></i> {{ _('Google Accounts') }}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
+      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
+    </a>
+  </li>
+  {% endif %}
+  <li class="nav-item">
+    <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% if current_user.can('role:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.roles') }}">
+      <i class="fas fa-user-tag"></i> {{ _('Roles') }}
+    </a>
+  </li>
+  {% endif %}
+  {% if current_user.can('permission:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.permissions') }}">
+      <i class="fas fa-shield-alt"></i> {{ _('Permissions') }}
+    </a>
+  </li>
+  {% endif %}
+</ul>
+
+<div class="card shadow-sm">
+  <div class="card-header bg-white d-flex justify-content-between align-items-center">
+    <h2 class="h5 mb-0">{{ _('Registered Service Accounts') }}</h2>
+    <div class="text-muted small" id="service-account-count"></div>
+  </div>
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0" id="service-account-table">
+        <thead class="table-light">
+          <tr>
+            <th scope="col">{{ _('Name') }}</th>
+            <th scope="col">{{ _('Scopes') }}</th>
+            <th scope="col">{{ _('Status') }}</th>
+            <th scope="col">{{ _('Registered At') }}</th>
+            <th scope="col">{{ _('Updated At') }}</th>
+            <th scope="col" class="text-end">{{ _('Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div class="mt-4">
+  <h2 class="h6 text-muted mb-2">{{ _('Available scopes you can assign') }}</h2>
+  <div class="d-flex flex-wrap gap-2" id="available-scope-badges"></div>
+</div>
+
+<!-- Create / Edit Modal -->
+<div class="modal fade" id="serviceAccountModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="serviceAccountModalLabel"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+      </div>
+      <form id="service-account-form" class="needs-validation" novalidate>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="service-account-name" class="form-label">{{ _('Account Name') }}</label>
+            <input type="text" class="form-control" id="service-account-name" required maxlength="100">
+            <div class="invalid-feedback" data-field="name"></div>
+          </div>
+          <div class="mb-3">
+            <label for="service-account-description" class="form-label">{{ _('Description') }}</label>
+            <textarea class="form-control" id="service-account-description" rows="2" maxlength="255"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="service-account-public-key" class="form-label">{{ _('Public Key (PEM)') }}</label>
+            <textarea class="form-control font-monospace" id="service-account-public-key" rows="6" required></textarea>
+            <div class="invalid-feedback" data-field="public_key"></div>
+          </div>
+          <div class="mb-3">
+            <label for="service-account-scopes" class="form-label">{{ _('Scopes (comma separated)') }}</label>
+            <input type="text" class="form-control" id="service-account-scopes" placeholder="maintenance:read, maintenance:write">
+            <div class="form-text">{{ _('Only scopes you already possess can be assigned.') }}</div>
+            <div class="invalid-feedback" data-field="scope_names"></div>
+          </div>
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="service-account-active" checked>
+            <label class="form-check-label" for="service-account-active">{{ _('Enable this account') }}</label>
+          </div>
+          <div class="alert alert-danger mt-3 d-none" id="service-account-error"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
+          <button type="submit" class="btn btn-primary" id="service-account-submit"></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Detail Modal -->
+<div class="modal fade" id="serviceAccountDetailModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="serviceAccountDetailLabel">{{ _('Service Account Details') }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
+      </div>
+      <div class="modal-body">
+        <dl class="row mb-0">
+          <dt class="col-sm-3">{{ _('Name') }}</dt>
+          <dd class="col-sm-9" id="detail-name"></dd>
+          <dt class="col-sm-3">{{ _('Description') }}</dt>
+          <dd class="col-sm-9" id="detail-description"></dd>
+          <dt class="col-sm-3">{{ _('Scopes') }}</dt>
+          <dd class="col-sm-9" id="detail-scopes"></dd>
+          <dt class="col-sm-3">{{ _('Public Key') }}</dt>
+          <dd class="col-sm-9"><pre class="bg-light p-3 small" id="detail-public-key"></pre></dd>
+          <dt class="col-sm-3">{{ _('Registered At') }}</dt>
+          <dd class="col-sm-9" id="detail-registered"></dd>
+          <dt class="col-sm-3">{{ _('Updated At') }}</dt>
+          <dd class="col-sm-9" id="detail-updated"></dd>
+        </dl>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function() {
+  const initialAccounts = {{ accounts|tojson }};
+  const availableScopes = {{ available_scopes|tojson }};
+
+  const tableBody = document.querySelector('#service-account-table tbody');
+  const countLabel = document.getElementById('service-account-count');
+  const availableScopeBadges = document.getElementById('available-scope-badges');
+  const modalElement = document.getElementById('serviceAccountModal');
+  const modal = new bootstrap.Modal(modalElement);
+  const detailModal = new bootstrap.Modal(document.getElementById('serviceAccountDetailModal'));
+  const form = document.getElementById('service-account-form');
+  const errorAlert = document.getElementById('service-account-error');
+  const submitButton = document.getElementById('service-account-submit');
+  const modalTitle = document.getElementById('serviceAccountModalLabel');
+
+  const state = {
+    accounts: initialAccounts,
+    editingId: null,
+  };
+
+  function formatDate(iso) {
+    if (!iso) return '-';
+    try {
+      const date = new Date(iso);
+      if (Number.isNaN(date.getTime())) return '-';
+      return date.toLocaleString();
+    } catch (err) {
+      return '-';
+    }
+  }
+
+  function renderAvailableScopes() {
+    availableScopeBadges.innerHTML = '';
+    if (!availableScopes || !availableScopes.length) {
+      availableScopeBadges.innerHTML = `<span class="badge bg-secondary">{{ _('No scopes available') }}</span>`;
+      return;
+    }
+    availableScopes.sort().forEach(scope => {
+      const span = document.createElement('span');
+      span.className = 'badge bg-info text-dark';
+      span.textContent = scope;
+      availableScopeBadges.appendChild(span);
+    });
+  }
+
+  function renderTable() {
+    tableBody.innerHTML = '';
+    const rows = [];
+    state.accounts.forEach(account => {
+      const tr = document.createElement('tr');
+      const activeBadge = account.active_flg
+        ? `<span class="badge bg-success">{{ _('Active') }}</span>`
+        : `<span class="badge bg-secondary">{{ _('Disabled') }}</span>`;
+      const scopes = account.scope_names
+        ? account.scope_names.split(',').map(scope => `<span class="badge bg-light text-dark me-1">${scope}</span>`).join(' ')
+        : '<span class="text-muted">-</span>';
+      tr.innerHTML = `
+        <td class="fw-semibold">${account.name}</td>
+        <td>${scopes}</td>
+        <td>${activeBadge}</td>
+        <td><small>${formatDate(account.reg_dttm)}</small></td>
+        <td><small>${formatDate(account.mod_dttm)}</small></td>
+        <td class="text-end">
+          <div class="btn-group btn-group-sm" role="group">
+            <button class="btn btn-outline-primary" data-action="view" data-id="${account.service_account_id}">
+              <i class="bi bi-eye"></i>
+            </button>
+            <button class="btn btn-outline-secondary" data-action="edit" data-id="${account.service_account_id}">
+              <i class="bi bi-pencil"></i>
+            </button>
+            <button class="btn btn-outline-danger" data-action="delete" data-id="${account.service_account_id}">
+              <i class="bi bi-trash"></i>
+            </button>
+          </div>
+        </td>
+      `;
+      rows.push(tr);
+    });
+    rows.forEach(row => tableBody.appendChild(row));
+    countLabel.textContent = '{{ _('Total') }}: ' + state.accounts.length;
+  }
+
+  function resetValidation() {
+    form.classList.remove('was-validated');
+    errorAlert.classList.add('d-none');
+    errorAlert.textContent = '';
+    form.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
+    form.querySelectorAll('.invalid-feedback').forEach(el => {
+      el.textContent = '';
+    });
+  }
+
+  function openModal(account) {
+    resetValidation();
+    state.editingId = account ? account.service_account_id : null;
+    modalTitle.textContent = account
+      ? '{{ _('Edit Service Account') }}'
+      : '{{ _('Create Service Account') }}';
+    submitButton.textContent = account ? '{{ _('Save Changes') }}' : '{{ _('Create') }}';
+
+    document.getElementById('service-account-name').value = account ? account.name : '';
+    document.getElementById('service-account-description').value = account?.description || '';
+    document.getElementById('service-account-public-key').value = account ? account.public_key : '';
+    document.getElementById('service-account-scopes').value = account ? account.scope_names : '';
+    document.getElementById('service-account-active').checked = account ? account.active_flg : true;
+
+    modal.show();
+  }
+
+  function showDetail(account) {
+    document.getElementById('detail-name').textContent = account.name;
+    document.getElementById('detail-description').textContent = account.description || '-';
+    document.getElementById('detail-scopes').innerHTML = account.scope_names
+      ? account.scope_names.split(',').map(scope => `<span class="badge bg-secondary me-1">${scope}</span>`).join(' ')
+      : '<span class="text-muted">-</span>';
+    document.getElementById('detail-public-key').textContent = account.public_key || '';
+    document.getElementById('detail-registered').textContent = formatDate(account.reg_dttm);
+    document.getElementById('detail-updated').textContent = formatDate(account.mod_dttm);
+    detailModal.show();
+  }
+
+  function findAccount(id) {
+    return state.accounts.find(item => item.service_account_id === id);
+  }
+
+  function serializeForm() {
+    return {
+      name: document.getElementById('service-account-name').value.trim(),
+      description: document.getElementById('service-account-description').value.trim(),
+      public_key: document.getElementById('service-account-public-key').value.trim(),
+      scope_names: document.getElementById('service-account-scopes').value.trim(),
+      active_flg: document.getElementById('service-account-active').checked,
+    };
+  }
+
+  async function submitForm(event) {
+    event.preventDefault();
+    const formData = serializeForm();
+    form.classList.add('was-validated');
+    if (!form.checkValidity()) {
+      return;
+    }
+
+    const url = state.editingId
+      ? `{{ url_for('admin.service_accounts_update', account_id=0)[:-6] }}${state.editingId}.json`
+      : `{{ url_for('admin.service_accounts_create') }}`;
+    const method = state.editingId ? 'PUT' : 'POST';
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        if (data && data.error) {
+          if (data.field) {
+            const feedback = form.querySelector(`.invalid-feedback[data-field="${data.field}"]`);
+            if (feedback) {
+              feedback.textContent = data.error;
+              feedback.closest('.mb-3')?.querySelector('input,textarea')?.classList.add('is-invalid');
+            }
+          } else {
+            errorAlert.textContent = data.error;
+            errorAlert.classList.remove('d-none');
+          }
+        }
+        return;
+      }
+
+      const item = data.item;
+      if (state.editingId) {
+        const index = state.accounts.findIndex(a => a.service_account_id === item.service_account_id);
+        if (index >= 0) {
+          state.accounts.splice(index, 1, item);
+        }
+      } else {
+        state.accounts.push(item);
+      }
+      renderTable();
+      modal.hide();
+    } catch (error) {
+      errorAlert.textContent = '{{ _('Unexpected error occurred. Please try again.') }}';
+      errorAlert.classList.remove('d-none');
+    }
+  }
+
+  async function deleteAccount(id) {
+    if (!confirm('{{ _('Are you sure you want to delete this service account?') }}')) {
+      return;
+    }
+    const url = `{{ url_for('admin.service_accounts_delete', account_id=0)[:-6] }}${id}.json`;
+    try {
+      const response = await fetch(url, { method: 'DELETE' });
+      if (!response.ok) {
+        return;
+      }
+      state.accounts = state.accounts.filter(acc => acc.service_account_id !== id);
+      renderTable();
+    } catch (error) {
+      console.error('Failed to delete service account', error);
+    }
+  }
+
+  tableBody.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const id = Number.parseInt(button.dataset.id, 10);
+    const action = button.dataset.action;
+    const account = findAccount(id);
+    if (!account) return;
+
+    if (action === 'view') {
+      showDetail(account);
+    } else if (action === 'edit') {
+      openModal(account);
+    } else if (action === 'delete') {
+      deleteAccount(id);
+    }
+  });
+
+  document.getElementById('btn-new-account').addEventListener('click', () => openModal(null));
+  form.addEventListener('submit', submitForm);
+
+  renderTable();
+  renderAvailableScopes();
+})();
+</script>
+{% endblock %}

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -8,6 +8,7 @@ from . import picker_session  # noqa
 from . import openapi  # noqa
 from . import version  # noqa
 from . import upload  # noqa
+from . import maintenance  # noqa
 
 # picker_session Blueprintをapi Blueprintに登録
 from .picker_session import bp as picker_session_bp

--- a/webapp/api/maintenance.py
+++ b/webapp/api/maintenance.py
@@ -1,0 +1,34 @@
+"""Maintenance API endpoints protected by service account JWTs."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+from . import bp
+from ..auth.service_account_auth import require_service_account_scopes
+
+maintenance_bp = Blueprint("maintenance_api", __name__, url_prefix="/maintenance")
+
+
+def _default_audience(req) -> str:
+    base = req.url_root.rstrip("/")
+    return f"{base}/api/maintenance"
+
+
+@maintenance_bp.route("/ping", methods=["GET"])
+@require_service_account_scopes(["maintenance:read"], audience=_default_audience)
+def maintenance_ping():
+    from flask import g
+
+    account = getattr(g, "service_account", None)
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "service_account": account.name if account else None,
+            }
+        ),
+        200,
+    )
+
+
+bp.register_blueprint(maintenance_bp)

--- a/webapp/auth/service_account_auth.py
+++ b/webapp/auth/service_account_auth.py
@@ -1,0 +1,228 @@
+"""Authentication helpers for validating service account JWTs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Iterable, Sequence
+
+import jwt
+from flask import current_app, g, request
+from flask_babel import gettext as _
+
+from core.models.service_account import ServiceAccount
+from webapp.services.service_account_service import ServiceAccountService
+
+_ALLOWED_ALGORITHMS = {"ES256", "RS256"}
+_MAX_TOKEN_LIFETIME = timedelta(minutes=10)
+
+
+@dataclass
+class ServiceAccountJWTError(Exception):
+    code: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass repr is enough
+        return self.message
+
+
+class ServiceAccountTokenValidator:
+    """Verify JWT signed tokens issued by registered service accounts."""
+
+    @staticmethod
+    def _select_account(claims: dict) -> ServiceAccount:
+        account_name = claims.get("iss") or claims.get("sub")
+        if not account_name:
+            raise ServiceAccountJWTError(
+                "UnknownAccount",
+                _("The service account identifier is missing from the token."),
+            )
+
+        account = ServiceAccountService.get_by_name(account_name)
+        if not account:
+            raise ServiceAccountJWTError(
+                "UnknownAccount",
+                _("The service account is not registered."),
+            )
+        if not account.active_flg:
+            raise ServiceAccountJWTError(
+                "DisabledAccount",
+                _("The service account is disabled."),
+            )
+        return account
+
+    @classmethod
+    def verify(
+        cls,
+        token: str,
+        *,
+        audience: str | Sequence[str] | None,
+        required_scopes: Iterable[str] | None = None,
+    ) -> tuple[ServiceAccount, dict]:
+        if not token:
+            raise ServiceAccountJWTError(
+                "UnknownAccount",
+                _("The token is not provided."),
+            )
+
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as exc:
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("The JWT header is invalid."),
+            ) from exc
+
+        algorithm = header.get("alg")
+        if algorithm not in _ALLOWED_ALGORITHMS:
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("The signature algorithm is not supported."),
+            )
+
+        try:
+            unsigned_claims = jwt.decode(
+                token,
+                options={"verify_signature": False, "verify_exp": False, "verify_aud": False},
+                algorithms=[algorithm],
+            )
+        except jwt.InvalidTokenError as exc:
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("Failed to parse the JWT."),
+            ) from exc
+
+        account = cls._select_account(unsigned_claims)
+
+        try:
+            claims = jwt.decode(
+                token,
+                key=account.public_key,
+                algorithms=[algorithm],
+                audience=audience,
+                options={"require": ["iat", "exp"]},
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise ServiceAccountJWTError(
+                "ExpiredToken",
+                _("The token has expired."),
+            ) from exc
+        except jwt.InvalidAudienceError as exc:
+            raise ServiceAccountJWTError(
+                "InvalidAudience",
+                _("The audience does not match."),
+            ) from exc
+        except jwt.InvalidSignatureError as exc:
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("Failed to verify the signature."),
+            ) from exc
+        except jwt.InvalidTokenError as exc:
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("The JWT is invalid."),
+            ) from exc
+
+        issued_at = datetime.fromtimestamp(claims["iat"], timezone.utc)
+        expires_at = datetime.fromtimestamp(claims["exp"], timezone.utc)
+        if expires_at <= issued_at:
+            raise ServiceAccountJWTError(
+                "ExpiredToken",
+                _("The token lifetime is invalid."),
+            )
+        if expires_at - issued_at > _MAX_TOKEN_LIFETIME:
+            raise ServiceAccountJWTError(
+                "ExpiredToken",
+                _("The token lifetime exceeds the maximum allowed."),
+            )
+
+        now = datetime.now(timezone.utc)
+        if issued_at - now > timedelta(minutes=1):  # clock skew guard
+            raise ServiceAccountJWTError(
+                "InvalidSignature",
+                _("The token issue time is in the future."),
+            )
+
+        account_scopes = set(account.scopes)
+        if required_scopes:
+            missing = [scope for scope in required_scopes if scope not in account_scopes]
+            if missing:
+                raise ServiceAccountJWTError(
+                    "InvalidScope",
+                    _("The required scope is not granted."),
+                )
+
+        return account, claims
+
+
+def _extract_bearer_token() -> str | None:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return auth_header.split(" ", 1)[1].strip()
+    return None
+
+
+def require_service_account_scopes(
+    scopes: Sequence[str] | None,
+    *,
+    audience: str | Sequence[str] | Callable[[object], str | Sequence[str]],
+):
+    """Decorator to protect endpoints that require service account authentication."""
+
+    def decorator(func):
+        from functools import wraps
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            token = _extract_bearer_token()
+            if callable(audience):
+                resolved_audience = audience(request)
+            else:
+                resolved_audience = audience
+
+            try:
+                account, claims = ServiceAccountTokenValidator.verify(
+                    token,
+                    audience=resolved_audience,
+                    required_scopes=scopes,
+                )
+            except ServiceAccountJWTError as exc:
+                current_app.logger.info(
+                    "Service account authentication failed.",
+                    extra={
+                        "event": "service_account.auth_failed",
+                        "code": exc.code,
+                        "message": exc.message,
+                        "endpoint": request.path,
+                    },
+                )
+                status = 401 if exc.code in {"InvalidSignature", "ExpiredToken"} else 403
+                response = {
+                    "error": exc.code,
+                    "message": exc.message,
+                }
+                return response, status
+
+            g.service_account = account
+            g.service_account_claims = claims
+
+            current_app.logger.debug(
+                "Service account authentication success.",
+                extra={
+                    "event": "service_account.auth_success",
+                    "service_account": account.name,
+                    "endpoint": request.path,
+                    "scopes": list(scopes or []),
+                },
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = [
+    "ServiceAccountTokenValidator",
+    "ServiceAccountJWTError",
+    "require_service_account_scopes",
+]

--- a/webapp/services/service_account_service.py
+++ b/webapp/services/service_account_service.py
@@ -1,0 +1,227 @@
+"""Service layer for managing service accounts and their credentials."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from flask import current_app
+from flask_babel import gettext as _
+from sqlalchemy.exc import IntegrityError
+
+from core.db import db
+from core.models.service_account import ServiceAccount
+
+
+@dataclass
+class ServiceAccountValidationError(Exception):
+    message: str
+    field: str | None = None
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass will cover
+        return self.message
+
+
+class ServiceAccountNotFoundError(Exception):
+    pass
+
+
+class ServiceAccountService:
+    allowed_algorithms = {"ES256", "RS256"}
+
+    @staticmethod
+    def _normalize_public_key(pem_text: str) -> str:
+        if not pem_text or not pem_text.strip():
+            raise ServiceAccountValidationError(
+                _("Please provide a public key."), field="public_key"
+            )
+
+        text = pem_text.strip().encode("utf-8")
+        if b"BEGIN PUBLIC KEY" not in text:
+            header = b"-----BEGIN PUBLIC KEY-----\n"
+            footer = b"\n-----END PUBLIC KEY-----"
+            text = header + text.replace(b"\r", b"") + footer
+        else:
+            text = text.replace(b"\r", b"")
+
+        try:
+            key = load_pem_public_key(text)
+        except Exception as exc:  # pragma: no cover - cryptography provides detailed error
+            raise ServiceAccountValidationError(
+                _("The public key is not a valid PEM-formatted value."),
+                field="public_key",
+            ) from exc
+
+        if not isinstance(key, (EllipticCurvePublicKey, RSAPublicKey)):
+            raise ServiceAccountValidationError(
+                _("The provided public key type is not supported."),
+                field="public_key",
+            )
+
+        normalized = key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        # 末尾の改行や余分な空白を除去し、統一した形式で保存
+        lines = [line.strip() for line in normalized.decode("utf-8").strip().splitlines()]
+        return "\n".join(lines)
+
+    @staticmethod
+    def _normalize_scopes(
+        scopes: str | Sequence[str],
+        *,
+        allowed_scopes: Iterable[str] | None,
+    ) -> List[str]:
+        if isinstance(scopes, str):
+            raw = [part.strip() for part in scopes.split(",")]
+        else:
+            raw = [str(part).strip() for part in scopes]
+
+        normalized: List[str] = []
+        seen = set()
+        for scope in raw:
+            if not scope:
+                continue
+            if scope in seen:
+                continue
+            normalized.append(scope)
+            seen.add(scope)
+
+        if allowed_scopes is not None:
+            allowed_set = {scope.strip() for scope in allowed_scopes if scope}
+            disallowed = [scope for scope in normalized if scope not in allowed_set]
+            if disallowed:
+                raise ServiceAccountValidationError(
+                    _("You are not allowed to assign the specified scopes."),
+                    field="scope_names",
+                )
+
+        return normalized
+
+    @classmethod
+    def create_account(
+        cls,
+        *,
+        name: str,
+        description: str | None,
+        public_key: str,
+        scope_names: str | Sequence[str],
+        active: bool,
+        allowed_scopes: Iterable[str] | None,
+    ) -> ServiceAccount:
+        if not name or not name.strip():
+            raise ServiceAccountValidationError(
+                _("Please provide a service account name."), field="name"
+            )
+
+        normalized_key = cls._normalize_public_key(public_key)
+        normalized_scopes = cls._normalize_scopes(scope_names, allowed_scopes=allowed_scopes)
+
+        account = ServiceAccount(
+            name=name.strip(),
+            description=description.strip() if description else None,
+            public_key=normalized_key,
+            active_flg=bool(active),
+        )
+        account.set_scopes(normalized_scopes)
+
+        db.session.add(account)
+        try:
+            db.session.commit()
+        except IntegrityError as exc:
+            db.session.rollback()
+            raise ServiceAccountValidationError(
+                _("A service account with the same name already exists."),
+                field="name",
+            ) from exc
+
+        current_app.logger.info(
+            "Service account created.",
+            extra={
+                "event": "service_account.created",
+                "service_account": account.name,
+                "active": account.active_flg,
+                "scopes": normalized_scopes,
+            },
+        )
+        return account
+
+    @classmethod
+    def update_account(
+        cls,
+        account_id: int,
+        *,
+        name: str,
+        description: str | None,
+        public_key: str,
+        scope_names: str | Sequence[str],
+        active: bool,
+        allowed_scopes: Iterable[str] | None,
+    ) -> ServiceAccount:
+        account = ServiceAccount.query.get(account_id)
+        if not account:
+            raise ServiceAccountNotFoundError()
+
+        if not name or not name.strip():
+            raise ServiceAccountValidationError(
+                _("Please provide a service account name."), field="name"
+            )
+
+        normalized_key = cls._normalize_public_key(public_key)
+        normalized_scopes = cls._normalize_scopes(scope_names, allowed_scopes=allowed_scopes)
+
+        account.name = name.strip()
+        account.description = description.strip() if description else None
+        account.public_key = normalized_key
+        account.active_flg = bool(active)
+        account.set_scopes(normalized_scopes)
+
+        try:
+            db.session.commit()
+        except IntegrityError as exc:
+            db.session.rollback()
+            raise ServiceAccountValidationError(
+                _("A service account with the same name already exists."),
+                field="name",
+            ) from exc
+
+        current_app.logger.info(
+            "Service account updated.",
+            extra={
+                "event": "service_account.updated",
+                "service_account": account.name,
+                "active": account.active_flg,
+                "scopes": normalized_scopes,
+            },
+        )
+        return account
+
+    @staticmethod
+    def delete_account(account_id: int) -> None:
+        account = ServiceAccount.query.get(account_id)
+        if not account:
+            raise ServiceAccountNotFoundError()
+
+        db.session.delete(account)
+        db.session.commit()
+
+        current_app.logger.info(
+            "Service account deleted.",
+            extra={
+                "event": "service_account.deleted",
+                "service_account": account.name,
+            },
+        )
+
+    @staticmethod
+    def list_accounts() -> list[ServiceAccount]:
+        return ServiceAccount.query.order_by(ServiceAccount.name.asc()).all()
+
+    @staticmethod
+    def get_by_name(name: str) -> ServiceAccount | None:
+        if not name:
+            return None
+        return ServiceAccount.query.filter_by(name=name).first()

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -40,6 +40,69 @@ msgstr "Invalid email or password"
 msgid "Email and password are required"
 msgstr "Email and password are required"
 
+msgid "Please provide a public key."
+msgstr "Please provide a public key."
+
+msgid "The public key is not a valid PEM-formatted value."
+msgstr "The public key is not a valid PEM-formatted value."
+
+msgid "The provided public key type is not supported."
+msgstr "The provided public key type is not supported."
+
+msgid "You are not allowed to assign the specified scopes."
+msgstr "You are not allowed to assign the specified scopes."
+
+msgid "Please provide a service account name."
+msgstr "Please provide a service account name."
+
+msgid "A service account with the same name already exists."
+msgstr "A service account with the same name already exists."
+
+msgid "The service account identifier is missing from the token."
+msgstr "The service account identifier is missing from the token."
+
+msgid "The service account is not registered."
+msgstr "The service account is not registered."
+
+msgid "The service account is disabled."
+msgstr "The service account is disabled."
+
+msgid "The token is not provided."
+msgstr "The token is not provided."
+
+msgid "The JWT header is invalid."
+msgstr "The JWT header is invalid."
+
+msgid "The signature algorithm is not supported."
+msgstr "The signature algorithm is not supported."
+
+msgid "Failed to parse the JWT."
+msgstr "Failed to parse the JWT."
+
+msgid "The token has expired."
+msgstr "The token has expired."
+
+msgid "The audience does not match."
+msgstr "The audience does not match."
+
+msgid "Failed to verify the signature."
+msgstr "Failed to verify the signature."
+
+msgid "The JWT is invalid."
+msgstr "The JWT is invalid."
+
+msgid "The token lifetime is invalid."
+msgstr "The token lifetime is invalid."
+
+msgid "The token lifetime exceeds the maximum allowed."
+msgstr "The token lifetime exceeds the maximum allowed."
+
+msgid "The token issue time is in the future."
+msgstr "The token issue time is in the future."
+
+msgid "The required scope is not granted."
+msgstr "The required scope is not granted."
+
 msgid "Email already exists"
 msgstr "Email already exists"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -599,6 +599,75 @@ msgstr "登録が完了しました。ログインしてください。"
 msgid "Email and password are required"
 msgstr "メールアドレスとパスワードは必須です"
 
+#: webapp/services/service_account_service.py:34
+msgid "Please provide a public key."
+msgstr "公開鍵を入力してください。"
+
+#: webapp/services/service_account_service.py:45
+msgid "The public key is not a valid PEM-formatted value."
+msgstr "公開鍵のPEM形式が正しくありません。"
+
+#: webapp/services/service_account_service.py:51
+msgid "The provided public key type is not supported."
+msgstr "サポートされていない公開鍵の種類です。"
+
+#: webapp/services/service_account_service.py:72
+msgid "You are not allowed to assign the specified scopes."
+msgstr "指定されたスコープを付与する権限がありません。"
+
+#: webapp/services/service_account_service.py:90
+msgid "Please provide a service account name."
+msgstr "アカウント名を入力してください。"
+
+#: webapp/services/service_account_service.py:107
+msgid "A service account with the same name already exists."
+msgstr "同じアカウント名が既に存在します。"
+
+msgid "The service account identifier is missing from the token."
+msgstr "トークンにサービスアカウント識別子が含まれていません。"
+
+msgid "The service account is not registered."
+msgstr "サービスアカウントが登録されていません。"
+
+msgid "The service account is disabled."
+msgstr "サービスアカウントが無効化されています。"
+
+msgid "The token is not provided."
+msgstr "トークンが指定されていません。"
+
+msgid "The JWT header is invalid."
+msgstr "JWTヘッダが不正です。"
+
+msgid "The signature algorithm is not supported."
+msgstr "サポートされていない署名方式です。"
+
+msgid "Failed to parse the JWT."
+msgstr "JWTの解析に失敗しました。"
+
+msgid "The token has expired."
+msgstr "トークンの有効期限が切れています。"
+
+msgid "The audience does not match."
+msgstr "audienceが一致しません。"
+
+msgid "Failed to verify the signature."
+msgstr "署名の検証に失敗しました。"
+
+msgid "The JWT is invalid."
+msgstr "JWTが不正です。"
+
+msgid "The token lifetime is invalid."
+msgstr "トークンの有効期限が不正です。"
+
+msgid "The token lifetime exceeds the maximum allowed."
+msgstr "トークンの有効期限が長すぎます。"
+
+msgid "The token issue time is in the future."
+msgstr "トークンの発行時刻が未来です。"
+
+msgid "The required scope is not granted."
+msgstr "必要なスコープが付与されていません。"
+
 #: webapp/auth/routes.py:70 webapp/auth/routes.py:115 webapp/auth/routes.py:226
 msgid "Email already exists"
 msgstr "このメールアドレスは既に登録されています"


### PR DESCRIPTION
## Summary
- replace remaining hard-coded Japanese service account authentication errors with English gettext strings
- add matching translation catalog entries for the new authentication messages in English and Japanese

## Testing
- pytest tests/test_service_account_jwt.py

------
https://chatgpt.com/codex/tasks/task_e_68efbae72f94832395bfcb0c39b7e40b