### PR TITLE
Adjust service account modal scrolling

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -15,17 +15,8 @@
     box-shadow: none;
   }
   #service-account-scope-list {
-    max-height: min(52vh, 420px);
-    overflow-y: auto;
     margin: 0;
     padding-inline: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
-    -webkit-overflow-scrolling: touch;
-    scrollbar-gutter: stable both-edges;
-  }
-  @media (max-width: 767.98px) {
-    #service-account-scope-list {
-      max-height: min(60vh, 360px);
-    }
   }
   [data-scope-selection] .card.border-danger {
     box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.15);


### PR DESCRIPTION
## Summary
- remove the fixed height and overflow limits from the service account scope list
- let the modal body handle scrolling so scope selection is easier on small viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f01be361248323bc527ad854d41d7d