### PR TITLE
Rename service account endpoint to jwt_endpoint

### DIFF
--- a/core/models/service_account.py
+++ b/core/models/service_account.py
@@ -20,7 +20,7 @@ class ServiceAccount(db.Model):
     service_account_id = db.Column(BigInt, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
     description = db.Column(db.String(255), nullable=True)
-    jtk_endpoint = db.Column(db.String(500), nullable=True)
+    jwt_endpoint = db.Column(db.String(500), nullable=True)
     scope_names = db.Column(db.String(1000), nullable=False, default="")
     active_flg = db.Column(db.Boolean, nullable=False, default=True)
     reg_dttm = db.Column(
@@ -63,7 +63,7 @@ class ServiceAccount(db.Model):
             "service_account_id": self.service_account_id,
             "name": self.name,
             "description": self.description,
-            "jtk_endpoint": self.jtk_endpoint,
+            "jwt_endpoint": self.jwt_endpoint,
             "scope_names": self.scope_names,
             "active_flg": self.active_flg,
             "reg_dttm": self.reg_dttm.isoformat() if self.reg_dttm else None,

--- a/migrations/versions/c2f4b18f1f6b_rename_jtk_endpoint_to_jwt_endpoint.py
+++ b/migrations/versions/c2f4b18f1f6b_rename_jtk_endpoint_to_jwt_endpoint.py
@@ -1,0 +1,20 @@
+"""Rename service account endpoint column from jtk_endpoint to jwt_endpoint."""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "c2f4b18f1f6b"
+down_revision = "a3c2b1d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("service_account") as batch_op:
+        batch_op.alter_column("jtk_endpoint", new_column_name="jwt_endpoint")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("service_account") as batch_op:
+        batch_op.alter_column("jwt_endpoint", new_column_name="jtk_endpoint")

--- a/tests/test_service_account_jwt.py
+++ b/tests/test_service_account_jwt.py
@@ -83,12 +83,12 @@ def _mock_jwks(monkeypatch, mapping: dict[str, list[dict]]):
     monkeypatch.setattr("requests.get", fake_get)
 
 
-def _create_account(app, name: str, jtk_endpoint: str, scopes: str):
+def _create_account(app, name: str, jwt_endpoint: str, scopes: str):
     allowed = [scope.strip() for scope in scopes.split(",") if scope.strip()]
     return ServiceAccountService.create_account(
         name=name,
         description="",
-        jtk_endpoint=jtk_endpoint,
+        jwt_endpoint=jwt_endpoint,
         scope_names=scopes,
         active=True,
         allowed_scopes=allowed,
@@ -297,26 +297,26 @@ def test_service_account_jwt_success_rs256(app_context, monkeypatch):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_jtk_endpoint_validation(app_context):
+def test_service_account_jwt_endpoint_validation(app_context):
     account = ServiceAccountService.create_account(
         name="normalize-bot",
         description=None,
-        jtk_endpoint=" https://keys.example.com/jwks ",
+        jwt_endpoint=" https://keys.example.com/jwks ",
         scope_names="maintenance:read",
         active=True,
         allowed_scopes=["maintenance:read"],
     )
 
-    assert account.jtk_endpoint == "https://keys.example.com/jwks"
+    assert account.jwt_endpoint == "https://keys.example.com/jwks"
 
     with pytest.raises(ServiceAccountValidationError) as exc:
         ServiceAccountService.create_account(
             name="invalid-bot",
             description=None,
-            jtk_endpoint="ftp://keys.example.com/jwks",
+            jwt_endpoint="ftp://keys.example.com/jwks",
             scope_names="maintenance:read",
             active=True,
             allowed_scopes=["maintenance:read"],
         )
 
-    assert exc.value.field == "jtk_endpoint"
+    assert exc.value.field == "jwt_endpoint"

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -60,7 +60,7 @@ def service_accounts_create():
         account = ServiceAccountService.create_account(
             name=payload.get("name", ""),
             description=payload.get("description"),
-            jtk_endpoint=payload.get("jtk_endpoint", ""),
+            jwt_endpoint=payload.get("jwt_endpoint", ""),
             scope_names=payload.get("scope_names", ""),
             active=payload.get("active_flg", True),
             allowed_scopes=current_user.permissions,
@@ -98,7 +98,7 @@ def service_accounts_update(account_id: int):
             account_id,
             name=payload.get("name", ""),
             description=payload.get("description"),
-            jtk_endpoint=payload.get("jtk_endpoint", ""),
+            jwt_endpoint=payload.get("jwt_endpoint", ""),
             scope_names=payload.get("scope_names", ""),
             active=payload.get("active_flg", True),
             allowed_scopes=current_user.permissions,
@@ -678,7 +678,7 @@ def _extract_service_account_payload() -> dict:
     return {
         "name": data.get("name", ""),
         "description": data.get("description"),
-        "jtk_endpoint": data.get("jtk_endpoint", ""),
+        "jwt_endpoint": data.get("jwt_endpoint", ""),
         "scope_names": data.get("scope_names", ""),
         "active_flg": active_value,
     }

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -136,10 +136,10 @@
             <textarea class="form-control" id="service-account-description" rows="2" maxlength="255"></textarea>
           </div>
           <div class="mb-3">
-            <label for="service-account-jtk-endpoint" class="form-label">{{ _('JTK endpoint URL') }}</label>
-            <input type="url" class="form-control" id="service-account-jtk-endpoint" required maxlength="500">
+            <label for="service-account-jwt-endpoint" class="form-label">{{ _('JWT endpoint URL') }}</label>
+            <input type="url" class="form-control" id="service-account-jwt-endpoint" required maxlength="500">
             <div class="form-text">{{ _('Specify the JWKS endpoint used to verify tokens for this service account.') }}</div>
-            <div class="invalid-feedback" data-field="jtk_endpoint"></div>
+            <div class="invalid-feedback" data-field="jwt_endpoint"></div>
           </div>
           <div class="mb-3" data-scope-selection>
             <label class="form-label fw-semibold" for="service-account-scope-search">{{ _('Scopes') }}</label>
@@ -206,8 +206,8 @@
           <dd class="col-sm-9" id="detail-description"></dd>
           <dt class="col-sm-3">{{ _('Scopes') }}</dt>
           <dd class="col-sm-9" id="detail-scopes"></dd>
-          <dt class="col-sm-3">{{ _('JTK endpoint URL') }}</dt>
-          <dd class="col-sm-9" id="detail-jtk-endpoint"></dd>
+          <dt class="col-sm-3">{{ _('JWT endpoint URL') }}</dt>
+          <dd class="col-sm-9" id="detail-jwt-endpoint"></dd>
           <dt class="col-sm-3">{{ _('Registered At') }}</dt>
           <dd class="col-sm-9" id="detail-registered"></dd>
           <dt class="col-sm-3">{{ _('Updated At') }}</dt>
@@ -580,7 +580,7 @@
 
     document.getElementById('service-account-name').value = account ? account.name : '';
     document.getElementById('service-account-description').value = account?.description || '';
-    document.getElementById('service-account-jtk-endpoint').value = account ? account.jtk_endpoint || '' : '';
+    document.getElementById('service-account-jwt-endpoint').value = account ? account.jwt_endpoint || '' : '';
     document.getElementById('service-account-active').checked = account ? account.active_flg : true;
 
     if (scopeSearchInput) {
@@ -602,7 +602,7 @@
     document.getElementById('detail-scopes').innerHTML = account.scope_names
       ? account.scope_names.split(',').map(scope => `<span class="badge bg-secondary me-1">${scope}</span>`).join(' ')
       : '<span class="text-muted">-</span>';
-    document.getElementById('detail-jtk-endpoint').textContent = account.jtk_endpoint || '';
+    document.getElementById('detail-jwt-endpoint').textContent = account.jwt_endpoint || '';
     document.getElementById('detail-registered').textContent = formatDate(account.reg_dttm);
     document.getElementById('detail-updated').textContent = formatDate(account.mod_dttm);
     detailModal.show();
@@ -616,7 +616,7 @@
     return {
       name: document.getElementById('service-account-name').value.trim(),
       description: document.getElementById('service-account-description').value.trim(),
-      jtk_endpoint: document.getElementById('service-account-jtk-endpoint').value.trim(),
+      jwt_endpoint: document.getElementById('service-account-jwt-endpoint').value.trim(),
       scope_names: Array.from(scopeCheckboxes.values())
         .filter((checkbox) => checkbox.checked)
         .map((checkbox) => checkbox.value)

--- a/webapp/auth/service_account_auth.py
+++ b/webapp/auth/service_account_auth.py
@@ -39,15 +39,15 @@ class ServiceAccountTokenValidator:
                 _("The token does not specify a key identifier."),
             )
 
-        if not account.jtk_endpoint:
+        if not account.jwt_endpoint:
             raise ServiceAccountJWTError(
                 "InvalidSignature",
-                _("The service account is missing a JTK endpoint."),
+                _("The service account is missing a JWT endpoint."),
             )
 
         timeout = current_app.config.get("SERVICE_ACCOUNT_JWKS_TIMEOUT", 5)
         try:
-            response = requests.get(account.jtk_endpoint, timeout=timeout)
+            response = requests.get(account.jwt_endpoint, timeout=timeout)
             response.raise_for_status()
         except requests.RequestException as exc:
             raise ServiceAccountJWTError(
@@ -60,14 +60,14 @@ class ServiceAccountTokenValidator:
         except ValueError as exc:
             raise ServiceAccountJWTError(
                 "InvalidSignature",
-                _("The JTK endpoint returned invalid JSON."),
+                _("The JWT endpoint returned invalid JSON."),
             ) from exc
 
         keys = payload.get("keys")
         if not isinstance(keys, list):
             raise ServiceAccountJWTError(
                 "InvalidSignature",
-                _("The JTK endpoint response did not include signing keys."),
+                _("The JWT endpoint response did not include signing keys."),
             )
 
         for jwk in keys:
@@ -82,7 +82,7 @@ class ServiceAccountTokenValidator:
             except (ValueError, TypeError) as exc:
                 raise ServiceAccountJWTError(
                     "InvalidSignature",
-                    _("Failed to construct a signing key from the JTK response."),
+                    _("Failed to construct a signing key from the JWT response."),
                 ) from exc
 
         raise ServiceAccountJWTError(

--- a/webapp/services/service_account_service.py
+++ b/webapp/services/service_account_service.py
@@ -28,18 +28,18 @@ class ServiceAccountNotFoundError(Exception):
 
 class ServiceAccountService:
     @staticmethod
-    def _normalize_jtk_endpoint(endpoint: str) -> str:
+    def _normalize_jwt_endpoint(endpoint: str) -> str:
         if not endpoint or not endpoint.strip():
             raise ServiceAccountValidationError(
-                _("Please provide a JTK endpoint."), field="jtk_endpoint"
+                _("Please provide a JWT endpoint."), field="jwt_endpoint"
             )
 
         value = endpoint.strip()
         parsed = urlparse(value)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             raise ServiceAccountValidationError(
-                _("The JTK endpoint must be a valid HTTP(S) URL."),
-                field="jtk_endpoint",
+                _("The JWT endpoint must be a valid HTTP(S) URL."),
+                field="jwt_endpoint",
             )
 
         return value
@@ -82,7 +82,7 @@ class ServiceAccountService:
         *,
         name: str,
         description: str | None,
-        jtk_endpoint: str,
+        jwt_endpoint: str,
         scope_names: str | Sequence[str],
         active: bool,
         allowed_scopes: Iterable[str] | None,
@@ -92,13 +92,13 @@ class ServiceAccountService:
                 _("Please provide a service account name."), field="name"
             )
 
-        normalized_endpoint = cls._normalize_jtk_endpoint(jtk_endpoint)
+        normalized_endpoint = cls._normalize_jwt_endpoint(jwt_endpoint)
         normalized_scopes = cls._normalize_scopes(scope_names, allowed_scopes=allowed_scopes)
 
         account = ServiceAccount(
             name=name.strip(),
             description=description.strip() if description else None,
-            jtk_endpoint=normalized_endpoint,
+            jwt_endpoint=normalized_endpoint,
             active_flg=bool(active),
         )
         account.set_scopes(normalized_scopes)
@@ -131,7 +131,7 @@ class ServiceAccountService:
         *,
         name: str,
         description: str | None,
-        jtk_endpoint: str,
+        jwt_endpoint: str,
         scope_names: str | Sequence[str],
         active: bool,
         allowed_scopes: Iterable[str] | None,
@@ -145,12 +145,12 @@ class ServiceAccountService:
                 _("Please provide a service account name."), field="name"
             )
 
-        normalized_endpoint = cls._normalize_jtk_endpoint(jtk_endpoint)
+        normalized_endpoint = cls._normalize_jwt_endpoint(jwt_endpoint)
         normalized_scopes = cls._normalize_scopes(scope_names, allowed_scopes=allowed_scopes)
 
         account.name = name.strip()
         account.description = description.strip() if description else None
-        account.jtk_endpoint = normalized_endpoint
+        account.jwt_endpoint = normalized_endpoint
         account.active_flg = bool(active)
         account.set_scopes(normalized_scopes)
 


### PR DESCRIPTION
## Summary
- rename the service account endpoint field to `jwt_endpoint` across the model, services, and API payloads
- update the admin UI copy and client logic to use the new JWT endpoint name
- add an Alembic migration and refresh unit tests for the renamed endpoint

## Testing
- pytest tests/test_service_account_jwt.py

------
https://chatgpt.com/codex/tasks/task_e_68f10d13cbac8323b2f23fc0a2b5fd21