### PR TITLE
Add scope selector UI for service accounts

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -1,6 +1,25 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Service Accounts') }}{% endblock %}
 
+{% block extra_head %}
+<style>
+  #service-account-scope-list .scope-option {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: var(--bs-body-bg);
+  }
+  #service-account-scope-list .scope-option:hover {
+    border-color: rgba(13, 110, 253, 0.35);
+    box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.1);
+  }
+  #service-account-scope-list .form-check-input:focus {
+    box-shadow: none;
+  }
+  [data-scope-selection] .card.border-danger {
+    box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.15);
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="d-flex align-items-center justify-content-between mb-4">
   <div>
@@ -105,10 +124,38 @@
             <textarea class="form-control font-monospace" id="service-account-public-key" rows="6" required></textarea>
             <div class="invalid-feedback" data-field="public_key"></div>
           </div>
-          <div class="mb-3">
-            <label for="service-account-scopes" class="form-label">{{ _('Scopes (comma separated)') }}</label>
-            <input type="text" class="form-control" id="service-account-scopes" placeholder="maintenance:read, maintenance:write">
-            <div class="form-text">{{ _('Only scopes you already possess can be assigned.') }}</div>
+          <div class="mb-3" data-scope-selection>
+            <label class="form-label fw-semibold" for="service-account-scope-search">{{ _('Scopes') }}</label>
+            <p class="text-muted small mb-3">{{ _('Select the scopes this service account should have access to.') }}</p>
+            <div class="card border" id="service-account-scope-card">
+              <div class="card-body">
+                <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-between mb-3">
+                  <div>
+                    <h6 class="mb-1">{{ _('Selected scopes') }}</h6>
+                    <span class="badge bg-primary" id="service-account-scope-count">0</span>
+                  </div>
+                  <div class="input-group">
+                    <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
+                    <input
+                      type="search"
+                      class="form-control"
+                      id="service-account-scope-search"
+                      placeholder="{{ _('Search scopes...') }}"
+                      aria-label="{{ _('Search scopes') }}"
+                    >
+                  </div>
+                </div>
+                <div class="mb-3">
+                  <div id="service-account-scope-summary" class="d-flex flex-wrap gap-2"></div>
+                  <p class="text-muted small mb-0" id="service-account-scope-none">{{ _('No scopes selected yet. Choose from the list below.') }}</p>
+                </div>
+                <div class="row row-cols-1 row-cols-md-2 g-2" id="service-account-scope-list"></div>
+                <div class="alert alert-light border d-none mt-3 text-center" id="service-account-scope-empty" role="status">
+                  <i class="fas fa-info-circle me-2 text-muted"></i>{{ _('No scopes match your search.') }}
+                </div>
+              </div>
+            </div>
+            <div class="form-text mt-2">{{ _('Only scopes you already possess can be assigned.') }}</div>
             <div class="invalid-feedback" data-field="scope_names"></div>
           </div>
           <div class="form-check form-switch">
@@ -174,11 +221,261 @@
   const errorAlert = document.getElementById('service-account-error');
   const submitButton = document.getElementById('service-account-submit');
   const modalTitle = document.getElementById('serviceAccountModalLabel');
+  const scopeListContainer = document.getElementById('service-account-scope-list');
+  const scopeSummaryContainer = document.getElementById('service-account-scope-summary');
+  const scopeCountBadge = document.getElementById('service-account-scope-count');
+  const scopeEmptyMessage = document.getElementById('service-account-scope-empty');
+  const scopeSearchInput = document.getElementById('service-account-scope-search');
+  const scopeNoneSelectedMessage = document.getElementById('service-account-scope-none');
+  const scopeSelectionCard = document.getElementById('service-account-scope-card');
+  const noScopesAvailableText = {{ _('You do not have any scopes that can be assigned yet.')|tojson }};
+  const lockedScopeNote = {{ _('This scope cannot be modified with your current permissions.')|tojson }};
 
   const state = {
     accounts: initialAccounts,
     editingId: null,
   };
