### PR TITLE
Fix group detail view subject conversion

### DIFF
--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -280,7 +280,7 @@ def group_detail(group_code: str):
     issued_certificate = session.pop("certs_last_issued", None)
 
     jwks_url = url_for("certs_api.jwks", group_code=group_code, _external=True)
-    subject_form_values = _subject_to_form_values(group.subject_dict())
+    subject_form_values = _subject_to_form_values(group.subject)
 
     return render_template(
         "certs/group_detail.html",


### PR DESCRIPTION
## Summary
- ensure the certificate group detail view converts the subject payload using the data object attribute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0b32703c083238a7f13d0423b4b79