### PR TITLE
Adjust service account modal scrolling

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -3,6 +3,18 @@
 
 {% block extra_head %}
 <style>
+  #serviceAccountModal .modal-dialog {
+    height: calc(100vh - 2rem);
+  }
+  #serviceAccountModal .modal-content {
+    height: 100%;
+  }
+  #serviceAccountModal .modal-body {
+    overflow-y: auto;
+  }
+  #serviceAccountModal #service-account-scope-card .card-body {
+    overflow: visible;
+  }
   #service-account-scope-list .scope-option {
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
     background: var(--bs-body-bg);


### PR DESCRIPTION
## Summary
- allow the entire Create Service Account modal to scroll within the viewport
- ensure the scope selection card no longer traps scrolling so permissions are easier to browse

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f0271f93a48323a5722929d2286c67