### PR TITLE
Drop legacy public key from service account model

### DIFF
--- a/core/models/service_account.py
+++ b/core/models/service_account.py
@@ -20,7 +20,7 @@ class ServiceAccount(db.Model):
     service_account_id = db.Column(BigInt, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
     description = db.Column(db.String(255), nullable=True)
-    public_key = db.Column(db.Text, nullable=False)
+    jtk_endpoint = db.Column(db.String(500), nullable=True)
     scope_names = db.Column(db.String(1000), nullable=False, default="")
     active_flg = db.Column(db.Boolean, nullable=False, default=True)
     reg_dttm = db.Column(
@@ -63,7 +63,7 @@ class ServiceAccount(db.Model):
             "service_account_id": self.service_account_id,
             "name": self.name,
             "description": self.description,
-            "public_key": self.public_key,
+            "jtk_endpoint": self.jtk_endpoint,
             "scope_names": self.scope_names,
             "active_flg": self.active_flg,
             "reg_dttm": self.reg_dttm.isoformat() if self.reg_dttm else None,

--- a/migrations/versions/0e7d64c89741_drop_public_key_column.py
+++ b/migrations/versions/0e7d64c89741_drop_public_key_column.py
@@ -1,0 +1,21 @@
+"""Remove deprecated public_key column from service_account."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0e7d64c89741'
+down_revision = '5d9d9f9a2b7e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('service_account') as batch_op:
+        batch_op.drop_column('public_key')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('service_account') as batch_op:
+        batch_op.add_column(sa.Column('public_key', sa.Text(), nullable=True))

--- a/migrations/versions/5d9d9f9a2b7e_add_jtk_endpoint_to_service_account.py
+++ b/migrations/versions/5d9d9f9a2b7e_add_jtk_endpoint_to_service_account.py
@@ -1,0 +1,33 @@
+"""add jtk endpoint to service account"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5d9d9f9a2b7e'
+down_revision = 'd1f6a0f9035e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'service_account',
+        sa.Column('jtk_endpoint', sa.String(length=500), nullable=True),
+    )
+    op.alter_column(
+        'service_account',
+        'public_key',
+        existing_type=sa.Text(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'service_account',
+        'public_key',
+        existing_type=sa.Text(),
+        nullable=False,
+    )
+    op.drop_column('service_account', 'jtk_endpoint')

--- a/tests/test_service_account_jwt.py
+++ b/tests/test_service_account_jwt.py
@@ -1,16 +1,22 @@
 from datetime import datetime, timedelta, timezone
 
+import json
 import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from jwt.algorithms import ECAlgorithm, RSAAlgorithm
 
 from core.db import db
 from webapp.auth.service_account_auth import (
     ServiceAccountJWTError,
     ServiceAccountTokenValidator,
 )
-from webapp.services.service_account_service import ServiceAccountService
+from webapp.services.service_account_service import (
+    ServiceAccountService,
+    ServiceAccountValidationError,
+)
 
 
 def _generate_es256_key_pair():
@@ -41,12 +47,48 @@ def _generate_rs256_key_pair():
     return private_pem, public_pem
 
 
-def _create_account(app, name: str, public_key: str, scopes: str):
+def _build_jwk(public_pem: str, algorithm: str, kid: str) -> dict:
+    public_key = load_pem_public_key(public_pem.encode("utf-8"))
+    if algorithm == "ES256":
+        jwk_json = ECAlgorithm.to_jwk(public_key)
+    elif algorithm == "RS256":
+        jwk_json = RSAAlgorithm.to_jwk(public_key)
+    else:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
+
+    jwk = json.loads(jwk_json)
+    jwk["kid"] = kid
+    jwk.setdefault("alg", algorithm)
+    jwk.setdefault("use", "sig")
+    return jwk
+
+
+def _mock_jwks(monkeypatch, mapping: dict[str, list[dict]]):
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+            self.status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def fake_get(url, *args, **kwargs):
+        if url not in mapping:
+            raise AssertionError(f"unexpected url {url}")
+        return FakeResponse({"keys": mapping[url]})
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+
+def _create_account(app, name: str, jtk_endpoint: str, scopes: str):
     allowed = [scope.strip() for scope in scopes.split(",") if scope.strip()]
     return ServiceAccountService.create_account(
         name=name,
         description="",
-        public_key=public_key,
+        jtk_endpoint=jtk_endpoint,
         scope_names=scopes,
         active=True,
         allowed_scopes=allowed,
@@ -61,6 +103,7 @@ def _issue_token(
     scopes: str,
     lifetime_minutes: int = 5,
     algorithm: str = "ES256",
+    kid: str = "test-key",
 ):
     now = datetime.now(timezone.utc)
     payload = {
@@ -71,15 +114,25 @@ def _issue_token(
         "exp": int((now + timedelta(minutes=lifetime_minutes)).timestamp()),
         "scope": scopes,
     }
-    return jwt.encode(payload, private_pem, algorithm=algorithm)
+    headers = {"kid": kid}
+    return jwt.encode(payload, private_pem, algorithm=algorithm, headers=headers)
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_success_es256(app_context):
+def test_service_account_jwt_success_es256(app_context, monkeypatch):
     private_pem, public_pem = _generate_es256_key_pair()
-    _create_account(app_context, "maintenance-bot", public_pem, "maintenance:read,maintenance:write")
+    endpoint = "https://example.com/jwks/maintenance"
+    kid = "maintenance-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", kid)]})
+    _create_account(app_context, "maintenance-bot", endpoint, "maintenance:read,maintenance:write")
 
