### PR TITLE
feat: allow configuring API base URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     FLASK_APP=wsgi.py \
     FLASK_ENV=production \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    API_BASE_URL=http://localhost:5000
 
 WORKDIR /app
 
@@ -90,7 +91,7 @@ RUN mkdir -p data/media data/thumbs data/playback data/local_import data/tmp dat
 USER appuser
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-  CMD curl -fsS http://localhost:5000/health/live || exit 1
+  CMD sh -c 'BASE="${API_BASE_URL:-http://localhost:5000}"; BASE="${BASE%/}"; curl -fsS "$BASE/health/live" || exit 1'
 
 EXPOSE 5000
 CMD ["gunicorn","--bind","0.0.0.0:5000","--workers","4","--timeout","120","--keep-alive","5","wsgi:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - PGID=${PGID:-1000}
       - UPLOAD_TMP_DIR=/app/data/tmp/upload
       - UPLOAD_DESTINATION_DIR=/app/data/uploads
+      - API_BASE_URL=${API_BASE_URL:-http://localhost:5000}
     env_file:
       - .env
     depends_on:
@@ -43,7 +44,7 @@ services:
     user: "${PUID:-1000}:${PGID:-1000}"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health/live')\""]
+      test: ["CMD-SHELL", "python -c \"import os, urllib.request; base = os.environ.get('API_BASE_URL', 'http://localhost:5000').rstrip('/') ; urllib.request.urlopen(base + '/health/live')\""]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -64,6 +65,7 @@ services:
       - PGID=${PGID:-1000}
       - UPLOAD_TMP_DIR=/app/data/tmp/upload
       - UPLOAD_DESTINATION_DIR=/app/data/uploads
+      - API_BASE_URL=${API_BASE_URL:-http://localhost:5000}
     env_file:
       - .env
     depends_on:
@@ -104,6 +106,7 @@ services:
       - TZ=${TZ:-Asia/Tokyo}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+      - API_BASE_URL=${API_BASE_URL:-http://localhost:5000}
     env_file:
       - .env
     depends_on:

--- a/shared/application/api_urls.py
+++ b/shared/application/api_urls.py
@@ -1,0 +1,39 @@
+"""Utilities for constructing internal API URLs."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urljoin
+
+DEFAULT_API_BASE_URL = "http://localhost:5000"
+
+
+def get_api_base_url() -> str:
+    """Return the base URL for internal API requests.
+
+    The value is read from the ``API_BASE_URL`` environment variable and
+    defaults to ``http://localhost:5000`` when the variable is not set.  The
+    trailing slash, if present, is removed to keep the base consistent.
+    """
+
+    base_url = os.environ.get("API_BASE_URL", DEFAULT_API_BASE_URL)
+    return base_url.rstrip("/")
+
+
+def build_api_url(path: str) -> str:
+    """Return a full URL for the given API path.
+
+    Parameters
+    ----------
+    path:
+        Relative path (with or without a leading slash) that should be appended
+        to the configured base URL.
+    """
+
+    base = get_api_base_url()
+    # ``urljoin`` requires the base to end with a slash to treat the second
+    # argument as a relative path.
+    return urljoin(f"{base}/", path.lstrip("/"))
+
+
+__all__ = ["DEFAULT_API_BASE_URL", "get_api_base_url", "build_api_url"]

--- a/tests/manual/debug_oauth_test.py
+++ b/tests/manual/debug_oauth_test.py
@@ -6,16 +6,19 @@ OAuth URL生成の実際の動作テスト
 import requests
 import json
 
+from shared.application.api_urls import build_api_url, get_api_base_url
+
 def test_oauth_url_generation():
     """実際のアプリケーションでOAuth URL生成をテスト"""
-    base_url = "http://localhost:5000"
-    
+    base_url = get_api_base_url()
+
     print("=== OAuth URL生成テスト ===\n")
+    print(f"Base URL: {base_url}\n")
     
     # 1. 通常のリクエスト（X-Forwarded-Protoなし）
     print("1. 通常のリクエスト:")
     try:
-        response = requests.get(f"{base_url}/debug/oauth-url")
+        response = requests.get(build_api_url("debug/oauth-url"))
         if response.status_code == 200:
             data = response.json()
             print(f"  - Callback URL: {data.get('callback_url')}")
@@ -34,7 +37,7 @@ def test_oauth_url_generation():
     print("2. X-Forwarded-Proto: https ヘッダー付き:")
     try:
         headers = {"X-Forwarded-Proto": "https"}
-        response = requests.get(f"{base_url}/debug/oauth-url", headers=headers)
+        response = requests.get(build_api_url("debug/oauth-url"), headers=headers)
         if response.status_code == 200:
             data = response.json()
             print(f"  - Callback URL: {data.get('callback_url')}")
@@ -53,7 +56,7 @@ def test_oauth_url_generation():
     print("3. 詳細ヘッダー情報:")
     try:
         headers = {"X-Forwarded-Proto": "https", "X-Forwarded-Host": "n.nolumia.com"}
-        response = requests.get(f"{base_url}/debug/headers", headers=headers)
+        response = requests.get(build_api_url("debug/headers"), headers=headers)
         if response.status_code == 200:
             data = response.json()
             print(f"  - Generated Callback URL: {data.get('generated_callback_url')}")

--- a/tests/manual_test_health.py
+++ b/tests/manual_test_health.py
@@ -10,6 +10,8 @@ import urllib.request
 import urllib.error
 from urllib.parse import urljoin
 
+from shared.application.api_urls import get_api_base_url, build_api_url
+
 
 def test_endpoint(base_url, endpoint, expected_status=200):
     """Test a single health endpoint"""
@@ -68,9 +70,9 @@ def test_endpoint(base_url, endpoint, expected_status=200):
 def main():
     """Main testing function"""
     if len(sys.argv) > 1:
-        base_url = sys.argv[1]
+        base_url = sys.argv[1].rstrip("/")
     else:
-        base_url = "http://localhost:5000"
+        base_url = get_api_base_url()
     
     print(f"Testing health endpoints at {base_url}")
     print("=" * 50)
@@ -114,7 +116,7 @@ def test_docker_healthcheck():
     try:
         # Docker healthcheck と同じコマンドを実行
         import urllib.request
-        url = 'http://localhost:5000/health/live'
+        url = build_api_url("health/live")
         print(f"Running: urllib.request.urlopen('{url}')")
         
         start_time = time.time()

--- a/tests/test_preview_api.py
+++ b/tests/test_preview_api.py
@@ -3,6 +3,8 @@
 import requests
 import json
 
+from shared.application.api_urls import build_api_url
+
 # テスト用のMarkdownコンテンツ
 test_content = """# 図表テストページ
 
@@ -27,7 +29,7 @@ https://example.com
 """
 
 # プレビューAPIをテスト
-url = "http://127.0.0.1:5000/wiki/api/preview"
+url = build_api_url("wiki/api/preview")
 headers = {"Content-Type": "application/json"}
 data = {"content": test_content}
 


### PR DESCRIPTION
## Summary
- add shared helper for building internal API URLs from the API_BASE_URL environment variable
- update Docker and docker-compose health checks plus manual scripts to rely on the configurable base URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f07345b7408323afc5621a42ebe7e6