### PR TITLE
Fix custom configuration label translation placeholder

### DIFF
--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -132,7 +132,7 @@
                 required
                 data-initial="{{ create_form_values.get('key_preset', '') }}"
                 data-placeholder="{{ _('Select key parameters') }}"
-                data-custom-label="{{ _('Custom configuration (%(details)s)') }}"
+                data-custom-label="{{ _('Custom configuration (%(details)s)', details='%(details)s') }}"
               ></select>
               <input type="hidden" id="key_type" name="key_type" value="{{ create_form_values.get('key_type', '') }}">
               <input type="hidden" id="key_curve" name="key_curve" value="{{ create_form_values.get('key_curve', '') }}">
@@ -235,7 +235,7 @@
                 name="key_preset"
                 required
                 data-placeholder="{{ _('Select key parameters') }}"
-                data-custom-label="{{ _('Custom configuration (%(details)s)') }}"
+                data-custom-label="{{ _('Custom configuration (%(details)s)', details='%(details)s') }}"
               ></select>
               <input type="hidden" id="edit_key_type" name="key_type">
               <input type="hidden" id="edit_key_curve" name="key_curve">


### PR DESCRIPTION
## Summary
- ensure the key preset dropdown translation is formatted with a placeholder value so rendering no longer raises a KeyError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1b9546c108323a83d555194034a2f