### PR TITLE
Fix missing script execution on certificate group pages

### DIFF
--- a/features/certs/presentation/ui/templates/certs/group_detail.html
+++ b/features/certs/presentation/ui/templates/certs/group_detail.html
@@ -197,7 +197,7 @@
   </div>
 </div>
 {% endblock %}
-{% block scripts %}
+{% block extra_scripts %}
 {{ super() }}
 <script>
 (function() {

--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -303,7 +303,7 @@
 </div>
 
 {% endblock %}
-{% block scripts %}
+{% block extra_scripts %}
 {{ super() }}
 <script>
 (function() {


### PR DESCRIPTION
## Summary
- update certificate group templates to use the base template's `extra_scripts` block
- ensure page-specific JavaScript executes for group listing and detail modals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1baf574a48323aecf84b9545902d1