### PR TITLE
Default usage type preset for certificate group keys

### DIFF
--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -248,6 +248,8 @@ def index():
         create_form_values["auto_rotate"] = "on"
     if "rotation_threshold_days" not in create_form_values:
         create_form_values["rotation_threshold_days"] = "30"
+    if not create_form_values.get("usage_type"):
+        create_form_values["usage_type"] = UsageType.SERVER_SIGNING.value
 
     return render_template(
         "certs/groups.html",

--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -258,6 +258,13 @@
       keySize: keySizeSelect.dataset.initial || keySizeSelect.value || '',
     };
 
+    if (!state.usageType) {
+      const firstUsageOption = Array.from(usageSelect.options || []).find((option) => option.value);
+      if (firstUsageOption) {
+        state.usageType = firstUsageOption.value;
+      }
+    }
+
     const placeholders = {
       keyType: keyTypeSelect.dataset.placeholder || '',
       keyCurve: keyCurveSelect.dataset.placeholder || '',


### PR DESCRIPTION
## Summary
- ensure the certificate group creation form defaults to the server signing usage when no value is stored
- update the key preset controller to pick the first available usage option so key type, curve, and size dropdowns populate immediately

## Testing
- pytest tests/features/certs/test_ui_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f0d71c29088323b191a2537b09c3da