-    token = _issue_token(private_pem, name="maintenance-bot", audience="familink:maintenance", scopes="maintenance:read maintenance:write")
+    token = _issue_token(
+        private_pem,
+        name="maintenance-bot",
+        audience="familink:maintenance",
+        scopes="maintenance:read maintenance:write",
+        kid=kid,
+    )
 
     account, claims = ServiceAccountTokenValidator.verify(
         token,
@@ -92,10 +145,19 @@ def test_service_account_jwt_success_es256(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_invalid_scope(app_context):
+def test_service_account_jwt_invalid_scope(app_context, monkeypatch):
     private_pem, public_pem = _generate_es256_key_pair()
-    _create_account(app_context, "scope-bot", public_pem, "maintenance:read")
-    token = _issue_token(private_pem, name="scope-bot", audience="familink:maintenance", scopes="maintenance:read")
+    endpoint = "https://example.com/jwks/scope"
+    kid = "scope-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", kid)]})
+    _create_account(app_context, "scope-bot", endpoint, "maintenance:read")
+    token = _issue_token(
+        private_pem,
+        name="scope-bot",
+        audience="familink:maintenance",
+        scopes="maintenance:read",
+        kid=kid,
+    )
 
     with pytest.raises(ServiceAccountJWTError) as exc:
         ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:write"])
@@ -104,9 +166,36 @@ def test_service_account_jwt_invalid_scope(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_expired(app_context):
+def test_service_account_jwt_unknown_kid(app_context, monkeypatch):
     private_pem, public_pem = _generate_es256_key_pair()
-    _create_account(app_context, "expired-bot", public_pem, "maintenance:read")
+    endpoint = "https://example.com/jwks/unknown"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", "other-key")]})
+    _create_account(app_context, "unknown-kid", endpoint, "maintenance:read")
+    token = _issue_token(
+        private_pem,
+        name="unknown-kid",
+        audience="familink:maintenance",
+        scopes="maintenance:read",
+        kid="missing-key",
+    )
+
+    with pytest.raises(ServiceAccountJWTError) as exc:
+        ServiceAccountTokenValidator.verify(
+            token,
+            audience="familink:maintenance",
+            required_scopes=["maintenance:read"],
+        )
+
+    assert exc.value.code == "InvalidSignature"
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_jwt_expired(app_context, monkeypatch):
+    private_pem, public_pem = _generate_es256_key_pair()
+    endpoint = "https://example.com/jwks/expired"
+    kid = "expired-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", kid)]})
+    _create_account(app_context, "expired-bot", endpoint, "maintenance:read")
     now = datetime.now(timezone.utc)
     payload = {
         "iss": "expired-bot",
@@ -116,7 +205,7 @@ def test_service_account_jwt_expired(app_context):
         "exp": int((now - timedelta(minutes=10)).timestamp()),
         "scope": "maintenance:read",
     }
-    token = jwt.encode(payload, private_pem, algorithm="ES256")
+    token = jwt.encode(payload, private_pem, algorithm="ES256", headers={"kid": kid})
 
     with pytest.raises(ServiceAccountJWTError) as exc:
         ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
@@ -137,13 +226,22 @@ def test_service_account_jwt_unknown_account(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_disabled_account(app_context):
+def test_service_account_jwt_disabled_account(app_context, monkeypatch):
     private_pem, public_pem = _generate_es256_key_pair()
-    account = _create_account(app_context, "disabled-bot", public_pem, "maintenance:read")
+    endpoint = "https://example.com/jwks/disabled"
+    kid = "disabled-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", kid)]})
+    account = _create_account(app_context, "disabled-bot", endpoint, "maintenance:read")
     account.active_flg = False
     db.session.commit()
 
