### PR TITLE
Add service accounts navigation link and update icon

### DIFF
--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -29,7 +29,7 @@
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% endif %}

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -18,7 +18,7 @@
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% endif %}

--- a/webapp/admin/templates/admin/google_accounts.html
+++ b/webapp/admin/templates/admin/google_accounts.html
@@ -27,7 +27,7 @@
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% endif %}

--- a/webapp/admin/templates/admin/permissions.html
+++ b/webapp/admin/templates/admin/permissions.html
@@ -23,7 +23,7 @@
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% endif %}

--- a/webapp/admin/templates/admin/roles.html
+++ b/webapp/admin/templates/admin/roles.html
@@ -23,7 +23,7 @@
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% endif %}

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -33,7 +33,7 @@
   {% endif %}
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-robot"></i> {{ _('Service Accounts') }}
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
     </a>
   </li>
   {% if current_user.can('role:manage') %}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -59,20 +59,27 @@
         {% if current_user.is_authenticated %}
           {% set show_system_manage = current_user.can('system:manage') %}
           {% set show_admin_only = current_user.has_role('admin') %}
+          {% set show_user_manage = current_user.can('user:manage') %}
+          {% set show_service_accounts = current_user.can('service_account:manage') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
             </a>
           </li>
-          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_system_manage or show_admin_only %}
+          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_system_manage or show_admin_only %}
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               {{ _('Management') }}
             </a>
             <ul class="dropdown-menu" aria-labelledby="managementNavDropdown">
-              {% if current_user.can('user:manage') %}
+              {% if show_user_manage %}
               <li><a class="dropdown-item" href="{{ url_for('admin.user') }}">{{ _('User Management') }}</a></li>
               <li><a class="dropdown-item" href="{{ url_for('admin.google_accounts') }}">{{ _('Google Accounts') }}</a></li>
+              {% endif %}
+              {% if show_service_accounts %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
+              {% endif %}
+              {% if show_user_manage %}
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="{{ url_for('admin.show_config') }}">{{ _('Config Settings') }}</a></li>
               <li><a class="dropdown-item" href="{{ url_for('admin.show_version') }}">{{ _('Version Info') }}</a></li>


### PR DESCRIPTION
## Summary
- expose the service accounts management page in the header dropdown when the user has the right permission
- replace the service accounts navigation icon with a key motif across the admin templates for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0125eff70832382cdcd27a94d230a