### PR TITLE
Use i18n string for certificate management link

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -81,7 +81,7 @@
               <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
               {% endif %}
               {% if show_certificate_manage %}
-              <li><a class="dropdown-item" href="{{ url_for('certs_ui.index') }}">証明書管理</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('certs_ui.index') }}">{{ _('Certificate Management') }}</a></li>
               {% endif %}
               {% if show_user_manage %}
               <li><hr class="dropdown-divider"></li>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -7,6 +7,9 @@ msgstr "Familink"
 msgid "Dashboard"
 msgstr "Dashboard"
 
+msgid "Certificate Management"
+msgstr "Certificate Management"
+
 msgid "Login"
 msgstr "Login"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -149,6 +149,10 @@ msgstr ""
 msgid "Google Accounts"
 msgstr "Googleアカウント"
 
+#: webapp/templates/base.html:84
+msgid "Certificate Management"
+msgstr "証明書管理"
+
 #: webapp/admin/templates/admin/admin_users.html:26
 #: webapp/admin/templates/admin/config_view.html:2
 #: webapp/admin/templates/admin/config_view.html:20


### PR DESCRIPTION
## Summary
- replace the hard-coded Japanese certificate management link label with a translatable string in the base template
- add the corresponding "Certificate Management" entry to the English and Japanese message catalogs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0483001f08323a3c8b76336ad408f