### PR TITLE
Add group certificate signing API

### DIFF
--- a/features/certs/application/dto.py
+++ b/features/certs/application/dto.py
@@ -72,6 +72,22 @@ class IssueCertificateForGroupOutput:
 
 
 @dataclass(slots=True)
+class SignGroupPayloadInput:
+    group_code: str
+    payload: bytes
+    kid: str | None = None
+    hash_algorithm: str = "SHA256"
+
+
+@dataclass(slots=True)
+class SignGroupPayloadOutput:
+    kid: str
+    signature: bytes
+    hash_algorithm: str
+    algorithm: str
+
+
+@dataclass(slots=True)
 class CertificateSearchFilters:
     limit: int = 50
     offset: int = 0

--- a/features/certs/application/rotation.py
+++ b/features/certs/application/rotation.py
@@ -106,6 +106,12 @@ class AutoRotateCertificatesUseCase:
 
             issued.auto_rotated_from_kid = auto_rotated_from
             saved = self._services.issued_store.save(issued)
+            self._services.private_key_store.save(
+                kid=saved.kid,
+                private_key_pem=private_key_pem,
+                group_id=group.id,
+                expires_at=saved.expires_at,
+            )
             results.append(
                 RotationResult(
                     group=group,

--- a/features/certs/application/services.py
+++ b/features/certs/application/services.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from features.certs.infrastructure.ca_store import CAKeyStore
 from features.certs.infrastructure.event_store import CertificateEventStore
 from features.certs.infrastructure.group_store import CertificateGroupStore
+from features.certs.infrastructure.private_key_store import CertificatePrivateKeyStore
 from features.certs.infrastructure.issued_store import IssuedCertificateStore
 
 
@@ -15,6 +16,7 @@ class CertificateServices:
     issued_store: IssuedCertificateStore
     group_store: CertificateGroupStore
     event_store: CertificateEventStore
+    private_key_store: CertificatePrivateKeyStore
 
 
 default_certificate_services = CertificateServices(
@@ -22,6 +24,7 @@ default_certificate_services = CertificateServices(
     issued_store=IssuedCertificateStore(),
     group_store=CertificateGroupStore(),
     event_store=CertificateEventStore(),
+    private_key_store=CertificatePrivateKeyStore(),
 )
 
 

--- a/features/certs/domain/exceptions.py
+++ b/features/certs/domain/exceptions.py
@@ -32,3 +32,7 @@ class CertificateGroupConflictError(CertificateError):
 
 class CertificateRotationError(CertificateError):
     """自動ローテーション処理に関する例外"""
+
+
+class CertificatePrivateKeyNotFoundError(CertificateError):
+    """証明書に対応する秘密鍵が存在しない場合の例外"""

--- a/features/certs/domain/models.py
+++ b/features/certs/domain/models.py
@@ -82,6 +82,17 @@ class CertificateGroup:
 
 
 @dataclass(slots=True)
+class CertificatePrivateKey:
+    """発行済み証明書に紐づく秘密鍵を保持するモデル"""
+
+    kid: str
+    private_key_pem: str
+    group_id: int | None
+    created_at: datetime
+    expires_at: datetime | None
+
+
+@dataclass(slots=True)
 class CertificateEvent:
     """証明書操作の監査ログ"""
 

--- a/features/certs/infrastructure/models.py
+++ b/features/certs/infrastructure/models.py
@@ -81,3 +81,18 @@ class CertificateEventEntity(db.Model):
     reason = db.Column(db.Text, nullable=True)
     details = db.Column(db.JSON().with_variant(JSONB, "postgresql"), nullable=True)
     occurred_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+
+class CertificatePrivateKeyEntity(db.Model):
+    """発行済み証明書に紐づく秘密鍵を保持するテーブル"""
+
+    __tablename__ = "certificate_private_keys"
+
+    kid = db.Column(db.String(64), db.ForeignKey("issued_certificates.kid", ondelete="CASCADE"), primary_key=True)
+    group_id = db.Column(db.BigInteger, db.ForeignKey("certificate_groups.id", ondelete="SET NULL"), nullable=True)
+    private_key_pem = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+    expires_at = db.Column(db.DateTime, nullable=True, index=True)
+
+    certificate = db.relationship("IssuedCertificateEntity", lazy="joined")
+    group = db.relationship("CertificateGroupEntity", lazy="joined")

--- a/features/certs/infrastructure/private_key_store.py
+++ b/features/certs/infrastructure/private_key_store.py
@@ -1,0 +1,58 @@
+"""証明書秘密鍵の保存を担当するストア"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from core.db import db
+from features.certs.domain.exceptions import CertificatePrivateKeyNotFoundError
+from features.certs.domain.models import CertificatePrivateKey
+
+from .models import CertificatePrivateKeyEntity
+
+
+class CertificatePrivateKeyStore:
+    """発行済み証明書に紐づく秘密鍵を保存・取得するストア"""
+
+    def save(
+        self,
+        *,
+        kid: str,
+        private_key_pem: str,
+        group_id: int | None,
+        expires_at: datetime | None = None,
+    ) -> CertificatePrivateKey:
+        entity = CertificatePrivateKeyEntity(
+            kid=kid,
+            group_id=group_id,
+            private_key_pem=private_key_pem,
+            expires_at=expires_at,
+        )
+        entity = db.session.merge(entity)
+        db.session.commit()
+        db.session.refresh(entity)
+        return self._entity_to_domain(entity)
+
+    def get(self, kid: str) -> CertificatePrivateKey:
+        entity = db.session.get(CertificatePrivateKeyEntity, kid)
+        if entity is None:
+            raise CertificatePrivateKeyNotFoundError("証明書に対応する秘密鍵が見つかりません")
+        return self._entity_to_domain(entity)
+
+    def delete(self, kid: str) -> None:
+        entity = db.session.get(CertificatePrivateKeyEntity, kid)
+        if entity is None:
+            return
+        db.session.delete(entity)
+        db.session.commit()
+
+    def _entity_to_domain(self, entity: CertificatePrivateKeyEntity) -> CertificatePrivateKey:
+        return CertificatePrivateKey(
+            kid=entity.kid,
+            private_key_pem=entity.private_key_pem,
+            group_id=entity.group_id,
+            created_at=entity.created_at,
+            expires_at=entity.expires_at,
+        )
+
+
+__all__ = ["CertificatePrivateKeyStore"]

--- a/features/certs/presentation/ui/services.py
+++ b/features/certs/presentation/ui/services.py
@@ -16,6 +16,7 @@ from .api_client import (
     GeneratedMaterial,
     IssuedCertificateWithPrivateKey,
     SignedCertificate,
+    SignedPayload,
 )
 
 
@@ -161,6 +162,21 @@ class CertificateUiService:
             subject_overrides=subject_overrides,
             valid_days=valid_days,
             key_usage=key_usage,
+        )
+
+    def sign_group_payload(
+        self,
+        group_code: str,
+        *,
+        payload: bytes,
+        kid: str | None = None,
+        hash_algorithm: str = "SHA256",
+    ) -> SignedPayload:
+        return self._client.sign_group_payload(
+            group_code,
+            payload=payload,
+            kid=kid,
+            hash_algorithm=hash_algorithm,
         )
 
     def revoke_certificate_in_group(


### PR DESCRIPTION
## Summary
- persist issued certificate private keys and expose a use case for signing payloads with active group certificates
- add a REST endpoint that validates group codes and signs provided payloads with the selected group certificate
- update the UI client/service and API tests to cover payload signing and the stricter validation rules

## Testing
- pytest tests/features/certs/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f0df27ddc88323831fd2afc7eed216