### PR TITLE
Fix service account scope selection scroll behavior

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -14,6 +14,19 @@
   #service-account-scope-list .form-check-input:focus {
     box-shadow: none;
   }
+  #service-account-scope-list {
+    max-height: min(52vh, 420px);
+    overflow-y: auto;
+    margin: 0;
+    padding-inline: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    -webkit-overflow-scrolling: touch;
+    scrollbar-gutter: stable both-edges;
+  }
+  @media (max-width: 767.98px) {
+    #service-account-scope-list {
+      max-height: min(60vh, 360px);
+    }
+  }
   [data-scope-selection] .card.border-danger {
     box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.15);
   }


### PR DESCRIPTION
## Summary
- add a max-height and overflow to the service account scope list so long permission lists remain scrollable
- adjust the padding and responsive limits so the two-column grid stays usable on smaller viewports

## Testing
- ⚠️ pytest -q *(interrupted after partial execution; UI-only change)*

------
https://chatgpt.com/codex/tasks/task_e_68f016c8a2348323b833837aa3ba7364