### PR TITLE
Fix certificate group custom label translation placeholder

### DIFF
--- a/features/certs/presentation/ui/templates/certs/groups.html
+++ b/features/certs/presentation/ui/templates/certs/groups.html
@@ -135,7 +135,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label" for="key_preset">{{ _('Key Parameters') }} <span class="text-danger">*</span></label>
-              {% set custom_label_template = _('Custom configuration (%(details)s)') %}
+              {% set custom_label_template = _('Custom configuration (%(details)s)', details='%(details)s') %}
               {% set custom_label_fallback = custom_label_template | replace('%(details)s', '-') %}
               <select
                 class="form-select"
@@ -252,7 +252,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label" for="edit_key_preset">{{ _('Key Parameters') }} <span class="text-danger">*</span></label>
-              {% set edit_custom_label_template = _('Custom configuration (%(details)s)') %}
+              {% set edit_custom_label_template = _('Custom configuration (%(details)s)', details='%(details)s') %}
               {% set edit_custom_label_fallback = edit_custom_label_template | replace('%(details)s', '-') %}
               <select
                 class="form-select"


### PR DESCRIPTION
## Summary
- ensure the custom key parameter label strings provide a value for the gettext placeholder
- keep the placeholder token in the template so the JavaScript replacement logic continues to work

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1da9cad28832395c4598395d02ff1