### PR TITLE
Add admin certificate management UI and permission

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -96,6 +96,8 @@ python scripts/seed_master_data.py
 - `wiki:admin` - Wiki管理
 - `wiki:read` - Wiki読み取り
 - `wiki:write` - Wiki書き込み
+- `service_account:manage` - サービスアカウント管理
+- `certificate:manage` - 証明書管理
 
 #### デフォルトユーザー
 - Email: `admin@example.com`

--- a/features/certs/domain/exceptions.py
+++ b/features/certs/domain/exceptions.py
@@ -16,3 +16,7 @@ class CertificateSigningError(CertificateError):
 
 class KeyGenerationError(CertificateError):
     """鍵生成時の例外"""
+
+
+class CertificateNotFoundError(CertificateError):
+    """証明書が存在しない場合の例外"""

--- a/features/certs/domain/models.py
+++ b/features/certs/domain/models.py
@@ -38,3 +38,9 @@ class IssuedCertificate:
     usage_type: UsageType
     jwk: dict
     issued_at: datetime
+    revoked_at: datetime | None = None
+    revocation_reason: str | None = None
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None

--- a/features/certs/presentation/ui/__init__.py
+++ b/features/certs/presentation/ui/__init__.py
@@ -1,0 +1,10 @@
+"""証明書管理UIのエントリポイント"""
+from __future__ import annotations
+
+from flask import Blueprint
+
+certs_ui_bp = Blueprint("certs_ui", __name__, template_folder="templates")
+
+from . import routes  # noqa: E402,F401
+
+__all__ = ["certs_ui_bp"]

