### PR TITLE
Add back navigation to certificate generation page

### DIFF
--- a/features/certs/presentation/ui/templates/certs/generate.html
+++ b/features/certs/presentation/ui/templates/certs/generate.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Generate Certificate') }} | {{ super() }}{% endblock %}
 {% block content %}
-<h1 class="h3 mb-4">{{ _('Generate Certificate') }}</h1>
+<div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-4">
+  <h1 class="h3 mb-3 mb-md-0">{{ _('Generate Certificate') }}</h1>
+  <a class="btn btn-outline-secondary" href="{{ url_for('certs_ui.index') }}">{{ _('Back to List') }}</a>
+</div>
 <div class="row g-4">
   <div class="col-lg-6">
     <div class="card shadow-sm">


### PR DESCRIPTION
## Summary
- add a back-to-list button on the certificate generation screen so users can return to the certificate index

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f080e0c010832381611c01a7efeb1e