### PR TITLE
Remove legacy service_account_api manage permission alias

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -97,7 +97,6 @@ python scripts/seed_master_data.py
 - `wiki:read` - Wiki読み取り
 - `wiki:write` - Wiki書き込み
 - `service_account:manage` - サービスアカウント管理
-- `service_account_api:manage` - サービスアカウントAPIキー管理
 - `certificate:manage` - 証明書管理
 - `certificate:sign` - 証明書署名
 

--- a/migrations/versions/2f6e4c3b1a2d_remove_service_account_api_manage_permission.py
+++ b/migrations/versions/2f6e4c3b1a2d_remove_service_account_api_manage_permission.py
@@ -1,0 +1,77 @@
+"""Remove legacy service_account_api:manage permission alias."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "2f6e4c3b1a2d"
+down_revision = "7d6e3f2a1b4c"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_CODE = "service_account_api:manage"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+    conn.execute(
+        sa.text("DELETE FROM role_permissions WHERE perm_id = :perm_id"),
+        {"perm_id": perm_id},
+    )
+    conn.execute(
+        sa.text("DELETE FROM permission WHERE id = :perm_id"),
+        {"perm_id": perm_id},
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+    if perm_row is None:
+        conn.execute(
+            sa.text("INSERT INTO permission (code) VALUES (:code)"),
+            {"code": PERMISSION_CODE},
+        )
+        perm_row = conn.execute(
+            sa.text("SELECT id FROM permission WHERE code = :code"),
+            {"code": PERMISSION_CODE},
+        ).first()
+
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+    admin_role = conn.execute(
+        sa.text("SELECT id FROM role WHERE name = 'admin'"),
+    ).first()
+    if not admin_role:
+        return
+
+    admin_role_id = admin_role[0]
+    existing = conn.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions WHERE role_id = :role_id AND perm_id = :perm_id"
+        ),
+        {"role_id": admin_role_id, "perm_id": perm_id},
+    ).first()
+    if existing is None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO role_permissions (role_id, perm_id) VALUES (:role_id, :perm_id)"
+            ),
+            {"role_id": admin_role_id, "perm_id": perm_id},
+        )

--- a/scripts/seed_master_data.py
+++ b/scripts/seed_master_data.py
@@ -59,7 +59,6 @@ def seed_permissions():
         {'id': 19, 'code': 'service_account:manage'},
         {'id': 20, 'code': 'certificate:manage'},
         {'id': 21, 'code': 'certificate:sign'},
-        {'id': 22, 'code': 'service_account_api:manage'},
         {'id': 23, 'code': 'api_key:read'},
         {'id': 24, 'code': 'api_key:manage'},
     ]
@@ -80,7 +79,7 @@ def seed_role_permissions():
         # admin (role_id=1) - all permissions
         (1, 1), (1, 2), (1, 3), (1, 4), (1, 5),
         (1, 6), (1, 7), (1, 8), (1, 9), (1, 10),
-        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18), (1, 19), (1, 20), (1, 21), (1, 22), (1, 23), (1, 24),
+        (1, 11), (1, 12), (1, 13), (1, 14), (1, 15), (1, 16), (1, 17), (1, 18), (1, 19), (1, 20), (1, 21), (1, 23), (1, 24),
         # manager (role_id=2) - limited permissions
         (2, 1), (2, 4), (2, 5), (2, 6), (2, 7), (2, 14), (2, 15), (2, 16),
         # member (role_id=3) - view only

--- a/tests/test_service_account_api_keys.py
+++ b/tests/test_service_account_api_keys.py
@@ -194,11 +194,17 @@ def test_service_account_api_allows_with_read_permission(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_api_allows_with_legacy_permission(app_context):
+def test_service_account_api_rejects_removed_legacy_permission(app_context):
     account_id = _create_service_account("maintenance:read")
     client = app_context.test_client()
     user = _create_user_with_permissions("service_account_api:manage")
     _login(client, user)
 
     response = client.get(f"/api/service_accounts/{account_id}/keys")
-    assert response.status_code == 200
+    assert response.status_code == 403
+
+    response = client.post(
+        f"/api/service_accounts/{account_id}/keys",
+        json={"scopes": ["maintenance:read"]},
+    )
+    assert response.status_code == 403

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -43,9 +43,7 @@ bp = Blueprint("admin", __name__, template_folder="templates")
 def _can_manage_api_keys() -> bool:
     if not hasattr(current_user, "can"):
         return False
-    return current_user.can("api_key:manage") or current_user.can(
-        "service_account_api:manage"
-    )
+    return current_user.can("api_key:manage")
 
 
 def _can_read_api_keys() -> bool:

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -230,7 +230,7 @@
   const countLabel = document.getElementById('service-account-count');
   const availableScopeBadges = document.getElementById('available-scope-badges');
   const apiKeyPageUrlTemplate = {{ url_for('admin.service_account_api_keys', account_id=0)|tojson }};
-  const canAccessApiKeys = {{ (current_user.can('api_key:read') or current_user.can('api_key:manage') or current_user.can('service_account_api:manage') or current_user.can('service_account_api:read'))|tojson }};
+  const canAccessApiKeys = {{ (current_user.can('api_key:read') or current_user.can('api_key:manage') or current_user.can('service_account_api:read'))|tojson }};
   const modalElement = document.getElementById('serviceAccountModal');
   const modal = new bootstrap.Modal(modalElement);
   const detailModal = new bootstrap.Modal(document.getElementById('serviceAccountDetailModal'));

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -36,9 +36,7 @@ def _parse_iso_datetime(raw: Any) -> datetime | None:
 def _has_manage_permission() -> bool:
     if not current_user.is_authenticated:
         return False
-    return current_user.can("api_key:manage") or current_user.can(
-        "service_account_api:manage"
-    )
+    return current_user.can("api_key:manage")
 
 
 def _has_read_permission() -> bool:


### PR DESCRIPTION
## Summary
- drop usage of the deprecated `service_account_api:manage` alias across the API, admin UI, and templates
- remove the alias from seeded master data and documentation
- add a migration that deletes the legacy permission and update tests to ensure it is rejected

## Testing
- pytest tests/test_service_account_api_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68f187d424d88323ac5a67dbcf9e3cf1