--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -1,0 +1,265 @@
+"""証明書管理UIのルーティング"""
+from __future__ import annotations
+
+import json
+
+from flask import (
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_babel import gettext as _
+from flask_login import current_user, login_required
+from cryptography.hazmat.primitives import serialization
+
+from features.certs.application.dto import (
+    GenerateCertificateMaterialInput,
+    SignCertificateInput,
+)
+from features.certs.application.use_cases import (
+    GenerateCertificateMaterialUseCase,
+    GetIssuedCertificateUseCase,
+    ListIssuedCertificatesUseCase,
+    ListJwksUseCase,
+    RevokeCertificateUseCase,
+    SignCertificateUseCase,
+)
+from features.certs.domain.exceptions import (
+    CertificateError,
+    CertificateNotFoundError,
+    CertificateValidationError,
+    KeyGenerationError,
+)
+from features.certs.domain.usage import UsageType
+
+from . import certs_ui_bp
+
+
+_KEY_USAGE_CHOICES: list[tuple[str, str]] = [
+    ("digitalSignature", _("digitalSignature - 電子署名")),
+    ("contentCommitment", _("contentCommitment - コンテンツコミット")),
+    ("keyEncipherment", _("keyEncipherment - 鍵暗号化")),
+    ("dataEncipherment", _("dataEncipherment - データ暗号化")),
+    ("keyAgreement", _("keyAgreement - 鍵共有")),
+    ("keyCertSign", _("keyCertSign - 証明書署名")),
+    ("crlSign", _("crlSign - CRL署名")),
+    ("encipherOnly", _("encipherOnly - 暗号化専用")),
+    ("decipherOnly", _("decipherOnly - 復号専用")),
+]
+
+
+def _ensure_permission() -> None:
+    if not current_user.can("certificate:manage"):
+        abort(403)
+
+
+def _build_subject_from_form(form_data: dict[str, str]) -> dict[str, str]:
+    mapping = {
+        "C": "subject_c",
+        "ST": "subject_st",
+        "L": "subject_l",
+        "O": "subject_o",
+        "OU": "subject_ou",
+        "CN": "subject_cn",
+        "emailAddress": "subject_email",
+    }
+    subject = {}
+    for oid, field_name in mapping.items():
+        value = (form_data.get(field_name) or "").strip()
+        if value:
+            subject[oid] = value
+    return subject
+
+
+def _format_pem_lines(pem: str | None) -> str | None:
+    if pem is None:
+        return None
+    return pem.strip()
+
+
+def _usage_options() -> list[tuple[str, str]]:
+    return [(usage.value, usage.name.replace("_", " ")) for usage in UsageType]
+
+
+@certs_ui_bp.route("/")
+@login_required
+def index():
+    _ensure_permission()
+
+    usage_param = request.args.get("usage")
+    usage_type: UsageType | None = None
+    if usage_param:
+        try:
+            usage_type = UsageType.from_str(usage_param)
+        except ValueError:
+            flash(_("不正な用途種別が指定されました。"), "error")
+            return redirect(url_for("certs_ui.index"))
+
+    certificates = ListIssuedCertificatesUseCase().execute(usage_type)
+
+    return render_template(
+        "certs/index.html",
+        certificates=certificates,
+        selected_usage=usage_type.value if usage_type else "",
+        usage_options=_usage_options(),
+    )
+
+
+@certs_ui_bp.route("/generate", methods=["GET", "POST"])
+@login_required
+def generate():
+    _ensure_permission()
+
+    context: dict[str, object] = {
+        "usage_options": _usage_options(),
+        "key_usage_choices": _KEY_USAGE_CHOICES,
+    }
+
+    if request.method == "POST":
+        form = request.form
+        subject = _build_subject_from_form(form)
+        if not subject:
+            flash(_("少なくとも1つのサブジェクト属性を入力してください。"), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+
+        key_type = form.get("key_type", "RSA")
+        key_bits_raw = form.get("key_bits", "2048")
+        try:
+            key_bits = int(key_bits_raw)
+        except (TypeError, ValueError):
+            flash(_("鍵長は整数で指定してください。"), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+
+        days_raw = form.get("days", "365")
+        try:
+            days = int(days_raw)
+        except (TypeError, ValueError):
+            flash(_("有効日数は整数で指定してください。"), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+
+        try:
+            usage_type = UsageType.from_str(form.get("usage_type"))
+        except ValueError:
+            flash(_("用途の指定が不正です。"), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+
+        key_usage = form.getlist("key_usage")
+        is_ca = form.get("is_ca") == "on"
+
+        material_input = GenerateCertificateMaterialInput(
+            subject=subject,
+            key_type=key_type,
+            key_bits=key_bits,
+            make_csr=True,
+            usage_type=usage_type,
+            key_usage=key_usage,
+        )
+
+        try:
+            material_result = GenerateCertificateMaterialUseCase().execute(material_input)
+            if not material_result.material.csr_pem:
+                raise CertificateError("CSRの生成に失敗しました。")
+            sign_input = SignCertificateInput(
+                csr_pem=material_result.material.csr_pem,
+                usage_type=usage_type,
+                days=days,
+                is_ca=is_ca,
+                key_usage=key_usage,
+            )
+            sign_result = SignCertificateUseCase().execute(sign_input)
+        except KeyGenerationError as exc:
+            flash(str(exc), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+        except CertificateValidationError as exc:
+            flash(str(exc), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+        except CertificateError as exc:
+            flash(str(exc), "error")
+            return render_template("certs/generate.html", **context, form_data=form)
+
+        flash(_("証明書を生成しました。"), "success")
+        context.update(
+            {
+                "form_data": form,
+                "generated_material": material_result.material,
+                "certificate_pem": sign_result.certificate_pem,
+                "kid": sign_result.kid,
+                "jwk_json": json.dumps(sign_result.jwk, indent=2, ensure_ascii=False),
+            }
+        )
+        return render_template("certs/generate.html", **context)
+
+    return render_template("certs/generate.html", **context)
+
+
+@certs_ui_bp.route("/public")
+@login_required
+def public_keys():
+    _ensure_permission()
+
+    usage_infos = []
+    jwks_use_case = ListJwksUseCase()
+    for usage in UsageType:
+        api_url = url_for("certs_api.jwks", usage=f"{usage.value}")
+        jwks_result = jwks_use_case.execute(usage)
+        usage_infos.append(
+            {
+                "usage": usage,
+                "api_url": api_url,
+                "key_count": len(jwks_result.get("keys", [])),
+                "jwks_json": json.dumps(jwks_result, indent=2, ensure_ascii=False),
+            }
+        )
+
+    return render_template("certs/public.html", usage_infos=usage_infos)
+
+
+@certs_ui_bp.route("/<string:kid>")
+@login_required
+def detail(kid: str):
+    _ensure_permission()
+
+    try:
+        certificate = GetIssuedCertificateUseCase().execute(kid)
+    except CertificateNotFoundError:
+        abort(404)
+
+    x509_cert = certificate.certificate
+    detail_context = {
+        "certificate": certificate,
+        "certificate_pem": _format_pem_lines(
+            x509_cert.public_bytes(encoding=serialization.Encoding.PEM).decode("utf-8")
+        ),
+        "not_before": x509_cert.not_valid_before,
+        "not_after": x509_cert.not_valid_after,
+        "subject": x509_cert.subject.rfc4514_string(),
+        "issuer": x509_cert.issuer.rfc4514_string(),
+        "jwk_json": json.dumps(certificate.jwk, indent=2, ensure_ascii=False),
+    }
+    return render_template("certs/detail.html", **detail_context)
+
+
+@certs_ui_bp.route("/revoke/<string:kid>", methods=["GET", "POST"])
+@login_required
+def revoke(kid: str):
+    _ensure_permission()
+
+    use_case = GetIssuedCertificateUseCase()
+    try:
+        certificate = use_case.execute(kid)
+    except CertificateNotFoundError:
+        abort(404)
+
+    if request.method == "POST":
+        reason = request.form.get("reason", "").strip() or None
+        try:
+            revoked = RevokeCertificateUseCase().execute(kid, reason)
+        except CertificateNotFoundError:
+            abort(404)
+        flash(_("証明書を失効しました。"), "success")
+        return redirect(url_for("certs_ui.detail", kid=revoked.kid))
+
+    return render_template("certs/revoke.html", certificate=certificate)

--- a/features/certs/presentation/ui/templates/certs/detail.html
+++ b/features/certs/presentation/ui/templates/certs/detail.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block title %}証明書詳細 | {{ super() }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div>
+    <h1 class="h3 mb-0">証明書詳細</h1>
+    <p class="text-muted mb-0">KID: <span class="font-monospace">{{ certificate.kid }}</span></p>
+  </div>
+  <div>
+    <a class="btn btn-outline-secondary me-2" href="{{ url_for('certs_ui.index') }}">一覧に戻る</a>
+    {% if not certificate.is_revoked %}
+    <a class="btn btn-danger" href="{{ url_for('certs_ui.revoke', kid=certificate.kid) }}">失効する</a>
+    {% endif %}
+  </div>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm h-100">
+      <div class="card-header">メタ情報</div>
+      <div class="card-body">
+        <dl class="row mb-0">
+          <dt class="col-sm-4">用途</dt>
+          <dd class="col-sm-8">{{ certificate.usage_type.value }}</dd>
+          <dt class="col-sm-4">発行日時</dt>
+          <dd class="col-sm-8">{{ certificate.issued_at.strftime('%Y-%m-%d %H:%M:%S') if certificate.issued_at else '-' }}</dd>
+          <dt class="col-sm-4">状態</dt>
+          <dd class="col-sm-8">
+            {% if certificate.is_revoked %}
+            <span class="badge bg-secondary">失効</span>
+            {% else %}
+            <span class="badge bg-success">有効</span>
+            {% endif %}
+          </dd>
+          <dt class="col-sm-4">失効日時</dt>
+          <dd class="col-sm-8">
+            {% if certificate.revoked_at %}
+            {{ certificate.revoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
+            {% else %}-{% endif %}
+          </dd>
+          <dt class="col-sm-4">失効理由</dt>
+          <dd class="col-sm-8">{{ certificate.revocation_reason or '-' }}</dd>
+          <dt class="col-sm-4">サブジェクト</dt>
+          <dd class="col-sm-8">{{ subject }}</dd>
+          <dt class="col-sm-4">発行者</dt>
+          <dd class="col-sm-8">{{ issuer }}</dd>
+          <dt class="col-sm-4">有効期間</dt>
+          <dd class="col-sm-8">{{ not_before }} 〜 {{ not_after }}</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card shadow-sm mb-4">
+      <div class="card-header">証明書 (PEM)</div>
+      <div class="card-body">
+        <pre class="bg-light p-2 rounded small">{{ certificate_pem }}</pre>
+      </div>
+    </div>
+    <div class="card shadow-sm">
+      <div class="card-header">JWK情報</div>
+      <div class="card-body">
+        <pre class="bg-light p-2 rounded small">{{ jwk_json }}</pre>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/features/certs/presentation/ui/templates/certs/generate.html
+++ b/features/certs/presentation/ui/templates/certs/generate.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+{% block title %}証明書生成 | {{ super() }}{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4">証明書生成</h1>
+<div class="row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-header">入力フォーム</div>
+      <div class="card-body">
+        <form method="post">
+          <div class="mb-3">
+            <label class="form-label">Common Name (CN)</label>
+            <input type="text" class="form-control" name="subject_cn" value="{{ (form_data or {}).get('subject_cn', '') }}" required>
+          </div>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Organization (O)</label>
+              <input type="text" class="form-control" name="subject_o" value="{{ (form_data or {}).get('subject_o', '') }}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Organizational Unit (OU)</label>
+              <input type="text" class="form-control" name="subject_ou" value="{{ (form_data or {}).get('subject_ou', '') }}">
+            </div>
+          </div>
+          <div class="row g-3 mt-1">
+            <div class="col-md-4">
+              <label class="form-label">Country (C)</label>
+              <input type="text" class="form-control" name="subject_c" value="{{ (form_data or {}).get('subject_c', '') }}">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">State/Province (ST)</label>
+              <input type="text" class="form-control" name="subject_st" value="{{ (form_data or {}).get('subject_st', '') }}">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Locality (L)</label>
+              <input type="text" class="form-control" name="subject_l" value="{{ (form_data or {}).get('subject_l', '') }}">
+            </div>
+          </div>
+          <div class="mb-3 mt-3">
+            <label class="form-label">メールアドレス</label>
+            <input type="email" class="form-control" name="subject_email" value="{{ (form_data or {}).get('subject_email', '') }}">
+          </div>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">用途</label>
+              <select class="form-select" name="usage_type">
+                {% for value, label in usage_options %}
+                <option value="{{ value }}" {% if (form_data or {}).get('usage_type', 'server_signing') == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">有効日数</label>
+              <input type="number" class="form-control" name="days" min="1" value="{{ (form_data or {}).get('days', '365') }}">
+            </div>
+          </div>
+          <div class="row g-3 mt-1">
+            <div class="col-md-6">
+              <label class="form-label">鍵タイプ</label>
+              <select class="form-select" name="key_type">
+                <option value="RSA" {% if (form_data or {}).get('key_type', 'RSA') == 'RSA' %}selected{% endif %}>RSA</option>
+                <option value="EC" {% if (form_data or {}).get('key_type') == 'EC' %}selected{% endif %}>EC (P-256)</option>
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">RSA鍵長</label>
+              <input type="number" class="form-control" name="key_bits" min="2048" step="1024" value="{{ (form_data or {}).get('key_bits', '2048') }}">
+            </div>
+          </div>
+          <div class="mb-3 mt-3">
+            <label class="form-label">Key Usage</label>
+            <div class="row row-cols-1 row-cols-sm-2 g-2">
+              {% set selected_key_usage = (form_data or {}).getlist('key_usage') if form_data else [] %}
+              {% for value, label in key_usage_choices %}
+              <div class="col">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="key_usage" value="{{ value }}" id="ku-{{ loop.index }}" {% if value in selected_key_usage %}checked{% endif %}>
+                  <label class="form-check-label" for="ku-{{ loop.index }}">{{ label }}</label>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input class="form-check-input" type="checkbox" id="is_ca" name="is_ca" {% if (form_data or {}).get('is_ca') %}checked{% endif %}>
+            <label class="form-check-label" for="is_ca">CA証明書としてマークする</label>
+          </div>
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary">生成する</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card shadow-sm mb-4">
+      <div class="card-header">秘密鍵 / 公開鍵</div>
+      <div class="card-body">
+        {% if generated_material %}
+        <h6>秘密鍵</h6>
+        <pre class="bg-light p-2 rounded small">{{ generated_material.private_key_pem }}</pre>
+        <h6>公開鍵</h6>
+        <pre class="bg-light p-2 rounded small">{{ generated_material.public_key_pem }}</pre>
+        {% else %}
+        <p class="text-muted mb-0">生成結果がここに表示されます。</p>
+        {% endif %}
+      </div>
+    </div>
+    <div class="card shadow-sm">
+      <div class="card-header">証明書 / JWKS</div>
+      <div class="card-body">
+        {% if certificate_pem %}
+        <h6>証明書 (PEM)</h6>
+        <pre class="bg-light p-2 rounded small">{{ certificate_pem }}</pre>
+        <h6>JWK</h6>
+        <pre class="bg-light p-2 rounded small">{{ jwk_json }}</pre>
+        <div class="mt-3">
+          <a class="btn btn-outline-primary" href="{{ url_for('certs_ui.detail', kid=kid) }}">詳細を表示</a>
+        </div>
+        {% else %}
+        <p class="text-muted mb-0">証明書生成後に詳細が表示されます。</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/features/certs/presentation/ui/templates/certs/index.html
+++ b/features/certs/presentation/ui/templates/certs/index.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block title %}証明書一覧 | {{ super() }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3">証明書一覧</h1>
+  <div>
+    <a class="btn btn-primary me-2" href="{{ url_for('certs_ui.generate') }}">
+      <i class="bi bi-plus-circle me-1"></i>新規生成
+    </a>
+    <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.public_keys') }}">
+      <i class="bi bi-link-45deg me-1"></i>公開鍵配布
+    </a>
+  </div>
+</div>
+
+<form class="row gy-2 gx-3 align-items-center mb-4" method="get">
+  <div class="col-auto">
+    <label class="form-label" for="usage">用途</label>
+    <select class="form-select" id="usage" name="usage" onchange="this.form.submit()">
+      <option value="">すべて</option>
+      {% for value, label in usage_options %}
+      <option value="{{ value }}" {% if selected_usage == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</form>
+
+<div class="table-responsive">
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        <th scope="col">KID</th>
+        <th scope="col">用途</th>
+        <th scope="col">発行日時</th>
+        <th scope="col">状態</th>
+        <th scope="col">失効日時</th>
+        <th scope="col">操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% if certificates %}
+        {% for cert in certificates %}
+        <tr>
+          <td class="font-monospace">{{ cert.kid }}</td>
+          <td>{{ cert.usage_type.value }}</td>
+          <td>{{ cert.issued_at.strftime('%Y-%m-%d %H:%M:%S') if cert.issued_at else '-' }}</td>
+          <td>
+            {% if cert.is_revoked %}
+            <span class="badge bg-secondary">失効</span>
+            {% else %}
+            <span class="badge bg-success">有効</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if cert.revoked_at %}
+            {{ cert.revoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
+            {% else %}-{% endif %}
+          </td>
+          <td>
+            <a class="btn btn-sm btn-outline-primary me-1" href="{{ url_for('certs_ui.detail', kid=cert.kid) }}">
+              詳細
+            </a>
+            {% if not cert.is_revoked %}
+            <a class="btn btn-sm btn-outline-danger" href="{{ url_for('certs_ui.revoke', kid=cert.kid) }}">
+              失効
+            </a>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      {% else %}
+      <tr>
+        <td colspan="6" class="text-center text-muted py-4">表示できる証明書がありません。</td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/features/certs/presentation/ui/templates/certs/public.html
+++ b/features/certs/presentation/ui/templates/certs/public.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}公開鍵配布 | {{ super() }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">公開鍵配布</h1>
+  <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.index') }}">一覧に戻る</a>
+</div>
+<p class="text-muted">JWKSエンドポイントへのリンクと現在公開中の鍵情報です。</p>
+
+<div class="accordion" id="jwksAccordion">
+  {% for info in usage_infos %}
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="heading-{{ loop.index }}">
+      <button class="accordion-button {% if not loop.first %}collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ loop.index }}" aria-expanded="{{ 'true' if loop.first else 'false' }}" aria-controls="collapse-{{ loop.index }}">
+        {{ info.usage.value }} ({{ info.key_count }} keys)
+      </button>
+    </h2>
+    <div id="collapse-{{ loop.index }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" aria-labelledby="heading-{{ loop.index }}" data-bs-parent="#jwksAccordion">
+      <div class="accordion-body">
+        <p class="mb-2">エンドポイント: <code>{{ info.api_url }}</code></p>
+        <div class="d-flex gap-2 mb-3">
+          <a class="btn btn-sm btn-outline-primary" href="{{ info.api_url }}" target="_blank" rel="noopener">ブラウザで開く</a>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="navigator.clipboard.writeText({{ info.api_url|tojson }})">URLをコピー</button>
+        </div>
+        <h6>JWKS JSON</h6>
+        <pre class="bg-light p-2 rounded small">{{ info.jwks_json }}</pre>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/features/certs/presentation/ui/templates/certs/revoke.html
+++ b/features/certs/presentation/ui/templates/certs/revoke.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}証明書失効 | {{ super() }}{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-header">証明書失効</div>
+      <div class="card-body">
+        <p>以下の証明書を失効させます。理由を入力してください。</p>
+        <dl class="row">
+          <dt class="col-sm-4">KID</dt>
+          <dd class="col-sm-8 font-monospace">{{ certificate.kid }}</dd>
+          <dt class="col-sm-4">用途</dt>
+          <dd class="col-sm-8">{{ certificate.usage_type.value }}</dd>
+          <dt class="col-sm-4">発行日時</dt>
+          <dd class="col-sm-8">{{ certificate.issued_at.strftime('%Y-%m-%d %H:%M:%S') if certificate.issued_at else '-' }}</dd>
+        </dl>
+        <form method="post">
+          <div class="mb-3">
+            <label class="form-label" for="reason">失効理由</label>
+            <textarea class="form-control" id="reason" name="reason" rows="3" placeholder="例: 鍵漏洩が判明したため"></textarea>
+          </div>
+          <div class="d-flex justify-content-between">
+            <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.detail', kid=certificate.kid) }}">戻る</a>
+            <button type="submit" class="btn btn-danger" onclick="return confirm('本当に失効しますか？この操作は元に戻せません。');">失効する</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/migrations/versions/e1f1aa7a3c5e_add_certificate_permission.py
+++ b/migrations/versions/e1f1aa7a3c5e_add_certificate_permission.py
@@ -1,0 +1,77 @@
+"""Add certificate management permission"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e1f1aa7a3c5e'
+down_revision = '0e7d64c89741'
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_CODE = 'certificate:manage'
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+    if perm_row is None:
+        conn.execute(
+            sa.text("INSERT INTO permission (code) VALUES (:code)"),
+            {"code": PERMISSION_CODE},
+        )
+        perm_row = conn.execute(
+            sa.text("SELECT id FROM permission WHERE code = :code"),
+            {"code": PERMISSION_CODE},
+        ).first()
+
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+    admin_role = conn.execute(
+        sa.text("SELECT id FROM role WHERE name = 'admin'"),
+    ).first()
+    if not admin_role:
+        return
+
+    admin_role_id = admin_role[0]
+    existing = conn.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions WHERE role_id = :role_id AND perm_id = :perm_id"
+        ),
+        {"role_id": admin_role_id, "perm_id": perm_id},
+    ).first()
+    if existing is None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO role_permissions (role_id, perm_id) VALUES (:role_id, :perm_id)"
+            ),
+            {"role_id": admin_role_id, "perm_id": perm_id},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+    conn.execute(
+        sa.text("DELETE FROM role_permissions WHERE perm_id = :perm_id"),
+        {"perm_id": perm_id},
+    )
+    conn.execute(
+        sa.text("DELETE FROM permission WHERE id = :perm_id"),
+        {"perm_id": perm_id},
+    )

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -57,6 +57,7 @@ def seed_permissions():
         {'id': 17, 'code': 'totp:view'},
         {'id': 18, 'code': 'totp:write'},
         {'id': 19, 'code': 'service_account:manage'},
+        {'id': 20, 'code': 'certificate:manage'},
     ]
     
     for perm_data in permissions_data:
@@ -75,7 +76,7 @@ def seed_role_permissions():
         # admin (role_id=1) - all permissions
         (1, 1), (1, 2), (1, 3), (1, 4), (1, 5),
         (1, 6), (1, 7), (1, 8), (1, 9), (1, 10),
-        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18), (1, 19),
+        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18), (1, 19), (1, 20),
         # manager (role_id=2) - limited permissions
         (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15), (2, 16),
         # member (role_id=3) - view only

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -504,6 +504,9 @@ def create_app():
     from features.totp.presentation import bp as totp_bp
     app.register_blueprint(totp_bp, url_prefix="/totp")
 
+    from features.certs.presentation.ui import certs_ui_bp
+    app.register_blueprint(certs_ui_bp, url_prefix="/certs")
+
     from features.certs.presentation.api import certs_api_bp
     app.register_blueprint(certs_api_bp, url_prefix="/api")
 

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -61,12 +61,13 @@
           {% set show_admin_only = current_user.has_role('admin') %}
           {% set show_user_manage = current_user.can('user:manage') %}
           {% set show_service_accounts = current_user.can('service_account:manage') %}
+          {% set show_certificate_manage = current_user.can('certificate:manage') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
             </a>
           </li>
-          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_system_manage or show_admin_only %}
+          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_certificate_manage or show_system_manage or show_admin_only %}
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               {{ _('Management') }}
@@ -78,6 +79,9 @@
               {% endif %}
               {% if show_service_accounts %}
               <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
+              {% endif %}
+              {% if show_certificate_manage %}
+              <li><a class="dropdown-item" href="{{ url_for('certs_ui.index') }}">証明書管理</a></li>
               {% endif %}
               {% if show_user_manage %}
               <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
## Summary
- add a dedicated `certificate:manage` permission with migrations, seeds, and navigation updates
- implement admin-only certificate management pages for listing, generating, viewing, revoking, and distributing JWKS
- extend certificate use cases and store to support listing, lookup, and revocation metadata for the UI

## Testing
- pytest tests/features -k cert --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68f03f4453d4832399f9effe96c478ae