+
+  const scopeCheckboxes = new Map();
+  let scopeOptionCounter = 0;
+
+  function createScopeColumn(scope, { disabled = false, note = '', prepend = false } = {}) {
+    if (!scopeListContainer) {
+      return null;
+    }
+
+    scopeListContainer.querySelectorAll('.alert').forEach((alertElement) => {
+      const container = alertElement.closest('.col');
+      if (container && container.parentElement === scopeListContainer) {
+        container.remove();
+      }
+    });
+
+    const column = document.createElement('div');
+    column.className = 'col';
+    column.dataset.scopeCode = scope.toLowerCase();
+
+    const option = document.createElement('div');
+    option.className = 'scope-option border rounded-3 p-3 h-100';
+    if (disabled) {
+      option.classList.add('bg-light', 'border-warning');
+    }
+
+    const formCheck = document.createElement('div');
+    formCheck.className = 'form-check';
+
+    const checkbox = document.createElement('input');
+    checkbox.className = 'form-check-input';
+    checkbox.type = 'checkbox';
+    checkbox.value = scope;
+    checkbox.id = `service-account-scope-${scopeOptionCounter++}`;
+    checkbox.disabled = disabled;
+
+    const label = document.createElement('label');
+    label.className = 'form-check-label d-block';
+    label.setAttribute('for', checkbox.id);
+
+    const { categoryDisplay, actionDisplay } = getScopeParts(scope);
+
+    if (categoryDisplay) {
+      const badge = document.createElement('span');
+      badge.className = 'badge rounded-pill bg-light text-dark text-uppercase small fw-semibold me-2';
+      badge.textContent = categoryDisplay;
+      label.appendChild(badge);
+    }
+
+    const codeSpan = document.createElement('span');
+    codeSpan.className = 'fw-semibold';
+    codeSpan.textContent = scope;
+    label.appendChild(codeSpan);
+
+    if (actionDisplay) {
+      const actionEl = document.createElement('div');
+      actionEl.className = 'text-muted small mt-1';
+      actionEl.textContent = actionDisplay;
+      label.appendChild(actionEl);
+    }
+
+    if (note) {
+      const noteEl = document.createElement('div');
+      noteEl.className = 'text-muted small mt-2';
+      noteEl.textContent = note;
+      label.appendChild(noteEl);
+    }
+
+    formCheck.appendChild(checkbox);
+    formCheck.appendChild(label);
+    option.appendChild(formCheck);
+    column.appendChild(option);
+
+    if (prepend && typeof scopeListContainer.prepend === 'function') {
+      scopeListContainer.prepend(column);
+    } else {
+      scopeListContainer.appendChild(column);
+    }
+
+    if (scopeSearchInput) {
+      scopeSearchInput.disabled = false;
+    }
+
+    scopeCheckboxes.set(scope, checkbox);
+
+    if (!disabled) {
+      checkbox.addEventListener('change', updateScopeSummary);
+    }
+
+    return checkbox;
+  }
+
+  function getScopeParts(scope) {
+    const parts = scope.split(':');
+    const category = parts.shift() || '';
+    const action = parts.join(':');
+
+    const categoryDisplay = category
+      ? category.replace(/[_-]+/g, ' ').trim().toUpperCase()
+      : '';
+
+    let actionDisplay = '';
+    if (action) {
+      const cleaned = action.replace(/[_-]+/g, ' ').trim();
+      actionDisplay = cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+    }
+
+    return {
+      category,
+      action,
+      categoryDisplay,
+      actionDisplay,
+    };
+  }
+
+  function updateScopeSummary() {
+    if (!scopeSummaryContainer || !scopeCountBadge) {
+      return;
+    }
+
+    const selected = Array.from(scopeCheckboxes.values())
+      .filter((checkbox) => checkbox.checked)
+      .map((checkbox) => checkbox.value);
+
+    scopeCountBadge.textContent = selected.length;
+    scopeSummaryContainer.innerHTML = '';
+
+    if (!selected.length) {
+      if (scopeNoneSelectedMessage) {
+        scopeNoneSelectedMessage.classList.remove('d-none');
+      }
+      return;
+    }
+
+    if (scopeNoneSelectedMessage) {
+      scopeNoneSelectedMessage.classList.add('d-none');
+    }
+
+    selected
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((scope) => {
+        const badge = document.createElement('span');
+        badge.className = 'badge bg-secondary';
+        badge.textContent = scope;
+        scopeSummaryContainer.appendChild(badge);
+      });
+  }
+
+  function filterScopes(keyword) {
+    if (!scopeListContainer || !scopeEmptyMessage) {
+      return;
+    }
+
+    const normalized = keyword.trim().toLowerCase();
+    let visible = 0;
+
+    scopeListContainer.querySelectorAll('[data-scope-code]').forEach((item) => {
+      const code = item.dataset.scopeCode || '';
+      const matches = !normalized || code.includes(normalized);
+      item.style.display = matches ? '' : 'none';
+      if (matches) {
+        visible += 1;
+      }
+    });
+
+    if (visible === 0) {
+      scopeEmptyMessage.classList.remove('d-none');
+    } else {
+      scopeEmptyMessage.classList.add('d-none');
+    }
+  }
+
+  function buildScopeOptions() {
+    if (!scopeListContainer) {
+      return;
+    }
+
+    scopeCheckboxes.clear();
+    scopeListContainer.innerHTML = '';
+    scopeOptionCounter = 0;
+
+    const uniqueScopes = Array.from(new Set(availableScopes || []))
+      .map((scope) => scope.trim())
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+
+    if (!uniqueScopes.length) {
+      const empty = document.createElement('div');
+      empty.className = 'col';
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-light border mb-0';
+      alert.setAttribute('role', 'status');
+      const icon = document.createElement('i');
+      icon.className = 'fas fa-info-circle me-2 text-muted';
+      alert.appendChild(icon);
+      alert.appendChild(document.createTextNode(noScopesAvailableText));
+      empty.appendChild(alert);
+      scopeListContainer.appendChild(empty);
+      if (scopeSearchInput) {
+        scopeSearchInput.disabled = true;
+      }
+      updateScopeSummary();
+      if (scopeEmptyMessage) {
+        scopeEmptyMessage.classList.add('d-none');
+      }
+      return;
+    }
+
+    if (scopeSearchInput) {
+      scopeSearchInput.disabled = false;
+    }
+
+    uniqueScopes.forEach((scope) => {
+      createScopeColumn(scope);
+    });
+
+    updateScopeSummary();
+    filterScopes(scopeSearchInput ? scopeSearchInput.value : '');
+  }
+
+  function setSelectedScopes(scopes) {
+    const selectedSet = new Set((scopes || []).map((scope) => scope.trim()).filter(Boolean));
+
+    selectedSet.forEach((scope) => {
+      if (!scopeCheckboxes.has(scope)) {
+        const checkbox = createScopeColumn(scope, { disabled: true, note: lockedScopeNote, prepend: true });
+        if (checkbox) {
+          checkbox.checked = true;
+        }
+      }
+    });
+
+    scopeCheckboxes.forEach((checkbox) => {
+      checkbox.checked = selectedSet.has(checkbox.value);
+    });
+
+    updateScopeSummary();
+    if (scopeSearchInput) {
+      filterScopes(scopeSearchInput.value);
+    }
+  }
 
   function formatDate(iso) {
     if (!iso) return '-';
@@ -249,7 +546,11 @@
     form.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
     form.querySelectorAll('.invalid-feedback').forEach(el => {
       el.textContent = '';
+      el.classList.remove('d-block');
     });
+    if (scopeSelectionCard) {
+      scopeSelectionCard.classList.remove('border-danger', 'border-2');
+    }
   }
 
   function openModal(account) {
@@ -263,8 +564,17 @@
     document.getElementById('service-account-name').value = account ? account.name : '';
     document.getElementById('service-account-description').value = account?.description || '';
     document.getElementById('service-account-public-key').value = account ? account.public_key : '';
-    document.getElementById('service-account-scopes').value = account ? account.scope_names : '';
     document.getElementById('service-account-active').checked = account ? account.active_flg : true;
+
+    if (scopeSearchInput) {
+      scopeSearchInput.value = '';
+      filterScopes('');
+    }
+
+    const selectedScopes = account && account.scope_names
+      ? account.scope_names.split(',').map((scope) => scope.trim()).filter(Boolean)
+      : [];
+    setSelectedScopes(selectedScopes);
 
     modal.show();
   }
