### PR TITLE
Add service account API key management

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -10,6 +10,7 @@ from .picker_session import PickerSession
 from .picker_import_task import PickerImportTask
 from .totp import TOTPCredential
 from .service_account import ServiceAccount
+from .service_account_api_key import ServiceAccountApiKey, ServiceAccountApiKeyLog
 
 __all__ = [
     'User',
@@ -27,4 +28,6 @@ __all__ = [
     'PickerImportTask',
     'TOTPCredential',
     'ServiceAccount',
+    'ServiceAccountApiKey',
+    'ServiceAccountApiKeyLog',
 ]

--- a/core/models/service_account_api_key.py
+++ b/core/models/service_account_api_key.py
@@ -1,0 +1,143 @@
+"""Models for service account API keys and their usage logs."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, List
+
+from werkzeug.security import check_password_hash
+
+from core.db import db
+
+# Align BIGINT usage with other models to keep SQLite compatibility
+BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ServiceAccountApiKey(db.Model):
+    __tablename__ = "service_account_api_key"
+
+    api_key_id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    service_account_id = db.Column(
+        BigInt,
+        db.ForeignKey("service_account.service_account_id"),
+        nullable=False,
+        index=True,
+    )
+    public_id = db.Column(db.String(32), nullable=False, unique=True)
+    secret_hash = db.Column(db.String(255), nullable=False)
+    scope_names = db.Column(db.String(2000), nullable=False)
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    revoked_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=_utc_now,
+        server_default=db.func.now(),
+    )
+    created_by = db.Column(db.String(255), nullable=False)
+
+    service_account = db.relationship(
+        "ServiceAccount",
+        backref=db.backref(
+            "api_keys",
+            lazy="dynamic",
+            cascade="all, delete-orphan",
+        ),
+    )
+
+    def set_scopes(self, scopes: Iterable[str]) -> None:
+        normalized: List[str] = []
+        seen = set()
+        for scope in scopes:
+            if not scope:
+                continue
+            if scope in seen:
+                continue
+            normalized.append(scope)
+            seen.add(scope)
+        self.scope_names = " ".join(normalized)
+
+    @property
+    def scopes(self) -> List[str]:
+        if not self.scope_names:
+            return []
+        return [
+            scope
+            for scope in (part.strip() for part in self.scope_names.split(" "))
+            if scope
+        ]
+
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    def is_expired(self, reference: datetime | None = None) -> bool:
+        if not self.expires_at:
+            return False
+        reference = reference or _utc_now()
+        return self.expires_at <= reference
+
+    def verify_secret(self, secret: str) -> bool:
+        if not secret:
+            return False
+        return check_password_hash(self.secret_hash, secret)
+
+    def as_dict(self) -> dict:
+        return {
+            "api_key_id": self.api_key_id,
+            "service_account_id": self.service_account_id,
+            "public_id": self.public_id,
+            "scopes": " ".join(self.scopes),
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_by": self.created_by,
+        }
+
+
+class ServiceAccountApiKeyLog(db.Model):
+    __tablename__ = "service_account_api_key_log"
+
+    log_id = db.Column(BigInt, primary_key=True, autoincrement=True)
+    api_key_id = db.Column(
+        BigInt,
+        db.ForeignKey("service_account_api_key.api_key_id"),
+        nullable=False,
+        index=True,
+    )
+    accessed_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=_utc_now,
+        server_default=db.func.now(),
+    )
+    ip_address = db.Column(db.String(64), nullable=True)
+    endpoint = db.Column(db.String(255), nullable=True)
+    user_agent = db.Column(db.String(255), nullable=True)
+
+    api_key = db.relationship(
+        "ServiceAccountApiKey",
+        backref=db.backref(
+            "access_logs",
+            lazy="dynamic",
+            cascade="all, delete-orphan",
+        ),
+    )
+
+    def as_dict(self) -> dict:
+        return {
+            "log_id": self.log_id,
+            "api_key_id": self.api_key_id,
+            "accessed_at": self.accessed_at.isoformat() if self.accessed_at else None,
+            "ip_address": self.ip_address,
+            "endpoint": self.endpoint,
+            "user_agent": self.user_agent,
+        }
+
+
+__all__ = [
+    "ServiceAccountApiKey",
+    "ServiceAccountApiKeyLog",
+]

--- a/migrations/versions/e6f1b2c3d4a5_add_service_account_api_keys.py
+++ b/migrations/versions/e6f1b2c3d4a5_add_service_account_api_keys.py
@@ -1,0 +1,87 @@
+"""Add service account API key management tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e6f1b2c3d4a5"
+down_revision = "c2f4b18f1f6b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    timestamp = sa.DateTime(timezone=True).with_variant(
+        sa.DateTime(timezone=True, fsp=6), "mysql"
+    )
+    bigint = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
+
+    op.create_table(
+        "service_account_api_key",
+        sa.Column("api_key_id", bigint, autoincrement=True, nullable=False),
+        sa.Column("service_account_id", bigint, nullable=False),
+        sa.Column("public_id", sa.String(length=32), nullable=False),
+        sa.Column("secret_hash", sa.String(length=255), nullable=False),
+        sa.Column("scope_names", sa.String(length=2000), nullable=False),
+        sa.Column("expires_at", timestamp, nullable=True),
+        sa.Column("revoked_at", timestamp, nullable=True),
+        sa.Column(
+            "created_at",
+            timestamp,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["service_account_id"],
+            ["service_account.service_account_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("api_key_id"),
+        sa.UniqueConstraint("public_id", name="uq_service_account_api_key_public_id"),
+    )
+    op.create_index(
+        "ix_service_account_api_key_service_account_id",
+        "service_account_api_key",
+        ["service_account_id"],
+    )
+
+    op.create_table(
+        "service_account_api_key_log",
+        sa.Column("log_id", bigint, autoincrement=True, nullable=False),
+        sa.Column("api_key_id", bigint, nullable=False),
+        sa.Column(
+            "accessed_at",
+            timestamp,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("ip_address", sa.String(length=64), nullable=True),
+        sa.Column("endpoint", sa.String(length=255), nullable=True),
+        sa.Column("user_agent", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["api_key_id"],
+            ["service_account_api_key.api_key_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("log_id"),
+    )
+    op.create_index(
+        "ix_service_account_api_key_log_api_key_id",
+        "service_account_api_key_log",
+        ["api_key_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_service_account_api_key_log_api_key_id",
+        table_name="service_account_api_key_log",
+    )
+    op.drop_table("service_account_api_key_log")
+    op.drop_index(
+        "ix_service_account_api_key_service_account_id",
+        table_name="service_account_api_key",
+    )
+    op.drop_table("service_account_api_key")

--- a/tests/test_service_account_api_keys.py
+++ b/tests/test_service_account_api_keys.py
@@ -1,0 +1,117 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from flask import jsonify, g
+
+from core.models.service_account_api_key import ServiceAccountApiKeyLog
+from webapp.auth.api_key_auth import require_api_key_scopes
+from webapp.services.service_account_api_key_service import (
+    ServiceAccountApiKeyService,
+    ServiceAccountApiKeyValidationError,
+)
+from webapp.services.service_account_service import ServiceAccountService
+
+
+def _create_service_account(scopes: str) -> int:
+    normalized = [scope.strip() for scope in scopes.replace(",", " ").split(" ") if scope.strip()]
+    account = ServiceAccountService.create_account(
+        name="media-bot",
+        description="Media automation",
+        jwt_endpoint="https://example.com/jwks/media",
+        scope_names=",".join(normalized),
+        active=True,
+        allowed_scopes=normalized,
+    )
+    return account.service_account_id
+
+
+@pytest.mark.usefixtures("app_context")
+def test_api_key_creation_and_listing(app_context):
+    account_id = _create_service_account("media:read media:upload")
+
+    record, api_key_value = ServiceAccountApiKeyService.create_key(
+        account_id,
+        scopes="media:read",
+        expires_at=None,
+        created_by="admin@example.com",
+    )
+
+    assert api_key_value.startswith("sa-")
+    assert record.public_id in api_key_value
+
+    keys = ServiceAccountApiKeyService.list_keys(account_id)
+    assert len(keys) == 1
+    assert keys[0].scopes == ["media:read"]
+
+
+@pytest.mark.usefixtures("app_context")
+def test_api_key_scope_validation(app_context):
+    account_id = _create_service_account("media:read")
+
+    with pytest.raises(ServiceAccountApiKeyValidationError):
+        ServiceAccountApiKeyService.create_key(
+            account_id,
+            scopes="media:write",
+            expires_at=None,
+            created_by="admin@example.com",
+        )
+
+
+@pytest.mark.usefixtures("app_context")
+def test_api_key_expiration_validation(app_context):
+    account_id = _create_service_account("media:read")
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+
+    with pytest.raises(ServiceAccountApiKeyValidationError):
+        ServiceAccountApiKeyService.create_key(
+            account_id,
+            scopes="media:read",
+            expires_at=past,
+            created_by="admin@example.com",
+        )
+
+
+@pytest.mark.usefixtures("app_context")
+def test_api_key_authentication_and_logging(app_context):
+    account_id = _create_service_account("maintenance:read")
+    record, api_key_value = ServiceAccountApiKeyService.create_key(
+        account_id,
+        scopes="maintenance:read",
+        expires_at=None,
+        created_by="admin@example.com",
+    )
+
+    app = app_context
+
+    @app.route("/api/test/protected")
+    @require_api_key_scopes(["maintenance:read"])
+    def protected_endpoint():
+        return jsonify({"service_account": g.service_account.name})
+
+    client = app.test_client()
+
+    response = client.get(
+        "/api/test/protected",
+        headers={"Authorization": f"ApiKey {api_key_value}"},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["service_account"] == "media-bot"
+
+    logs = ServiceAccountApiKeyLog.query.all()
+    assert len(logs) == 1
+    assert logs[0].api_key_id == record.api_key_id
+    assert logs[0].endpoint == "/api/test/protected"
+
+    ServiceAccountApiKeyService.revoke_key(
+        account_id, record.api_key_id, actor="admin@example.com"
+    )
+
+    response = client.get(
+        "/api/test/protected",
+        headers={"Authorization": f"ApiKey {api_key_value}"},
+    )
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Revoked"
+
+    logs = ServiceAccountApiKeyLog.query.all()
+    assert len(logs) == 1

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -9,6 +9,7 @@ from . import openapi  # noqa
 from . import version  # noqa
 from . import upload  # noqa
 from . import maintenance  # noqa
+from . import service_account_keys  # noqa
 
 # picker_session Blueprintをapi Blueprintに登録
 from .picker_session import bp as picker_session_bp

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -1,0 +1,130 @@
+"""REST endpoints for managing service account API keys."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from flask import jsonify, request
+from flask_login import current_user, login_required
+
+from . import bp
+from webapp.services.service_account_api_key_service import (
+    ServiceAccountApiKeyNotFoundError,
+    ServiceAccountApiKeyService,
+    ServiceAccountApiKeyValidationError,
+)
+
+
+def _parse_iso_datetime(raw: Any) -> datetime | None:
+    if raw in (None, ""):
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("expires_at must be a string in ISO 8601 format")
+
+    value = raw.strip()
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _ensure_permission():
+    if not current_user.is_authenticated:
+        return False
+    return current_user.can("service_account:manage")
+
+
+@bp.route("/service_accounts/<int:account_id>/keys", methods=["GET"])
+@login_required
+def list_service_account_keys(account_id: int):
+    if not _ensure_permission():
+        return jsonify({"error": "forbidden"}), 403
+
+    try:
+        keys = ServiceAccountApiKeyService.list_keys(account_id)
+    except ServiceAccountApiKeyValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+    except ServiceAccountApiKeyNotFoundError:
+        return jsonify({"error": "not_found"}), 404
+
+    return jsonify({"items": [key.as_dict() for key in keys]})
+
+
+@bp.route("/service_accounts/<int:account_id>/keys", methods=["POST"])
+@login_required
+def create_service_account_key(account_id: int):
+    if not _ensure_permission():
+        return jsonify({"error": "forbidden"}), 403
+
+    payload = request.get_json(silent=True) or {}
+    expires_at_raw = payload.get("expires_at")
+    try:
+        expires_at = _parse_iso_datetime(expires_at_raw)
+    except ValueError as exc:
+        return jsonify({"error": str(exc), "field": "expires_at"}), 400
+
+    try:
+        record, api_key_value = ServiceAccountApiKeyService.create_key(
+            account_id,
+            scopes=payload.get("scopes", ""),
+            expires_at=expires_at,
+            created_by=current_user.email,
+        )
+    except ServiceAccountApiKeyValidationError as exc:
+        response = {"error": exc.message}
+        if exc.field:
+            response["field"] = exc.field
+        return jsonify(response), 400
+    except ServiceAccountApiKeyNotFoundError:
+        return jsonify({"error": "not_found"}), 404
+
+    result = record.as_dict()
+    result["api_key"] = api_key_value
+    return jsonify({"item": result}), 201
+
+
+@bp.route(
+    "/service_accounts/<int:account_id>/keys/<int:key_id>/revoke",
+    methods=["POST"],
+)
+@login_required
+def revoke_service_account_key(account_id: int, key_id: int):
+    if not _ensure_permission():
+        return jsonify({"error": "forbidden"}), 403
+
+    try:
+        key = ServiceAccountApiKeyService.revoke_key(
+            account_id, key_id, actor=current_user.email
+        )
+    except ServiceAccountApiKeyNotFoundError:
+        return jsonify({"error": "not_found"}), 404
+    except ServiceAccountApiKeyValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+
+    return jsonify({"item": key.as_dict()})
+
+
+@bp.route("/service_accounts/<int:account_id>/keys/logs", methods=["GET"])
+@login_required
+def list_service_account_key_logs(account_id: int):
+    if not _ensure_permission():
+        return jsonify({"error": "forbidden"}), 403
+
+    key_id = request.args.get("key_id", type=int)
+    limit = request.args.get("limit", type=int)
+
+    try:
+        logs = ServiceAccountApiKeyService.list_logs(
+            account_id, key_id=key_id, limit=limit
+        )
+    except ServiceAccountApiKeyValidationError as exc:
+        return jsonify({"error": exc.message}), 400
+    except ServiceAccountApiKeyNotFoundError:
+        return jsonify({"error": "not_found"}), 404
+
+    return jsonify({"items": [log.as_dict() for log in logs]})

--- a/webapp/auth/api_key_auth.py
+++ b/webapp/auth/api_key_auth.py
@@ -1,0 +1,153 @@
+"""Authentication helpers for API key based service account access."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+from flask import current_app, g, request
+
+from core.models.service_account import ServiceAccount
+from core.models.service_account_api_key import ServiceAccountApiKey
+from webapp.services.service_account_api_key_service import (
+    ServiceAccountApiKeyService,
+)
+
+
+@dataclass
+class ApiKeyAuthError(Exception):
+    code: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass repr is enough
+        return self.message
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _extract_api_key_token() -> str:
+    header = request.headers.get("Authorization", "")
+    if not header:
+        raise ApiKeyAuthError("MissingAuthorization", "The Authorization header is missing.")
+    if not header.startswith("ApiKey "):
+        raise ApiKeyAuthError("InvalidAuthorization", "The Authorization header is not an API key.")
+    token = header.split(" ", 1)[1].strip()
+    if not token:
+        raise ApiKeyAuthError("InvalidAuthorization", "The API key value is empty.")
+    return token
+
+
+class ServiceAccountApiKeyAuthenticator:
+    """Validate API key tokens issued for service accounts."""
+
+    @staticmethod
+    def _select_key(token: str) -> ServiceAccountApiKey:
+        parts = token.split("-", 2)
+        if len(parts) != 3 or parts[0] != "sa":
+            raise ApiKeyAuthError("InvalidFormat", "The API key format is invalid.")
+
+        public_id, secret = parts[1], parts[2]
+        if not public_id or not secret:
+            raise ApiKeyAuthError("InvalidFormat", "The API key is incomplete.")
+
+        key = ServiceAccountApiKey.query.filter_by(public_id=public_id).first()
+        if not key:
+            raise ApiKeyAuthError("UnknownKey", "The API key is not recognized.")
+
+        if not key.verify_secret(secret):
+            raise ApiKeyAuthError("InvalidSecret", "The API key secret is invalid.")
+
+        return key
+
+    @classmethod
+    def authenticate(
+        cls,
+        token: str,
+        *,
+        required_scopes: Iterable[str] | None = None,
+    ) -> tuple[ServiceAccountApiKey, ServiceAccount]:
+        key = cls._select_key(token)
+        account = key.service_account
+
+        if not account or not account.active_flg:
+            raise ApiKeyAuthError("DisabledAccount", "The service account is disabled.")
+
+        if key.is_revoked():
+            raise ApiKeyAuthError("Revoked", "The API key has been revoked.")
+
+        if key.is_expired(_utc_now()):
+            raise ApiKeyAuthError("Expired", "The API key has expired.")
+
+        if required_scopes:
+            scopes = set(scope for scope in required_scopes if scope)
+            if scopes and not scopes.issubset(set(key.scopes)):
+                raise ApiKeyAuthError(
+                    "InsufficientScope",
+                    "The API key does not include the required scopes.",
+                )
+
+        return key, account
+
+
+def require_api_key_scopes(scopes: Sequence[str] | None):
+    """Decorator to require API key authentication with optional scope enforcement."""
+
+    def decorator(func):
+        from functools import wraps
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                token = _extract_api_key_token()
+                key, account = ServiceAccountApiKeyAuthenticator.authenticate(
+                    token, required_scopes=scopes
+                )
+            except ApiKeyAuthError as exc:
+                current_app.logger.info(
+                    "API key authentication failed.",
+                    extra={
+                        "event": "service_account_api_key.auth_failed",
+                        "code": exc.code,
+                        "error_message": exc.message,
+                        "endpoint": request.path,
+                    },
+                )
+                status = 403 if exc.code == "InsufficientScope" else 401
+                response = {"error": exc.code, "message": exc.message}
+                return response, status
+
+            g.service_account = account
+            g.service_account_api_key = key
+
+            current_app.logger.debug(
+                "API key authentication success.",
+                extra={
+                    "event": "service_account_api_key.auth_success",
+                    "service_account": account.name,
+                    "api_key_id": key.api_key_id,
+                    "endpoint": request.path,
+                    "scopes": list(scopes or []),
+                },
+            )
+
+            ServiceAccountApiKeyService.record_usage(
+                key,
+                ip_address=request.remote_addr,
+                endpoint=request.path,
+                user_agent=request.headers.get("User-Agent"),
+            )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = [
+    "ServiceAccountApiKeyAuthenticator",
+    "ApiKeyAuthError",
+    "require_api_key_scopes",
+]

--- a/webapp/services/service_account_api_key_service.py
+++ b/webapp/services/service_account_api_key_service.py
@@ -1,0 +1,229 @@
+"""Service layer for managing service account API keys."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Sequence
+import secrets
+
+from flask import current_app
+from werkzeug.security import generate_password_hash
+
+from core.db import db
+from core.models.service_account import ServiceAccount
+from core.models.service_account_api_key import (
+    ServiceAccountApiKey,
+    ServiceAccountApiKeyLog,
+)
+
+
+@dataclass
+class ServiceAccountApiKeyValidationError(Exception):
+    message: str
+    field: str | None = None
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass repr is enough
+        return self.message
+
+
+class ServiceAccountApiKeyNotFoundError(Exception):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ServiceAccountApiKeyService:
+    @staticmethod
+    def _normalize_scopes(scopes: str | Sequence[str]) -> list[str]:
+        if isinstance(scopes, str):
+            raw = [part.strip() for part in scopes.replace(",", " ").split(" ")]
+        else:
+            raw = [str(part).strip() for part in scopes]
+
+        normalized: list[str] = []
+        seen = set()
+        for scope in raw:
+            if not scope:
+                continue
+            if scope in seen:
+                continue
+            normalized.append(scope)
+            seen.add(scope)
+        return normalized
+
+    @staticmethod
+    def _ensure_account(account_id: int) -> ServiceAccount:
+        account = db.session.get(ServiceAccount, account_id)
+        if not account:
+            raise ServiceAccountApiKeyNotFoundError()
+        if not account.active_flg:
+            raise ServiceAccountApiKeyValidationError(
+                "The service account is disabled.",
+                field=None,
+            )
+        return account
+
+    @classmethod
+    def create_key(
+        cls,
+        account_id: int,
+        *,
+        scopes: str | Sequence[str],
+        expires_at: datetime | None,
+        created_by: str,
+    ) -> tuple[ServiceAccountApiKey, str]:
+        account = cls._ensure_account(account_id)
+        normalized_scopes = cls._normalize_scopes(scopes)
+        if not normalized_scopes:
+            raise ServiceAccountApiKeyValidationError(
+                "At least one scope must be specified.", field="scopes"
+            )
+
+        allowed_scopes = set(account.scopes)
+        requested_set = set(normalized_scopes)
+        if not requested_set.issubset(allowed_scopes):
+            raise ServiceAccountApiKeyValidationError(
+                "The requested scopes are not permitted for this service account.",
+                field="scopes",
+            )
+
+        if expires_at and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at and expires_at <= _utc_now():
+            raise ServiceAccountApiKeyValidationError(
+                "The expiration time must be in the future.", field="expires_at"
+            )
+
+        if not created_by:
+            raise ServiceAccountApiKeyValidationError(
+                "The creator must be specified.", field="created_by"
+            )
+
+        # Generate a unique public identifier for the key
+        public_id = None
+        for _ in range(5):
+            candidate = secrets.token_hex(8)
+            existing = ServiceAccountApiKey.query.filter_by(public_id=candidate).first()
+            if not existing:
+                public_id = candidate
+                break
+        if public_id is None:
+            raise RuntimeError("Failed to allocate a unique API key identifier.")
+
+        secret = secrets.token_hex(24)
+        api_key_value = f"sa-{public_id}-{secret}"
+
+        record = ServiceAccountApiKey(
+            service_account_id=account.service_account_id,
+            public_id=public_id,
+            secret_hash=generate_password_hash(secret),
+            expires_at=expires_at,
+            created_by=created_by,
+        )
+        record.set_scopes(normalized_scopes)
+
+        db.session.add(record)
+        db.session.commit()
+
+        current_app.logger.info(
+            "Service account API key created.",
+            extra={
+                "event": "service_account_api_key.created",
+                "service_account": account.name,
+                "api_key_id": record.api_key_id,
+                "scopes": normalized_scopes,
+                "expires_at": expires_at.isoformat() if expires_at else None,
+                "created_by": created_by,
+            },
+        )
+
+        return record, api_key_value
+
+    @classmethod
+    def list_keys(cls, account_id: int) -> list[ServiceAccountApiKey]:
+        cls._ensure_account(account_id)
+        return (
+            ServiceAccountApiKey.query.filter_by(service_account_id=account_id)
+            .order_by(ServiceAccountApiKey.created_at.desc())
+            .all()
+        )
+
+    @classmethod
+    def revoke_key(
+        cls, account_id: int, key_id: int, *, actor: str | None = None
+    ) -> ServiceAccountApiKey:
+        cls._ensure_account(account_id)
+        key = (
+            ServiceAccountApiKey.query.filter_by(
+                service_account_id=account_id, api_key_id=key_id
+            ).first()
+        )
+        if not key:
+            raise ServiceAccountApiKeyNotFoundError()
+        if key.revoked_at:
+            return key
+
+        key.revoked_at = _utc_now()
+        db.session.commit()
+
+        current_app.logger.info(
+            "Service account API key revoked.",
+            extra={
+                "event": "service_account_api_key.revoked",
+                "service_account_id": account_id,
+                "api_key_id": key_id,
+                "actor": actor,
+            },
+        )
+        return key
+
+    @classmethod
+    def record_usage(
+        cls,
+        api_key: ServiceAccountApiKey,
+        *,
+        ip_address: str | None,
+        endpoint: str | None,
+        user_agent: str | None,
+    ) -> ServiceAccountApiKeyLog:
+        log = ServiceAccountApiKeyLog(
+            api_key_id=api_key.api_key_id,
+            ip_address=ip_address[:64] if ip_address else None,
+            endpoint=endpoint[:255] if endpoint else None,
+            user_agent=user_agent[:255] if user_agent else None,
+        )
+        db.session.add(log)
+        db.session.commit()
+        return log
+
+    @classmethod
+    def list_logs(
+        cls,
+        account_id: int,
+        *,
+        key_id: int | None = None,
+        limit: int | None = 100,
+    ) -> list[ServiceAccountApiKeyLog]:
+        cls._ensure_account(account_id)
+        query = ServiceAccountApiKeyLog.query.join(ServiceAccountApiKey).filter(
+            ServiceAccountApiKey.service_account_id == account_id
+        )
+        if key_id is not None:
+            query = query.filter(ServiceAccountApiKeyLog.api_key_id == key_id)
+
+        query = query.order_by(ServiceAccountApiKeyLog.accessed_at.desc())
+
+        if limit is not None:
+            limit = max(1, min(limit, 500))
+            query = query.limit(limit)
+
+        return query.all()
+
+
+__all__ = [
+    "ServiceAccountApiKeyService",
+    "ServiceAccountApiKeyValidationError",
+    "ServiceAccountApiKeyNotFoundError",
+]


### PR DESCRIPTION
## Summary
- add persistence models and migration for service account API keys and access logs
- implement service layer, API endpoints, and authentication helper for API key issuance, revocation, and auditing
- cover the new behaviour with unit tests for issuance rules, auth, and logging

## Testing
- pytest tests/test_service_account_api_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68f114450c9083239135d9175a2d393b