### PR TITLE
Enforce certificate group code format in UI

### DIFF
--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
 from http import HTTPStatus
 
@@ -23,6 +24,8 @@ from features.certs.presentation.ui.api_client import CertsApiClientError
 from features.certs.presentation.ui.services import CertificateUiService
 
 from . import certs_ui_bp
+
+_GROUP_CODE_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 
 _KEY_USAGE_CHOICES: list[tuple[str, str]] = [
     ("digitalSignature", _("digitalSignature - digital signature")),
@@ -291,6 +294,14 @@ def create_group():
     if not group_code:
         _remember_form_state()
         flash(_("Group code is required."), "error")
+        return redirect(url_for("certs_ui.index"))
+
+    if not _GROUP_CODE_PATTERN.fullmatch(group_code):
+        _remember_form_state()
+        flash(
+            _("Group code must contain only lowercase letters, numbers, hyphen, or underscore."),
+            "error",
+        )
         return redirect(url_for("certs_ui.index"))
 
     display_name = (form.get("display_name") or "").strip() or None

--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -97,7 +97,18 @@
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label" for="group_code">{{ _('Group Code') }} <span class="text-danger">*</span></label>
-              <input class="form-control" type="text" id="group_code" name="group_code" required value="{{ create_form_values.get('group_code', '') }}">
+              <input
+                class="form-control"
+                type="text"
+                id="group_code"
+                name="group_code"
+                required
+                pattern="[a-z0-9_-]+"
+                title="{{ _('Group code must contain only lowercase letters, numbers, hyphen, or underscore.') }}"
+                autocapitalize="none"
+                autocomplete="off"
+                value="{{ create_form_values.get('group_code', '') }}"
+              >
             </div>
             <div class="col-md-6">
               <label class="form-label" for="display_name">{{ _('Display Name') }}</label>


### PR DESCRIPTION
## Summary
- validate certificate group codes against the lowercase hyphen/underscore pattern in the UI route
- add client-side validation hints for group code entry in the create group modal

## Testing
- pytest tests/features/certs/test_ui_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f0e76583508323a2160709c626de3e