@@ -290,7 +600,10 @@
       name: document.getElementById('service-account-name').value.trim(),
       description: document.getElementById('service-account-description').value.trim(),
       public_key: document.getElementById('service-account-public-key').value.trim(),
-      scope_names: document.getElementById('service-account-scopes').value.trim(),
+      scope_names: Array.from(scopeCheckboxes.values())
+        .filter((checkbox) => checkbox.checked)
+        .map((checkbox) => checkbox.value)
+        .join(','),
       active_flg: document.getElementById('service-account-active').checked,
     };
   }
@@ -321,7 +634,12 @@
             const feedback = form.querySelector(`.invalid-feedback[data-field="${data.field}"]`);
             if (feedback) {
               feedback.textContent = data.error;
-              feedback.closest('.mb-3')?.querySelector('input,textarea')?.classList.add('is-invalid');
+              if (data.field === 'scope_names') {
+                feedback.classList.add('d-block');
+                scopeSelectionCard?.classList.add('border-danger', 'border-2');
+              } else {
+                feedback.closest('.mb-3')?.querySelector('input,textarea')?.classList.add('is-invalid');
+              }
             }
           } else {
             errorAlert.textContent = data.error;
@@ -384,6 +702,13 @@
 
   document.getElementById('btn-new-account').addEventListener('click', () => openModal(null));
   form.addEventListener('submit', submitForm);
+
+  buildScopeOptions();
+  if (scopeSearchInput) {
+    scopeSearchInput.addEventListener('input', (event) => {
+      filterScopes(event.target.value);
+    });
+  }
 
   renderTable();
   renderAvailableScopes();


### PR DESCRIPTION
## Summary
- replace the comma-separated scope input on the service account modal with an interactive selector patterned after the role editor
- add client-side filtering, selection badges, and validation feedback for scope choices including support for scopes outside the current user's assignable list

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f012a720408323b122f8afb7d40a1c