### PR TITLE
Translate certs UI templates to English

### DIFF
--- a/features/certs/presentation/ui/templates/certs/detail.html
+++ b/features/certs/presentation/ui/templates/certs/detail.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
-{% block title %}証明書詳細 | {{ super() }}{% endblock %}
+{% block title %}{{ _('Certificate Details') }} | {{ super() }}{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
   <div>
-    <h1 class="h3 mb-0">証明書詳細</h1>
-    <p class="text-muted mb-0">KID: <span class="font-monospace">{{ certificate.kid }}</span></p>
+    <h1 class="h3 mb-0">{{ _('Certificate Details') }}</h1>
+    <p class="text-muted mb-0">{{ _('KID') }}: <span class="font-monospace">{{ certificate.kid }}</span></p>
   </div>
   <div>
-    <a class="btn btn-outline-secondary me-2" href="{{ url_for('certs_ui.index') }}">一覧に戻る</a>
+    <a class="btn btn-outline-secondary me-2" href="{{ url_for('certs_ui.index') }}">{{ _('Back to List') }}</a>
     {% if not certificate.is_revoked %}
-    <a class="btn btn-danger" href="{{ url_for('certs_ui.revoke', kid=certificate.kid) }}">失効する</a>
+    <a class="btn btn-danger" href="{{ url_for('certs_ui.revoke', kid=certificate.kid) }}">{{ _('Revoke Certificate') }}</a>
     {% endif %}
   </div>
 </div>
@@ -17,48 +17,48 @@
 <div class="row g-4">
   <div class="col-lg-6">
     <div class="card shadow-sm h-100">
-      <div class="card-header">メタ情報</div>
+      <div class="card-header">{{ _('Metadata') }}</div>
       <div class="card-body">
         <dl class="row mb-0">
-          <dt class="col-sm-4">用途</dt>
+          <dt class="col-sm-4">{{ _('Usage') }}</dt>
           <dd class="col-sm-8">{{ certificate.usage_type.value }}</dd>
-          <dt class="col-sm-4">発行日時</dt>
+          <dt class="col-sm-4">{{ _('Issued At') }}</dt>
           <dd class="col-sm-8">{{ certificate.issued_at.strftime('%Y-%m-%d %H:%M:%S') if certificate.issued_at else '-' }}</dd>
-          <dt class="col-sm-4">状態</dt>
+          <dt class="col-sm-4">{{ _('Status') }}</dt>
           <dd class="col-sm-8">
             {% if certificate.is_revoked %}
-            <span class="badge bg-secondary">失効</span>
+            <span class="badge bg-secondary">{{ _('Revoked') }}</span>
             {% else %}
-            <span class="badge bg-success">有効</span>
+            <span class="badge bg-success">{{ _('Active') }}</span>
             {% endif %}
           </dd>
-          <dt class="col-sm-4">失効日時</dt>
+          <dt class="col-sm-4">{{ _('Revoked At') }}</dt>
           <dd class="col-sm-8">
             {% if certificate.revoked_at %}
             {{ certificate.revoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
             {% else %}-{% endif %}
           </dd>
-          <dt class="col-sm-4">失効理由</dt>
+          <dt class="col-sm-4">{{ _('Revocation Reason') }}</dt>
           <dd class="col-sm-8">{{ certificate.revocation_reason or '-' }}</dd>
-          <dt class="col-sm-4">サブジェクト</dt>
+          <dt class="col-sm-4">{{ _('Subject') }}</dt>
           <dd class="col-sm-8">{{ subject }}</dd>
-          <dt class="col-sm-4">発行者</dt>
+          <dt class="col-sm-4">{{ _('Issuer') }}</dt>
           <dd class="col-sm-8">{{ issuer }}</dd>
-          <dt class="col-sm-4">有効期間</dt>
-          <dd class="col-sm-8">{{ not_before }} 〜 {{ not_after }}</dd>
+          <dt class="col-sm-4">{{ _('Validity Period') }}</dt>
+          <dd class="col-sm-8">{{ not_before }} {{ _('to') }} {{ not_after }}</dd>
         </dl>
       </div>
     </div>
   </div>
   <div class="col-lg-6">
     <div class="card shadow-sm mb-4">
-      <div class="card-header">証明書 (PEM)</div>
+      <div class="card-header">{{ _('Certificate (PEM)') }}</div>
       <div class="card-body">
         <pre class="bg-light p-2 rounded small">{{ certificate_pem }}</pre>
       </div>
     </div>
     <div class="card shadow-sm">
-      <div class="card-header">JWK情報</div>
+      <div class="card-header">{{ _('JWK Information') }}</div>
       <div class="card-body">
         <pre class="bg-light p-2 rounded small">{{ jwk_json }}</pre>
       </div>

--- a/features/certs/presentation/ui/templates/certs/generate.html
+++ b/features/certs/presentation/ui/templates/certs/generate.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% block title %}証明書生成 | {{ super() }}{% endblock %}
+{% block title %}{{ _('Generate Certificate') }} | {{ super() }}{% endblock %}
 {% block content %}
-<h1 class="h3 mb-4">証明書生成</h1>
+<h1 class="h3 mb-4">{{ _('Generate Certificate') }}</h1>
 <div class="row g-4">
   <div class="col-lg-6">
     <div class="card shadow-sm">
-      <div class="card-header">入力フォーム</div>
+      <div class="card-header">{{ _('Input Form') }}</div>
       <div class="card-body">
         <form method="post">
           <div class="mb-3">
@@ -37,12 +37,12 @@
             </div>
           </div>
           <div class="mb-3 mt-3">
-            <label class="form-label">メールアドレス</label>
+            <label class="form-label">{{ _('Email Address') }}</label>
             <input type="email" class="form-control" name="subject_email" value="{{ (form_data or {}).get('subject_email', '') }}">
           </div>
           <div class="row g-3">
             <div class="col-md-6">
-              <label class="form-label">用途</label>
+              <label class="form-label">{{ _('Usage') }}</label>
               <select class="form-select" name="usage_type">
                 {% for value, label in usage_options %}
                 <option value="{{ value }}" {% if (form_data or {}).get('usage_type', 'server_signing') == value %}selected{% endif %}>{{ label }}</option>
@@ -50,25 +50,25 @@
               </select>
             </div>
             <div class="col-md-6">
-              <label class="form-label">有効日数</label>
+              <label class="form-label">{{ _('Validity (days)') }}</label>
               <input type="number" class="form-control" name="days" min="1" value="{{ (form_data or {}).get('days', '365') }}">
             </div>
           </div>
           <div class="row g-3 mt-1">
             <div class="col-md-6">
-              <label class="form-label">鍵タイプ</label>
+              <label class="form-label">{{ _('Key Type') }}</label>
               <select class="form-select" name="key_type">
                 <option value="RSA" {% if (form_data or {}).get('key_type', 'RSA') == 'RSA' %}selected{% endif %}>RSA</option>
                 <option value="EC" {% if (form_data or {}).get('key_type') == 'EC' %}selected{% endif %}>EC (P-256)</option>
               </select>
             </div>
             <div class="col-md-6">
-              <label class="form-label">RSA鍵長</label>
+              <label class="form-label">{{ _('RSA Key Size') }}</label>
               <input type="number" class="form-control" name="key_bits" min="2048" step="1024" value="{{ (form_data or {}).get('key_bits', '2048') }}">
             </div>
           </div>
           <div class="mb-3 mt-3">
-            <label class="form-label">Key Usage</label>
+            <label class="form-label">{{ _('Key Usage') }}</label>
             <div class="row row-cols-1 row-cols-sm-2 g-2">
               {% set selected_key_usage = (form_data or {}).getlist('key_usage') if form_data else [] %}
               {% for value, label in key_usage_choices %}
@@ -83,10 +83,10 @@
           </div>
           <div class="form-check form-switch mb-3">
             <input class="form-check-input" type="checkbox" id="is_ca" name="is_ca" {% if (form_data or {}).get('is_ca') %}checked{% endif %}>
-            <label class="form-check-label" for="is_ca">CA証明書としてマークする</label>
+            <label class="form-check-label" for="is_ca">{{ _('Mark as CA certificate') }}</label>
           </div>
           <div class="d-grid">
-            <button type="submit" class="btn btn-primary">生成する</button>
+            <button type="submit" class="btn btn-primary">{{ _('Generate') }}</button>
           </div>
         </form>
       </div>
@@ -94,31 +94,31 @@
   </div>
   <div class="col-lg-6">
     <div class="card shadow-sm mb-4">
-      <div class="card-header">秘密鍵 / 公開鍵</div>
+      <div class="card-header">{{ _('Private Key / Public Key') }}</div>
       <div class="card-body">
         {% if generated_material %}
-        <h6>秘密鍵</h6>
+        <h6>{{ _('Private Key') }}</h6>
         <pre class="bg-light p-2 rounded small">{{ generated_material.private_key_pem }}</pre>
-        <h6>公開鍵</h6>
+        <h6>{{ _('Public Key') }}</h6>
         <pre class="bg-light p-2 rounded small">{{ generated_material.public_key_pem }}</pre>
         {% else %}
-        <p class="text-muted mb-0">生成結果がここに表示されます。</p>
+        <p class="text-muted mb-0">{{ _('Generation results will appear here.') }}</p>
         {% endif %}
       </div>
     </div>
     <div class="card shadow-sm">
-      <div class="card-header">証明書 / JWKS</div>
+      <div class="card-header">{{ _('Certificate / JWKS') }}</div>
       <div class="card-body">
         {% if certificate_pem %}
-        <h6>証明書 (PEM)</h6>
+        <h6>{{ _('Certificate (PEM)') }}</h6>
         <pre class="bg-light p-2 rounded small">{{ certificate_pem }}</pre>
-        <h6>JWK</h6>
+        <h6>{{ _('JWK') }}</h6>
         <pre class="bg-light p-2 rounded small">{{ jwk_json }}</pre>
         <div class="mt-3">
-          <a class="btn btn-outline-primary" href="{{ url_for('certs_ui.detail', kid=kid) }}">詳細を表示</a>
+          <a class="btn btn-outline-primary" href="{{ url_for('certs_ui.detail', kid=kid) }}">{{ _('View Details') }}</a>
         </div>
         {% else %}
-        <p class="text-muted mb-0">証明書生成後に詳細が表示されます。</p>
+        <p class="text-muted mb-0">{{ _('Certificate details will be shown after generation.') }}</p>
         {% endif %}
       </div>
     </div>

--- a/features/certs/presentation/ui/templates/certs/index.html
+++ b/features/certs/presentation/ui/templates/certs/index.html
@@ -1,23 +1,23 @@
 {% extends "base.html" %}
-{% block title %}証明書一覧 | {{ super() }}{% endblock %}
+{% block title %}{{ _('Certificate List') }} | {{ super() }}{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h1 class="h3">証明書一覧</h1>
+  <h1 class="h3">{{ _('Certificate List') }}</h1>
   <div>
     <a class="btn btn-primary me-2" href="{{ url_for('certs_ui.generate') }}">
-      <i class="bi bi-plus-circle me-1"></i>新規生成
+      <i class="bi bi-plus-circle me-1"></i>{{ _('Generate New') }}
     </a>
     <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.public_keys') }}">
-      <i class="bi bi-link-45deg me-1"></i>公開鍵配布
+      <i class="bi bi-link-45deg me-1"></i>{{ _('Public Key Distribution') }}
     </a>
   </div>
 </div>
 
 <form class="row gy-2 gx-3 align-items-center mb-4" method="get">
   <div class="col-auto">
-    <label class="form-label" for="usage">用途</label>
+    <label class="form-label" for="usage">{{ _('Usage') }}</label>
     <select class="form-select" id="usage" name="usage" onchange="this.form.submit()">
-      <option value="">すべて</option>
+      <option value="">{{ _('All') }}</option>
       {% for value, label in usage_options %}
       <option value="{{ value }}" {% if selected_usage == value %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
@@ -30,11 +30,11 @@
     <thead>
       <tr>
         <th scope="col">KID</th>
-        <th scope="col">用途</th>
-        <th scope="col">発行日時</th>
-        <th scope="col">状態</th>
-        <th scope="col">失効日時</th>
-        <th scope="col">操作</th>
+        <th scope="col">{{ _('Usage') }}</th>
+        <th scope="col">{{ _('Issued At') }}</th>
+        <th scope="col">{{ _('Status') }}</th>
+        <th scope="col">{{ _('Revoked At') }}</th>
+        <th scope="col">{{ _('Actions') }}</th>
       </tr>
     </thead>
     <tbody>
@@ -46,9 +46,9 @@
           <td>{{ cert.issued_at.strftime('%Y-%m-%d %H:%M:%S') if cert.issued_at else '-' }}</td>
           <td>
             {% if cert.is_revoked %}
-            <span class="badge bg-secondary">失効</span>
+            <span class="badge bg-secondary">{{ _('Revoked') }}</span>
             {% else %}
-            <span class="badge bg-success">有効</span>
+            <span class="badge bg-success">{{ _('Active') }}</span>
             {% endif %}
           </td>
           <td>
@@ -58,11 +58,11 @@
           </td>
           <td>
             <a class="btn btn-sm btn-outline-primary me-1" href="{{ url_for('certs_ui.detail', kid=cert.kid) }}">
-              詳細
+              {{ _('View Details') }}
             </a>
             {% if not cert.is_revoked %}
             <a class="btn btn-sm btn-outline-danger" href="{{ url_for('certs_ui.revoke', kid=cert.kid) }}">
-              失効
+              {{ _('Revoke') }}
             </a>
             {% endif %}
           </td>
@@ -70,7 +70,7 @@
         {% endfor %}
       {% else %}
       <tr>
-        <td colspan="6" class="text-center text-muted py-4">表示できる証明書がありません。</td>
+        <td colspan="6" class="text-center text-muted py-4">{{ _('No certificates available to display.') }}</td>
       </tr>
       {% endif %}
     </tbody>

--- a/features/certs/presentation/ui/templates/certs/public.html
+++ b/features/certs/presentation/ui/templates/certs/public.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% block title %}公開鍵配布 | {{ super() }}{% endblock %}
+{% block title %}{{ _('Public Key Distribution') }} | {{ super() }}{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h1 class="h3 mb-0">公開鍵配布</h1>
-  <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.index') }}">一覧に戻る</a>
+  <h1 class="h3 mb-0">{{ _('Public Key Distribution') }}</h1>
+  <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.index') }}">{{ _('Back to List') }}</a>
 </div>
-<p class="text-muted">JWKSエンドポイントへのリンクと現在公開中の鍵情報です。</p>
+<p class="text-muted">{{ _('Links to the JWKS endpoints and information about currently published keys.') }}</p>
 
 <div class="accordion" id="jwksAccordion">
   {% for info in usage_infos %}
@@ -17,12 +17,12 @@
     </h2>
     <div id="collapse-{{ loop.index }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" aria-labelledby="heading-{{ loop.index }}" data-bs-parent="#jwksAccordion">
       <div class="accordion-body">
-        <p class="mb-2">エンドポイント: <code>{{ info.api_url }}</code></p>
+        <p class="mb-2">{{ _('Endpoint') }}: <code>{{ info.api_url }}</code></p>
         <div class="d-flex gap-2 mb-3">
-          <a class="btn btn-sm btn-outline-primary" href="{{ info.api_url }}" target="_blank" rel="noopener">ブラウザで開く</a>
-          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="navigator.clipboard.writeText({{ info.api_url|tojson }})">URLをコピー</button>
+          <a class="btn btn-sm btn-outline-primary" href="{{ info.api_url }}" target="_blank" rel="noopener">{{ _('Open in Browser') }}</a>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="navigator.clipboard.writeText({{ info.api_url|tojson }})">{{ _('Copy URL') }}</button>
         </div>
-        <h6>JWKS JSON</h6>
+        <h6>{{ _('JWKS JSON') }}</h6>
         <pre class="bg-light p-2 rounded small">{{ info.jwks_json }}</pre>
       </div>
     </div>

--- a/features/certs/presentation/ui/templates/certs/revoke.html
+++ b/features/certs/presentation/ui/templates/certs/revoke.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
-{% block title %}証明書失効 | {{ super() }}{% endblock %}
+{% block title %}{{ _('Revoke Certificate') }} | {{ super() }}{% endblock %}
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-lg-6">
     <div class="card shadow-sm">
-      <div class="card-header">証明書失効</div>
+      <div class="card-header">{{ _('Revoke Certificate') }}</div>
       <div class="card-body">
-        <p>以下の証明書を失効させます。理由を入力してください。</p>
+        <p>{{ _('Revoke the certificate below and provide a reason for the revocation.') }}</p>
         <dl class="row">
           <dt class="col-sm-4">KID</dt>
           <dd class="col-sm-8 font-monospace">{{ certificate.kid }}</dd>
-          <dt class="col-sm-4">用途</dt>
+          <dt class="col-sm-4">{{ _('Usage') }}</dt>
           <dd class="col-sm-8">{{ certificate.usage_type.value }}</dd>
-          <dt class="col-sm-4">発行日時</dt>
+          <dt class="col-sm-4">{{ _('Issued At') }}</dt>
           <dd class="col-sm-8">{{ certificate.issued_at.strftime('%Y-%m-%d %H:%M:%S') if certificate.issued_at else '-' }}</dd>
         </dl>
         <form method="post">
           <div class="mb-3">
-            <label class="form-label" for="reason">失効理由</label>
-            <textarea class="form-control" id="reason" name="reason" rows="3" placeholder="例: 鍵漏洩が判明したため"></textarea>
+            <label class="form-label" for="reason">{{ _('Revocation Reason') }}</label>
+            <textarea class="form-control" id="reason" name="reason" rows="3" placeholder="{{ _('Example: Key was compromised') }}"></textarea>
           </div>
           <div class="d-flex justify-content-between">
-            <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.detail', kid=certificate.kid) }}">戻る</a>
-            <button type="submit" class="btn btn-danger" onclick="return confirm('本当に失効しますか？この操作は元に戻せません。');">失効する</button>
+            <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.detail', kid=certificate.kid) }}">{{ _('Back') }}</a>
+            <button type="submit" class="btn btn-danger" onclick="return confirm('{{ _('Are you sure you want to revoke this certificate? This action cannot be undone.') }}');">{{ _('Revoke') }}</button>
           </div>
         </form>
       </div>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -396,3 +396,156 @@ msgstr "Parent Page"
 
 msgid "Are you sure you want to cancel the local import?"
 msgstr "Are you sure you want to cancel the local import?"
+
+msgid "Certificate List"
+msgstr "Certificate List"
+
+msgid "Generate New"
+msgstr "Generate New"
+
+msgid "Public Key Distribution"
+msgstr "Public Key Distribution"
+
+msgid "Usage"
+msgstr "Usage"
+
+msgid "All"
+msgstr "All"
+
+msgid "Issued At"
+msgstr "Issued At"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Revoked At"
+msgstr "Revoked At"
+
+msgid "Actions"
+msgstr "Actions"
+
+msgid "Revoked"
+msgstr "Revoked"
+
+msgid "Active"
+msgstr "Active"
+
+msgid "View Details"
+msgstr "View Details"
+
+msgid "Revoke"
+msgstr "Revoke"
+
+msgid "No certificates available to display."
+msgstr "No certificates available to display."
+
+msgid "Certificate Details"
+msgstr "Certificate Details"
+
+msgid "KID"
+msgstr "KID"
+
+msgid "Back to List"
+msgstr "Back to List"
+
+msgid "Revoke Certificate"
+msgstr "Revoke Certificate"
+
+msgid "Metadata"
+msgstr "Metadata"
+
+msgid "Revocation Reason"
+msgstr "Revocation Reason"
+
+msgid "Subject"
+msgstr "Subject"
+
+msgid "Issuer"
+msgstr "Issuer"
+
+msgid "Validity Period"
+msgstr "Validity Period"
+
+msgid "to"
+msgstr "to"
+
+msgid "Certificate (PEM)"
+msgstr "Certificate (PEM)"
+
+msgid "JWK Information"
+msgstr "JWK Information"
+
+msgid "Generate Certificate"
+msgstr "Generate Certificate"
+
+msgid "Input Form"
+msgstr "Input Form"
+
+msgid "Email Address"
+msgstr "Email Address"
+
+msgid "Validity (days)"
+msgstr "Validity (days)"
+
+msgid "Key Type"
+msgstr "Key Type"
+
+msgid "RSA Key Size"
+msgstr "RSA Key Size"
+
+msgid "Key Usage"
+msgstr "Key Usage"
+
+msgid "Mark as CA certificate"
+msgstr "Mark as CA certificate"
+
+msgid "Generate"
+msgstr "Generate"
+
+msgid "Private Key / Public Key"
+msgstr "Private Key / Public Key"
+
+msgid "Private Key"
+msgstr "Private Key"
+
+msgid "Public Key"
+msgstr "Public Key"
+
+msgid "Generation results will appear here."
+msgstr "Generation results will appear here."
+
+msgid "Certificate / JWKS"
+msgstr "Certificate / JWKS"
+
+msgid "JWK"
+msgstr "JWK"
+
+msgid "Certificate details will be shown after generation."
+msgstr "Certificate details will be shown after generation."
+
+msgid "Revoke the certificate below and provide a reason for the revocation."
+msgstr "Revoke the certificate below and provide a reason for the revocation."
+
+msgid "Example: Key was compromised"
+msgstr "Example: Key was compromised"
+
+msgid "Back"
+msgstr "Back"
+
+msgid "Are you sure you want to revoke this certificate? This action cannot be undone."
+msgstr "Are you sure you want to revoke this certificate? This action cannot be undone."
+
+msgid "Links to the JWKS endpoints and information about currently published keys."
+msgstr "Links to the JWKS endpoints and information about currently published keys."
+
+msgid "Endpoint"
+msgstr "Endpoint"
+
+msgid "Open in Browser"
+msgstr "Open in Browser"
+
+msgid "Copy URL"
+msgstr "Copy URL"
+
+msgid "JWKS JSON"
+msgstr "JWKS JSON"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -2431,3 +2431,156 @@ msgstr "閉じる"
 msgid "Run import"
 msgstr "インポート実行"
 
+msgid "Certificate List"
+msgstr "証明書一覧"
+
+msgid "Generate New"
+msgstr "新規生成"
+
+msgid "Public Key Distribution"
+msgstr "公開鍵配布"
+
+msgid "Usage"
+msgstr "用途"
+
+msgid "All"
+msgstr "すべて"
+
+msgid "Issued At"
+msgstr "発行日時"
+
+msgid "Status"
+msgstr "状態"
+
+msgid "Revoked At"
+msgstr "失効日時"
+
+msgid "Actions"
+msgstr "操作"
+
+msgid "Revoked"
+msgstr "失効"
+
+msgid "Active"
+msgstr "有効"
+
+msgid "View Details"
+msgstr "詳細を表示"
+
+msgid "Revoke"
+msgstr "失効"
+
+msgid "No certificates available to display."
+msgstr "表示できる証明書がありません。"
+
+msgid "Certificate Details"
+msgstr "証明書詳細"
+
+msgid "KID"
+msgstr "KID"
+
+msgid "Back to List"
+msgstr "一覧に戻る"
+
+msgid "Revoke Certificate"
+msgstr "証明書を失効"
+
+msgid "Metadata"
+msgstr "メタ情報"
+
+msgid "Revocation Reason"
+msgstr "失効理由"
+
+msgid "Subject"
+msgstr "サブジェクト"
+
+msgid "Issuer"
+msgstr "発行者"
+
+msgid "Validity Period"
+msgstr "有効期間"
+
+msgid "to"
+msgstr "〜"
+
+msgid "Certificate (PEM)"
+msgstr "証明書 (PEM)"
+
+msgid "JWK Information"
+msgstr "JWK情報"
+
+msgid "Generate Certificate"
+msgstr "証明書生成"
+
+msgid "Input Form"
+msgstr "入力フォーム"
+
+msgid "Email Address"
+msgstr "メールアドレス"
+
+msgid "Validity (days)"
+msgstr "有効日数"
+
+msgid "Key Type"
+msgstr "鍵タイプ"
+
+msgid "RSA Key Size"
+msgstr "RSA鍵長"
+
+msgid "Key Usage"
+msgstr "Key Usage"
+
+msgid "Mark as CA certificate"
+msgstr "CA証明書としてマークする"
+
+msgid "Generate"
+msgstr "生成する"
+
+msgid "Private Key / Public Key"
+msgstr "秘密鍵 / 公開鍵"
+
+msgid "Private Key"
+msgstr "秘密鍵"
+
+msgid "Public Key"
+msgstr "公開鍵"
+
+msgid "Generation results will appear here."
+msgstr "生成結果がここに表示されます。"
+
+msgid "Certificate / JWKS"
+msgstr "証明書 / JWKS"
+
+msgid "JWK"
+msgstr "JWK"
+
+msgid "Certificate details will be shown after generation."
+msgstr "証明書生成後に詳細が表示されます。"
+
+msgid "Revoke the certificate below and provide a reason for the revocation."
+msgstr "以下の証明書を失効させます。理由を入力してください。"
+
+msgid "Example: Key was compromised"
+msgstr "例: 鍵漏洩が判明したため"
+
+msgid "Back"
+msgstr "戻る"
+
+msgid "Are you sure you want to revoke this certificate? This action cannot be undone."
+msgstr "本当に失効しますか？この操作は元に戻せません。"
+
+msgid "Links to the JWKS endpoints and information about currently published keys."
+msgstr "JWKSエンドポイントへのリンクと現在公開中の鍵情報です。"
+
+msgid "Endpoint"
+msgstr "エンドポイント"
+
+msgid "Open in Browser"
+msgstr "ブラウザで開く"
+
+msgid "Copy URL"
+msgstr "URLをコピー"
+
+msgid "JWKS JSON"
+msgstr "JWKS JSON"
+


### PR DESCRIPTION
## Summary
- replace hardcoded Japanese text in the certs UI templates with gettext-powered English labels
- add the corresponding English and Japanese translations to messages.po

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0461e34208323a715fc82912a03c9