### PR TITLE
Align admin tab order

### DIFF
--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -21,11 +21,6 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
-      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
@@ -33,6 +28,11 @@
     </a>
   </li>
   {% endif %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
+      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
+    </a>
+  </li>
   {% endif %}
   {% if current_user.can('role:manage') %}
   <li class="nav-item">

--- a/webapp/admin/templates/admin/google_accounts.html
+++ b/webapp/admin/templates/admin/google_accounts.html
@@ -19,11 +19,6 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
-      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
@@ -31,6 +26,11 @@
     </a>
   </li>
   {% endif %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
+      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
+    </a>
+  </li>
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/permissions.html
+++ b/webapp/admin/templates/admin/permissions.html
@@ -15,11 +15,6 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
-      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
@@ -27,6 +22,11 @@
     </a>
   </li>
   {% endif %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
+      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
+    </a>
+  </li>
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/roles.html
+++ b/webapp/admin/templates/admin/roles.html
@@ -15,11 +15,6 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
-      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
   {% if current_user.can('service_account:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.service_accounts') }}">
@@ -27,6 +22,11 @@
     </a>
   </li>
   {% endif %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.show_config') }}">
+      <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
+    </a>
+  </li>
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -55,17 +55,21 @@
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
   </li>
+  {% endif %}
+  {% if current_user.can('service_account:manage') %}
+  <li class="nav-item">
+    <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% endif %}
+  {% if current_user.can('user:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.show_config') }}">
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
   {% endif %}
-  <li class="nav-item">
-    <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
-      <i class="fas fa-key"></i> {{ _('Service Accounts') }}
-    </a>
-  </li>
   {% if current_user.can('role:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">


### PR DESCRIPTION
## Summary
- reorder the admin management navigation tabs to consistently follow the requested sequence
- ensure the Service Accounts tab is rendered before Config Settings while preserving existing permission guards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1e31232188323a32224dec49a07e6