### PR TITLE
Add migration for certificate events and fix group detail subject

### DIFF
--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -280,7 +280,7 @@ def group_detail(group_code: str):
     issued_certificate = session.pop("certs_last_issued", None)
 
     jwks_url = url_for("certs_api.jwks", group_code=group_code, _external=True)
-    subject_form_values = _subject_to_form_values(group.subject_dict())
+    subject_form_values = _subject_to_form_values(group.subject)
 
     return render_template(
         "certs/group_detail.html",

--- a/migrations/versions/c7d8e9f0a1b2_add_certificate_events_table.py
+++ b/migrations/versions/c7d8e9f0a1b2_add_certificate_events_table.py
@@ -1,0 +1,80 @@
+"""add certificate events table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "c7d8e9f0a1b2"
+down_revision = "a3c2b1d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind else ""
+
+    json_type = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+    op.create_table(
+        "certificate_events",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("actor", sa.String(length=255), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("target_kid", sa.String(length=64), nullable=True),
+        sa.Column("target_group_code", sa.String(length=64), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("details", json_type, nullable=True),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_certificate_events_target_kid",
+        "certificate_events",
+        ["target_kid"],
+    )
+    op.create_index(
+        "ix_certificate_events_target_group_code",
+        "certificate_events",
+        ["target_group_code"],
+    )
+    op.create_index(
+        "ix_certificate_events_occurred_at",
+        "certificate_events",
+        ["occurred_at"],
+    )
+
+    if dialect in {"mysql", "mariadb"}:
+        op.create_check_constraint(
+            "ck_certificate_events_details_json",
+            "certificate_events",
+            "json_valid(details)",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind else ""
+
+    if dialect in {"mysql", "mariadb"}:
+        op.drop_constraint(
+            "ck_certificate_events_details_json",
+            "certificate_events",
+            type_="check",
+        )
+
+    op.drop_index("ix_certificate_events_occurred_at", table_name="certificate_events")
+    op.drop_index("ix_certificate_events_target_group_code", table_name="certificate_events")
+    op.drop_index("ix_certificate_events_target_kid", table_name="certificate_events")
+    op.drop_table("certificate_events")


### PR DESCRIPTION
## Summary
- add an Alembic migration to create the certificate_events audit table with indexes and JSON validation
- use the CertificateGroupData.subject mapping when populating the group detail form to avoid AttributeError

## Testing
- pytest tests/features/certs -q

------
https://chatgpt.com/codex/tasks/task_e_68f0a4826ecc8323bfcce8a8ded870bc