### PR TITLE
Persist issued certificates to the database

### DIFF
--- a/features/certs/infrastructure/issued_store.py
+++ b/features/certs/infrastructure/issued_store.py
@@ -1,49 +1,75 @@
-"""発行済み証明書の保存"""
+"""Persistent store for issued certificates."""
 from __future__ import annotations
 
 from datetime import datetime
-from threading import Lock
 
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+from sqlalchemy import delete
+
+from core.db import db
 from features.certs.domain.models import IssuedCertificate
 from features.certs.domain.usage import UsageType
 
+from .models import IssuedCertificateEntity
+
 
 class IssuedCertificateStore:
-    """簡易的なオンメモリストア"""
-
-    def __init__(self) -> None:
-        self._store: dict[str, IssuedCertificate] = {}
-        self._lock = Lock()
+    """Database-backed certificate repository."""
 
     def add(self, cert: IssuedCertificate) -> None:
-        with self._lock:
-            self._store[cert.kid] = cert
+        pem = cert.certificate.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+        entity = IssuedCertificateEntity(
+            kid=cert.kid,
+            usage_type=cert.usage_type.value,
+            certificate_pem=pem,
+            jwk=cert.jwk,
+            issued_at=cert.issued_at,
+            revoked_at=cert.revoked_at,
+            revocation_reason=cert.revocation_reason,
+        )
+        db.session.merge(entity)
+        db.session.commit()
 
     def list_all(self) -> list[IssuedCertificate]:
-        with self._lock:
-            return sorted(self._store.values(), key=lambda cert: cert.issued_at, reverse=True)
+        query = IssuedCertificateEntity.query.order_by(IssuedCertificateEntity.issued_at.desc())
+        return [self._to_domain(entity) for entity in query.all()]
 
     def list_by_usage(self, usage: UsageType) -> list[IssuedCertificate]:
-        with self._lock:
-            return sorted(
-                (cert for cert in self._store.values() if cert.usage_type == usage),
-                key=lambda cert: cert.issued_at,
-                reverse=True,
-            )
+        query = (
+            IssuedCertificateEntity.query.filter_by(usage_type=usage.value)
+            .order_by(IssuedCertificateEntity.issued_at.desc())
+        )
+        return [self._to_domain(entity) for entity in query.all()]
 
     def get(self, kid: str) -> IssuedCertificate | None:
-        with self._lock:
-            return self._store.get(kid)
+        entity = db.session.get(IssuedCertificateEntity, kid)
+        if entity is None:
+            return None
+        return self._to_domain(entity)
 
     def revoke(self, kid: str, reason: str | None = None) -> IssuedCertificate | None:
-        with self._lock:
-            cert = self._store.get(kid)
-            if not cert:
-                return None
-            cert.revoked_at = datetime.utcnow()
-            cert.revocation_reason = reason
-            return cert
+        entity = db.session.get(IssuedCertificateEntity, kid)
+        if entity is None:
+            return None
+        entity.revoked_at = datetime.utcnow()
+        entity.revocation_reason = reason
+        db.session.commit()
+        return self._to_domain(entity)
 
     def clear(self) -> None:
-        with self._lock:
-            self._store.clear()
+        db.session.execute(delete(IssuedCertificateEntity))
+        db.session.commit()
+
+    def _to_domain(self, entity: IssuedCertificateEntity) -> IssuedCertificate:
+        certificate = x509.load_pem_x509_certificate(entity.certificate_pem.encode("utf-8"))
+        return IssuedCertificate(
+            kid=entity.kid,
+            certificate=certificate,
+            usage_type=UsageType(entity.usage_type),
+            jwk=entity.jwk,
+            issued_at=entity.issued_at,
+            revoked_at=entity.revoked_at,
+            revocation_reason=entity.revocation_reason,
+        )

--- a/features/certs/infrastructure/models.py
+++ b/features/certs/infrastructure/models.py
@@ -1,0 +1,22 @@
+"""SQLAlchemy models for certificate infrastructure."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.dialects.postgresql import JSONB
+
+from core.db import db
+
+
+class IssuedCertificateEntity(db.Model):
+    """Persistent storage for issued certificates."""
+
+    __tablename__ = "issued_certificates"
+
+    kid = db.Column(db.String(64), primary_key=True)
+    usage_type = db.Column(db.String(32), nullable=False, index=True)
+    certificate_pem = db.Column(db.Text, nullable=False)
+    jwk = db.Column(db.JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    issued_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+    revoked_at = db.Column(db.DateTime, nullable=True)
+    revocation_reason = db.Column(db.Text, nullable=True)

--- a/migrations/versions/f2d3a7b6d5c9_add_issued_certificates_table.py
+++ b/migrations/versions/f2d3a7b6d5c9_add_issued_certificates_table.py
@@ -1,0 +1,45 @@
+"""add issued certificates table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "f2d3a7b6d5c9"
+down_revision = "e1f1aa7a3c5e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "issued_certificates",
+        sa.Column("kid", sa.String(length=64), primary_key=True),
+        sa.Column("usage_type", sa.String(length=32), nullable=False),
+        sa.Column("certificate_pem", sa.Text(), nullable=False),
+        sa.Column(
+            "jwk",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+        ),
+        sa.Column("issued_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("revocation_reason", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_issued_certificates_usage_type",
+        "issued_certificates",
+        ["usage_type"],
+    )
+    op.create_index(
+        "ix_issued_certificates_issued_at",
+        "issued_certificates",
+        ["issued_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_issued_certificates_issued_at", table_name="issued_certificates")
+    op.drop_index("ix_issued_certificates_usage_type", table_name="issued_certificates")
+    op.drop_table("issued_certificates")

--- a/tests/features/certs/test_api.py
+++ b/tests/features/certs/test_api.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 
+from features.certs.application.use_cases import GetIssuedCertificateUseCase
+
 
 def test_generate_sign_and_jwks_flow(app_context):
     client = app_context.test_client()
@@ -57,6 +59,10 @@ def test_generate_sign_and_jwks_flow(app_context):
     jwks = jwks_resp.get_json()
     assert jwks["keys"]
     assert jwks["keys"][0]["kid"] == signed["kid"]
+
+    with app_context.app_context():
+        stored = GetIssuedCertificateUseCase().execute(signed["kid"])
+        assert stored.kid == signed["kid"]
 
 
 def test_generate_rejects_unknown_usage(app_context):

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -469,6 +469,7 @@ def create_app():
     from core.models import log as _log  # noqa: F401
     from core.models.wiki import models as _wiki_models  # noqa: F401
     from core.models import totp as _totp_models  # noqa: F401
+    from features.certs.infrastructure import models as _cert_models  # noqa: F401
 
 
     # Blueprint 登録


### PR DESCRIPTION
## Summary
- replace the in-memory issued certificate store with a SQLAlchemy-backed implementation so detail pages can be loaded reliably
- add the issued certificate model to the app startup and create an Alembic migration for the new table
- extend the certificate API flow test to confirm issued certificates can be fetched from the persistent store

## Testing
- pytest tests/features/certs/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f04d2e4778832397d70e09ffdf16d5