### PR TITLE
Fix log limit default for service account key logs

### DIFF
--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -116,7 +116,10 @@ def list_service_account_key_logs(account_id: int):
         return jsonify({"error": "forbidden"}), 403
 
     key_id = request.args.get("key_id", type=int)
-    limit = request.args.get("limit", type=int)
+    if "limit" in request.args:
+        limit = request.args.get("limit", type=int)
+    else:
+        limit = 100
 
     try:
         logs = ServiceAccountApiKeyService.list_logs(


### PR DESCRIPTION
## Summary
- ensure the service account key log endpoint defaults to the intended 100 row limit when the client omits the limit query parameter

## Testing
- pytest tests/test_service_account_api_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68f17b6b8eb0832394a4168fc9fd5625