### PR TITLE
Add confirmation before issuing group certificate

### DIFF
--- a/features/certs/presentation/ui/templates/certs/group_detail.html
+++ b/features/certs/presentation/ui/templates/certs/group_detail.html
@@ -57,7 +57,7 @@
 <div class="card mb-4">
   <div class="card-header">{{ _('Issue New Certificate') }}</div>
   <div class="card-body">
-    <form method="post" action="{{ url_for('certs_ui.issue_certificate', group_code=group.group_code) }}" class="row g-3">
+    <form method="post" action="{{ url_for('certs_ui.issue_certificate', group_code=group.group_code) }}" class="row g-3" id="issueCertificateForm">
       <div class="col-md-3">
         <label class="form-label" for="valid_days">{{ _('Validity (days)') }}</label>
         <input type="number" class="form-control" id="valid_days" name="valid_days" min="1" placeholder="{{ group.rotation_threshold_days * 2 }}">
@@ -232,6 +232,16 @@
     form.action = `{{ url_for('certs_ui.revoke_certificate_in_group', group_code=group.group_code, kid='__KID__') }}`.replace('__KID__', encodeURIComponent(kid));
     form.querySelector('#revoke_reason').value = '';
   });
+
+  const issueForm = document.getElementById('issueCertificateForm');
+  if (issueForm) {
+    const confirmMessage = {{ _("Are you sure you want to issue a new certificate for this group?") | tojson }};
+    issueForm.addEventListener('submit', function(event) {
+      if (!window.confirm(confirmMessage)) {
+        event.preventDefault();
+      }
+    });
+  }
 })();
 </script>
 {% endblock %}

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1143,3 +1143,6 @@ msgstr "Specify at least one search condition and submit the form to view result
 
 msgid "Back to Group"
 msgstr "Back to Group"
+
+msgid "Are you sure you want to issue a new certificate for this group?"
+msgstr "Are you sure you want to issue a new certificate for this group?"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -3164,3 +3164,6 @@ msgstr "reasonは文字列で指定してください"
 
 msgid "The certificate does not exist in the specified group."
 msgstr "指定したグループに証明書が存在しません"
+
+msgid "Are you sure you want to issue a new certificate for this group?"
+msgstr "このグループに新しい証明書を発行します。よろしいですか？"


### PR DESCRIPTION
## Summary
- add a confirmation dialog before submitting the issue-certificate form on the group detail page
- provide localized strings for the new confirmation message in English and Japanese

## Testing
- pytest tests/features/certs/test_ui_api_client.py

------
https://chatgpt.com/codex/tasks/task_e_68f1dfa1f99083238f51ed61a3aac21f