### PR TITLE
Drop CERTS_API_BASE_URL in favor of API_BASE_URL

### DIFF
--- a/features/certs/presentation/ui/api_client.py
+++ b/features/certs/presentation/ui/api_client.py
@@ -12,6 +12,7 @@ from flask import Flask, current_app, has_request_context, request, url_for
 
 from features.certs.domain.usage import UsageType
 from webapp.auth.utils import log_requests_and_send
+from shared.application.api_urls import get_api_base_url
 
 
 class CertsApiClientError(RuntimeError):
@@ -191,13 +192,14 @@ class CertsApiClient:
         return urljoin(base_url.rstrip("/") + "/", path)
 
     def _resolve_base_url(self) -> str:
-        base_url = self._app.config.get("CERTS_API_BASE_URL")
-        if base_url:
-            return base_url
+        env_base_url = get_api_base_url()
+        if env_base_url:
+            return env_base_url
+
         if has_request_context():
             return request.url_root
         raise CertsApiClientError(
-            "CERTS_API_BASE_URL is not configured", HTTPStatus.INTERNAL_SERVER_ERROR
+            "API_BASE_URL is not configured", HTTPStatus.INTERNAL_SERVER_ERROR
         )
 
     def _build_headers(self) -> dict[str, str]:

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -29,7 +29,6 @@ class Config:
     
     # URL生成設定
     PREFERRED_URL_SCHEME = os.environ.get("PREFERRED_URL_SCHEME", "http")
-    CERTS_API_BASE_URL = os.environ.get("CERTS_API_BASE_URL")
     CERTS_API_TIMEOUT = float(os.environ.get("CERTS_API_TIMEOUT", "10"))
 
     SQLALCHEMY_BINDS = {}
@@ -121,7 +120,6 @@ class TestConfig(Config):
     
     # Session設定
     SESSION_COOKIE_SECURE = False
-    CERTS_API_BASE_URL = None
 
     # Feature X DB binding（テスト時は無効）
     SQLALCHEMY_BINDS = {}


### PR DESCRIPTION
## Summary
- update the certs UI API client to always use API_BASE_URL from the shared helper
- remove the deprecated CERTS_API_BASE_URL application configuration entry

## Testing
- pytest tests/features/certs -q

------
https://chatgpt.com/codex/tasks/task_e_68f0772ee298832381d11ceddff8ee48