### PR TITLE
feat: surface certificate management entry points

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -53,6 +53,13 @@
           </a>
         </li>
         {% endif %}
+        {% if current_user.can('certificate:manage') %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('certs_ui.index') }}">
+            <i class="bi bi-award me-1"></i>{{ _('Certificates') }}
+          </a>
+        </li>
+        {% endif %}
         {% endif %}
       </ul>
       <ul class="navbar-nav">
@@ -61,13 +68,12 @@
           {% set show_admin_only = current_user.has_role('admin') %}
           {% set show_user_manage = current_user.can('user:manage') %}
           {% set show_service_accounts = current_user.can('service_account:manage') %}
-          {% set show_certificate_manage = current_user.can('certificate:manage') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
             </a>
           </li>
-          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_certificate_manage or show_system_manage or show_admin_only %}
+          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_system_manage or show_admin_only %}
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               {{ _('Management') }}
@@ -79,9 +85,6 @@
               {% endif %}
               {% if show_service_accounts %}
               <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
-              {% endif %}
-              {% if show_certificate_manage %}
-              <li><a class="dropdown-item" href="{{ url_for('certs_ui.index') }}">{{ _('Certificate Management') }}</a></li>
               {% endif %}
               {% if show_user_manage %}
               <li><hr class="dropdown-divider"></li>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -55,6 +55,13 @@
             </a>
           </div>
           {% endif %}
+          {% if current_user.can('certificate:manage') %}
+          <div class="col-md-4 mb-3">
+            <a href="{{ url_for('certs_ui.index') }}" class="btn btn-secondary btn-lg w-100">
+              <i class="bi bi-award"></i><br>{{ _('Certificate Management') }}
+            </a>
+          </div>
+          {% endif %}
           {% if current_user.can('media:view') %}
           <div class="col-md-4 mb-3">
             <a href="{{ url_for('photo_view.home') }}" class="btn btn-success btn-lg w-100">

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -149,9 +149,13 @@ msgstr ""
 msgid "Google Accounts"
 msgstr "Googleアカウント"
 
-#: webapp/templates/base.html:84
+#: webapp/templates/base.html:91 webapp/templates/index.html:52
 msgid "Certificate Management"
 msgstr "証明書管理"
+
+#: webapp/templates/base.html:68
+msgid "Certificates"
+msgstr "証明書"
 
 #: webapp/admin/templates/admin/admin_users.html:26
 #: webapp/admin/templates/admin/config_view.html:2


### PR DESCRIPTION
## Summary
- expose certificate management directly in the main navigation bar instead of the management dropdown
- add a top page shortcut button for certificate management and localize the new label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f08f06b710832389be69d6f0f1e72c