### PR TITLE
Improve certificate group UI messaging and error handling

### DIFF
--- a/features/certs/presentation/ui/templates/certs/group_detail.html
+++ b/features/certs/presentation/ui/templates/certs/group_detail.html
@@ -126,8 +126,8 @@
         <thead>
           <tr>
             <th scope="col">KID</th>
-            <th scope="col">{{ _('Issued At') }}</th>
-            <th scope="col">{{ _('Expires At') }}</th>
+            <th scope="col">{{ _('Issued At') }} <small class="text-muted">UTC</small></th>
+            <th scope="col">{{ _('Expires At') }} <small class="text-muted">UTC</small></th>
             <th scope="col">{{ _('Status') }}</th>
             <th scope="col">{{ _('Revoked At') }}</th>
             <th scope="col">{{ _('Actions') }}</th>

--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -19,7 +19,7 @@
         <th scope="col">{{ _('Rotation Threshold (days)') }}</th>
         <th scope="col">{{ _('Key Type') }}</th>
         <th scope="col">{{ _('Subject') }}</th>
-        <th scope="col">{{ _('Updated At') }}</th>
+        <th scope="col">{{ _('Updated At') }} <small class="text-muted">UTC</small></th>
         <th scope="col" class="text-end">{{ _('Actions') }}</th>
       </tr>
     </thead>
@@ -94,6 +94,16 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
         </div>
         <div class="modal-body">
+          {% set errors = create_form_errors | default([]) %}
+          {% if errors %}
+          <div class="alert alert-danger" role="alert">
+            <ul class="mb-0">
+              {% for message in errors %}
+              <li>{{ message }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label" for="group_code">{{ _('Group Code') }} <span class="text-danger">*</span></label>
@@ -109,6 +119,7 @@
                 autocomplete="off"
                 value="{{ create_form_values.get('group_code', '') }}"
               >
+              <p class="form-text text-muted small mb-0">{{ _('Group code must contain only lowercase letters, numbers, hyphen, or underscore.') }}</p>
             </div>
             <div class="col-md-6">
               <label class="form-label" for="display_name">{{ _('Display Name') }}</label>
@@ -153,7 +164,6 @@
           </div>
           <hr>
           <h3 class="h6 mb-1">{{ _('Subject Template') }}</h3>
-          <p class="text-muted small mb-3">{{ _('Fill in all required subject attributes using ASCII characters. Country code must be a two-letter ISO 3166-1 alpha-2 value (e.g., JP).') }}</p>
           <div class="row g-3">
             {% for oid, field_name, label, required in subject_fields %}
             <div class="col-md-6">
@@ -178,6 +188,7 @@
                 {% if required %}required{% endif %}
                 data-required-message="{{ _('%(label)s is required.', label=label) }}"
               >
+              <div class="form-text text-muted small">{{ _('Fill in all required subject attributes using ASCII characters. Country code must be a two-letter ISO 3166-1 alpha-2 value (e.g., JP).') }}</div>
               {% else %}
               <input
                 class="form-control"
@@ -212,6 +223,16 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
         </div>
         <div class="modal-body">
+          {% set edit_errors = edit_form_errors | default([]) %}
+          {% if edit_errors %}
+          <div class="alert alert-danger" role="alert">
+            <ul class="mb-0">
+              {% for message in edit_errors %}
+              <li>{{ message }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label" for="edit_group_code">{{ _('Group Code') }} <span class="text-danger">*</span></label>
@@ -259,7 +280,6 @@
           </div>
           <hr>
           <h3 class="h6 mb-1">{{ _('Subject Template') }}</h3>
-          <p class="text-muted small mb-3">{{ _('Fill in all required subject attributes using ASCII characters. Country code must be a two-letter ISO 3166-1 alpha-2 value (e.g., JP).') }}</p>
           <div class="row g-3">
             {% for oid, field_name, label, required in subject_fields %}
             <div class="col-md-6">
@@ -283,6 +303,7 @@
                 {% if required %}required{% endif %}
                 data-required-message="{{ _('%(label)s is required.', label=label) }}"
               >
+              <div class="form-text text-muted small">{{ _('Fill in all required subject attributes using ASCII characters. Country code must be a two-letter ISO 3166-1 alpha-2 value (e.g., JP).') }}</div>
               {% else %}
               <input
                 class="form-control"

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -1,7 +1,10 @@
 // Disable submit buttons to prevent multiple submissions and show spinner
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('form').forEach(form => {
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
       const btn = form.querySelector('button[type="submit"]');
       if (btn && !btn.disabled) {
         btn.disabled = true;
@@ -10,6 +13,15 @@ window.addEventListener('DOMContentLoaded', () => {
         spinner.setAttribute('role', 'status');
         spinner.setAttribute('aria-hidden', 'true');
         btn.appendChild(spinner);
+
+        setTimeout(() => {
+          if (event.defaultPrevented) {
+            btn.disabled = false;
+            if (spinner.parentNode === btn) {
+              spinner.remove();
+            }
+          }
+        });
       }
     });
   });


### PR DESCRIPTION
## Summary
- show UTC indicators on certificate tables and move subject template guidance next to the country field
- surface validation errors within the certificate group modals and add explicit group code usage notes
- prevent the submit spinner from persisting when a form submission is cancelled

## Testing
- pytest tests/features/certs *(fails: KeyError: 'message' raised while rendering base.html)*

------
https://chatgpt.com/codex/tasks/task_e_68f1cf982b488323882872f1e9b134a6