-    token = _issue_token(private_pem, name="disabled-bot", audience="familink:maintenance", scopes="maintenance:read")
+    token = _issue_token(
+        private_pem,
+        name="disabled-bot",
+        audience="familink:maintenance",
+        scopes="maintenance:read",
+        kid=kid,
+    )
 
     with pytest.raises(ServiceAccountJWTError) as exc:
         ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
@@ -152,10 +250,20 @@ def test_service_account_jwt_disabled_account(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_lifetime_limit(app_context):
+def test_service_account_jwt_lifetime_limit(app_context, monkeypatch):
     private_pem, public_pem = _generate_es256_key_pair()
-    _create_account(app_context, "long-bot", public_pem, "maintenance:read")
-    token = _issue_token(private_pem, name="long-bot", audience="familink:maintenance", scopes="maintenance:read", lifetime_minutes=15)
+    endpoint = "https://example.com/jwks/long"
+    kid = "long-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "ES256", kid)]})
+    _create_account(app_context, "long-bot", endpoint, "maintenance:read")
+    token = _issue_token(
+        private_pem,
+        name="long-bot",
+        audience="familink:maintenance",
+        scopes="maintenance:read",
+        lifetime_minutes=15,
+        kid=kid,
+    )
 
     with pytest.raises(ServiceAccountJWTError) as exc:
         ServiceAccountTokenValidator.verify(token, audience="familink:maintenance", required_scopes=["maintenance:read"])
@@ -164,15 +272,19 @@ def test_service_account_jwt_lifetime_limit(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jwt_success_rs256(app_context):
+def test_service_account_jwt_success_rs256(app_context, monkeypatch):
     private_pem, public_pem = _generate_rs256_key_pair()
-    _create_account(app_context, "rsa-bot", public_pem, "maintenance:read")
+    endpoint = "https://example.com/jwks/rsa"
+    kid = "rsa-key"
+    _mock_jwks(monkeypatch, {endpoint: [_build_jwk(public_pem, "RS256", kid)]})
+    _create_account(app_context, "rsa-bot", endpoint, "maintenance:read")
     token = _issue_token(
         private_pem,
         name="rsa-bot",
         audience="familink:maintenance",
         scopes="maintenance:read",
         algorithm="RS256",
+        kid=kid,
     )
 
     account, _ = ServiceAccountTokenValidator.verify(
@@ -185,18 +297,26 @@ def test_service_account_jwt_success_rs256(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_public_key_normalization(app_context):
-    private_pem, public_pem = _generate_es256_key_pair()
-    pem_body = "".join(public_pem.splitlines()[1:-1])  # PEMヘッダ・フッタを除外
+def test_service_account_jtk_endpoint_validation(app_context):
     account = ServiceAccountService.create_account(
         name="normalize-bot",
         description=None,
-        public_key=pem_body,
+        jtk_endpoint=" https://keys.example.com/jwks ",
         scope_names="maintenance:read",
         active=True,
         allowed_scopes=["maintenance:read"],
     )
 
-    assert "BEGIN PUBLIC KEY" in account.public_key
-    assert account.public_key.strip().startswith("-----BEGIN PUBLIC KEY-----")
-    assert account.public_key.strip().endswith("-----END PUBLIC KEY-----")
+    assert account.jtk_endpoint == "https://keys.example.com/jwks"
+
+    with pytest.raises(ServiceAccountValidationError) as exc:
+        ServiceAccountService.create_account(
+            name="invalid-bot",
+            description=None,
+            jtk_endpoint="ftp://keys.example.com/jwks",
+            scope_names="maintenance:read",
+            active=True,
+            allowed_scopes=["maintenance:read"],
+        )
+
+    assert exc.value.field == "jtk_endpoint"

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -60,7 +60,7 @@ def service_accounts_create():
         account = ServiceAccountService.create_account(
             name=payload.get("name", ""),
             description=payload.get("description"),
-            public_key=payload.get("public_key", ""),
+            jtk_endpoint=payload.get("jtk_endpoint", ""),
             scope_names=payload.get("scope_names", ""),
             active=payload.get("active_flg", True),
             allowed_scopes=current_user.permissions,
@@ -98,7 +98,7 @@ def service_accounts_update(account_id: int):
             account_id,
             name=payload.get("name", ""),
             description=payload.get("description"),
-            public_key=payload.get("public_key", ""),
+            jtk_endpoint=payload.get("jtk_endpoint", ""),
             scope_names=payload.get("scope_names", ""),
             active=payload.get("active_flg", True),
             allowed_scopes=current_user.permissions,
@@ -678,7 +678,7 @@ def _extract_service_account_payload() -> dict:
     return {
         "name": data.get("name", ""),
         "description": data.get("description"),
-        "public_key": data.get("public_key", ""),
+        "jtk_endpoint": data.get("jtk_endpoint", ""),
         "scope_names": data.get("scope_names", ""),
         "active_flg": active_value,
     }

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -136,9 +136,10 @@
             <textarea class="form-control" id="service-account-description" rows="2" maxlength="255"></textarea>
           </div>
           <div class="mb-3">
-            <label for="service-account-public-key" class="form-label">{{ _('Public Key (PEM)') }}</label>
-            <textarea class="form-control font-monospace" id="service-account-public-key" rows="6" required></textarea>
-            <div class="invalid-feedback" data-field="public_key"></div>
+            <label for="service-account-jtk-endpoint" class="form-label">{{ _('JTK endpoint URL') }}</label>
+            <input type="url" class="form-control" id="service-account-jtk-endpoint" required maxlength="500">
+            <div class="form-text">{{ _('Specify the JWKS endpoint used to verify tokens for this service account.') }}</div>
+            <div class="invalid-feedback" data-field="jtk_endpoint"></div>
           </div>
           <div class="mb-3" data-scope-selection>
             <label class="form-label fw-semibold" for="service-account-scope-search">{{ _('Scopes') }}</label>
@@ -205,8 +206,8 @@
           <dd class="col-sm-9" id="detail-description"></dd>
           <dt class="col-sm-3">{{ _('Scopes') }}</dt>
           <dd class="col-sm-9" id="detail-scopes"></dd>
-          <dt class="col-sm-3">{{ _('Public Key') }}</dt>
-          <dd class="col-sm-9"><pre class="bg-light p-3 small" id="detail-public-key"></pre></dd>
+          <dt class="col-sm-3">{{ _('JTK endpoint URL') }}</dt>
+          <dd class="col-sm-9" id="detail-jtk-endpoint"></dd>
           <dt class="col-sm-3">{{ _('Registered At') }}</dt>
           <dd class="col-sm-9" id="detail-registered"></dd>
           <dt class="col-sm-3">{{ _('Updated At') }}</dt>
@@ -579,7 +580,7 @@
 
     document.getElementById('service-account-name').value = account ? account.name : '';
     document.getElementById('service-account-description').value = account?.description || '';
-    document.getElementById('service-account-public-key').value = account ? account.public_key : '';
+    document.getElementById('service-account-jtk-endpoint').value = account ? account.jtk_endpoint || '' : '';
     document.getElementById('service-account-active').checked = account ? account.active_flg : true;
 
     if (scopeSearchInput) {
@@ -601,7 +602,7 @@
     document.getElementById('detail-scopes').innerHTML = account.scope_names
       ? account.scope_names.split(',').map(scope => `<span class="badge bg-secondary me-1">${scope}</span>`).join(' ')
       : '<span class="text-muted">-</span>';
-    document.getElementById('detail-public-key').textContent = account.public_key || '';
+    document.getElementById('detail-jtk-endpoint').textContent = account.jtk_endpoint || '';
     document.getElementById('detail-registered').textContent = formatDate(account.reg_dttm);
     document.getElementById('detail-updated').textContent = formatDate(account.mod_dttm);
     detailModal.show();
@@ -615,7 +616,7 @@
     return {
       name: document.getElementById('service-account-name').value.trim(),
       description: document.getElementById('service-account-description').value.trim(),
-      public_key: document.getElementById('service-account-public-key').value.trim(),
+      jtk_endpoint: document.getElementById('service-account-jtk-endpoint').value.trim(),
       scope_names: Array.from(scopeCheckboxes.values())
         .filter((checkbox) => checkbox.checked)
         .map((checkbox) => checkbox.value)


### PR DESCRIPTION
## Summary
- remove the obsolete `public_key` attribute from the `ServiceAccount` model and its serialized output
- stop touching the removed column in the service layer when creating or updating accounts
- add a migration that drops the deprecated `public_key` column from the `service_account` table

## Testing
- pytest tests/test_service_account_jwt.py

------
https://chatgpt.com/codex/tasks/task_e_68f02a70a44483239cdb24e17d17a15b