### PR TITLE
Add common name column to certificate list

### DIFF
--- a/features/certs/presentation/ui/templates/certs/index.html
+++ b/features/certs/presentation/ui/templates/certs/index.html
@@ -30,6 +30,7 @@
     <thead>
       <tr>
         <th scope="col">KID</th>
+        <th scope="col">{{ _('Common Name') }}</th>
         <th scope="col">{{ _('Usage') }}</th>
         <th scope="col">{{ _('Issued At') }}</th>
         <th scope="col">{{ _('Status') }}</th>
@@ -42,6 +43,7 @@
         {% for cert in certificates %}
         <tr>
           <td class="font-monospace">{{ cert.kid }}</td>
+          <td>{{ cert.common_name or '-' }}</td>
           <td>{{ cert.usage_type.value }}</td>
           <td>{{ cert.issued_at.strftime('%Y-%m-%d %H:%M:%S') if cert.issued_at else '-' }}</td>
           <td>

--- a/tests/features/certs/test_ui_service.py
+++ b/tests/features/certs/test_ui_service.py
@@ -29,6 +29,7 @@ class _DummyClient:
                 issued_at=None,
                 revoked_at=None,
                 revocation_reason=None,
+                subject="CN=example",
             )
         ]
 
@@ -40,9 +41,9 @@ class _DummyClient:
             issued_at=None,
             revoked_at=None,
             revocation_reason=None,
+            subject="CN=sub",
             certificate_pem="pem",
             jwk={},
-            subject="sub",
             issuer="issuer",
             not_before=None,
             not_after=None,

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -403,6 +403,9 @@ msgstr "Are you sure you want to cancel the local import?"
 msgid "Certificate List"
 msgstr "Certificate List"
 
+msgid "Common Name"
+msgstr "Common Name"
+
 msgid "Generate New"
 msgstr "Generate New"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -2438,6 +2438,9 @@ msgstr "インポート実行"
 msgid "Certificate List"
 msgstr "証明書一覧"
 
+msgid "Common Name"
+msgstr "コモンネーム"
+
 msgid "Generate New"
 msgstr "新規生成"
 


### PR DESCRIPTION
## Summary
- parse certificate subjects to expose common name in the UI client
- show the certificate common name in the certificate list and add translations
- update certificate UI service tests for the new subject data

## Testing
- pytest tests/features/certs/test_ui_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f082e57ebc8323a2bad18df8cf1781