### PR TITLE
Allow API key managers to reach service account pages

### DIFF
--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -60,15 +60,22 @@ def _can_read_api_keys() -> bool:
 @bp.route("/service-accounts")
 @login_required
 def service_accounts():
-    if not current_user.can("service_account:manage"):
+    can_manage_accounts = current_user.can("service_account:manage")
+    can_access_api_keys = _can_read_api_keys()
+
+    if not (can_manage_accounts or can_access_api_keys):
         return _(u"You do not have permission to access this page."), 403
 
     accounts = [account.as_dict() for account in ServiceAccountService.list_accounts()]
-    available_scopes = sorted(current_user.permissions)
+    available_scopes = (
+        sorted(current_user.permissions) if can_manage_accounts else []
+    )
     return render_template(
         "admin/service_accounts.html",
         accounts=accounts,
         available_scopes=available_scopes,
+        can_manage_accounts=can_manage_accounts,
+        can_access_api_keys=can_access_api_keys,
     )
 
 

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -34,13 +34,27 @@
 {% block content %}
 <div class="d-flex align-items-center justify-content-between mb-4">
   <div>
-    <h1 class="h3 mb-1">{{ _('Service Accounts') }}</h1>
-    <p class="text-muted mb-0">{{ _('Manage machine-to-machine credentials and scopes.') }}</p>
+    <h1 class="h3 mb-1">
+      {% if can_manage_accounts %}
+        {{ _('Service Accounts') }}
+      {% else %}
+        {{ _('API Key Management') }}
+      {% endif %}
+    </h1>
+    <p class="text-muted mb-0">
+      {% if can_manage_accounts %}
+        {{ _('Manage machine-to-machine credentials and scopes.') }}
+      {% else %}
+        {{ _('Select a service account to issue or review API keys.') }}
+      {% endif %}
+    </p>
   </div>
+  {% if can_manage_accounts %}
   <button class="btn btn-primary" id="btn-new-account">
     <i class="bi bi-plus-circle"></i>
     <span>{{ _('New Service Account') }}</span>
   </button>
+  {% endif %}
 </div>
 
 <ul class="nav nav-tabs mb-4">
@@ -60,6 +74,12 @@
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
       <i class="fas fa-key"></i> {{ _('Service Accounts') }}
+    </a>
+  </li>
+  {% elif can_access_api_keys %}
+  <li class="nav-item">
+    <a class="nav-link active" href="{{ url_for('admin.service_accounts') }}">
+      <i class="fas fa-key"></i> {{ _('API Key Management') }}
     </a>
   </li>
   {% endif %}
@@ -110,10 +130,12 @@
   </div>
 </div>
 
+{% if can_manage_accounts %}
 <div class="mt-4">
   <h2 class="h6 text-muted mb-2">{{ _('Available scopes you can assign') }}</h2>
   <div class="d-flex flex-wrap gap-2" id="available-scope-badges"></div>
 </div>
+{% endif %}
 
 <!-- Create / Edit Modal -->
 <div class="modal fade" id="serviceAccountModal" tabindex="-1" aria-hidden="true">
@@ -226,19 +248,22 @@
 (function() {
   const initialAccounts = {{ accounts|tojson }};
   const availableScopes = {{ available_scopes|tojson }};
+  const canManageAccounts = {{ can_manage_accounts|tojson }};
+  const canAccessApiKeys = {{ can_access_api_keys|tojson }};
 
   const tableBody = document.querySelector('#service-account-table tbody');
   const countLabel = document.getElementById('service-account-count');
   const availableScopeBadges = document.getElementById('available-scope-badges');
   const apiKeyPageUrlTemplate = {{ url_for('admin.service_account_api_keys', account_id=0)|tojson }};
-  const canAccessApiKeys = {{ (current_user.can('api_key:read') or current_user.can('api_key:manage') or current_user.can('service_account_api:read'))|tojson }};
   const modalElement = document.getElementById('serviceAccountModal');
-  const modal = new bootstrap.Modal(modalElement);
-  const detailModal = new bootstrap.Modal(document.getElementById('serviceAccountDetailModal'));
+  const modal = modalElement ? new bootstrap.Modal(modalElement) : null;
+  const detailModalElement = document.getElementById('serviceAccountDetailModal');
+  const detailModal = detailModalElement ? new bootstrap.Modal(detailModalElement) : null;
   const form = document.getElementById('service-account-form');
   const errorAlert = document.getElementById('service-account-error');
   const submitButton = document.getElementById('service-account-submit');
   const modalTitle = document.getElementById('serviceAccountModalLabel');
+  const newAccountButton = document.getElementById('btn-new-account');
   const scopeListContainer = document.getElementById('service-account-scope-list');
   const scopeSummaryContainer = document.getElementById('service-account-scope-summary');
   const scopeCountBadge = document.getElementById('service-account-scope-count');
@@ -507,6 +532,9 @@
   }
 
   function renderAvailableScopes() {
+    if (!availableScopeBadges) {
+      return;
+    }
     availableScopeBadges.innerHTML = '';
     if (!availableScopes || !availableScopes.length) {
       availableScopeBadges.innerHTML = `<span class="badge bg-secondary">{{ _('No scopes available') }}</span>`;
@@ -531,6 +559,36 @@
       const scopes = account.scope_names
         ? account.scope_names.split(',').map(scope => `<span class="badge bg-light text-dark me-1">${scope}</span>`).join(' ')
         : '<span class="text-muted">-</span>';
+      const actionButtons = [
+        `<button class="btn btn-outline-primary" data-action="view" data-id="${account.service_account_id}">
+            <i class="bi bi-eye"></i>
+          </button>`,
+      ];
+
+      if (canManageAccounts) {
+        actionButtons.push(`
+          <button class="btn btn-outline-secondary" data-action="edit" data-id="${account.service_account_id}">
+            <i class="bi bi-pencil"></i>
+          </button>
+        `);
+      }
+
+      if (canAccessApiKeys) {
+        actionButtons.push(`
+          <button class="btn btn-outline-dark" data-action="api-keys" data-id="${account.service_account_id}">
+            <i class="bi bi-key"></i>
+          </button>
+        `);
+      }
+
+      if (canManageAccounts) {
+        actionButtons.push(`
+          <button class="btn btn-outline-danger" data-action="delete" data-id="${account.service_account_id}">
+            <i class="bi bi-trash"></i>
+          </button>
+        `);
+      }
+
       tr.innerHTML = `
         <td class="fw-semibold">${account.name}</td>
         <td>${scopes}</td>
@@ -539,27 +597,16 @@
         <td><small>${formatDate(account.mod_dttm)}</small></td>
         <td class="text-end">
           <div class="btn-group btn-group-sm" role="group">
-            <button class="btn btn-outline-primary" data-action="view" data-id="${account.service_account_id}">
-              <i class="bi bi-eye"></i>
-            </button>
-            <button class="btn btn-outline-secondary" data-action="edit" data-id="${account.service_account_id}">
-              <i class="bi bi-pencil"></i>
-            </button>
-            ${canAccessApiKeys ? `
-              <button class="btn btn-outline-dark" data-action="api-keys" data-id="${account.service_account_id}">
-                <i class="bi bi-key"></i>
-              </button>
-            ` : ''}
-            <button class="btn btn-outline-danger" data-action="delete" data-id="${account.service_account_id}">
-              <i class="bi bi-trash"></i>
-            </button>
+            ${actionButtons.join('')}
           </div>
         </td>
       `;
       rows.push(tr);
     });
     rows.forEach(row => tableBody.appendChild(row));
-    countLabel.textContent = '{{ _('Total') }}: ' + state.accounts.length;
+    if (countLabel) {
+      countLabel.textContent = '{{ _('Total') }}: ' + state.accounts.length;
+    }
   }
 
   function resetValidation() {
@@ -577,6 +624,9 @@
   }
 
   function openModal(account) {
+    if (!canManageAccounts || !modal || !submitButton || !modalTitle) {
+      return;
+    }
     resetValidation();
     state.editingId = account ? account.service_account_id : null;
     modalTitle.textContent = account
@@ -611,7 +661,9 @@
     document.getElementById('detail-jwt-endpoint').textContent = account.jwt_endpoint || '';
     document.getElementById('detail-registered').textContent = formatDate(account.reg_dttm);
     document.getElementById('detail-updated').textContent = formatDate(account.mod_dttm);
-    detailModal.show();
+    if (detailModal) {
+      detailModal.show();
+    }
   }
 
   function findAccount(id) {
@@ -633,6 +685,9 @@
 
   async function submitForm(event) {
     event.preventDefault();
+    if (!canManageAccounts) {
+      return;
+    }
     const formData = serializeForm();
     form.classList.add('was-validated');
     if (!form.checkValidity()) {
@@ -682,7 +737,9 @@
         state.accounts.push(item);
       }
       renderTable();
-      modal.hide();
+      if (modal) {
+        modal.hide();
+      }
     } catch (error) {
       errorAlert.textContent = '{{ _('Unexpected error occurred. Please try again.') }}';
       errorAlert.classList.remove('d-none');
@@ -690,6 +747,9 @@
   }
 
   async function deleteAccount(id) {
+    if (!canManageAccounts) {
+      return;
+    }
     if (!confirm('{{ _('Are you sure you want to delete this service account?') }}')) {
       return;
     }
@@ -717,23 +777,32 @@
     if (action === 'view') {
       showDetail(account);
     } else if (action === 'edit') {
+      if (!canManageAccounts) return;
       openModal(account);
-    } else if (action === 'api-keys' && canAccessApiKeys) {
+    } else if (action === 'api-keys') {
+      if (!canAccessApiKeys) return;
       const target = apiKeyPageUrlTemplate.replace('/0/', `/${id}/`);
       window.location.href = target;
     } else if (action === 'delete') {
+      if (!canManageAccounts) return;
       deleteAccount(id);
     }
   });
 
-  document.getElementById('btn-new-account').addEventListener('click', () => openModal(null));
-  form.addEventListener('submit', submitForm);
+  if (newAccountButton) {
+    newAccountButton.addEventListener('click', () => openModal(null));
+  }
+  if (canManageAccounts && form) {
+    form.addEventListener('submit', submitForm);
+  }
 
-  buildScopeOptions();
-  if (scopeSearchInput) {
-    scopeSearchInput.addEventListener('input', (event) => {
-      filterScopes(event.target.value);
-    });
+  if (canManageAccounts) {
+    buildScopeOptions();
+    if (scopeSearchInput) {
+      scopeSearchInput.addEventListener('input', (event) => {
+        filterScopes(event.target.value);
+      });
+    }
   }
 
   renderTable();

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -68,6 +68,7 @@
           {% set show_admin_only = current_user.has_role('admin') %}
           {% set show_user_manage = current_user.can('user:manage') %}
           {% set show_service_accounts = current_user.can('service_account:manage') %}
+          {% set show_api_key_management = current_user.can('api_key:manage') or current_user.can('api_key:read') or current_user.can('service_account_api:read') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
@@ -85,6 +86,8 @@
               {% endif %}
               {% if show_service_accounts %}
               <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
+              {% elif show_api_key_management %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('API Key Management') }}</a></li>
               {% endif %}
               {% if show_user_manage %}
               <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
## Summary
- allow users with API key permissions to open the service account listing and reuse it for API key management
- add an API Key Management entry in the management dropdown for users without full service account permissions
- adjust the service account UI so read-only viewers cannot trigger creation, editing, or deletion actions while still reaching API key tools

## Testing
- pytest tests/test_service_account_api_keys.py


------
https://chatgpt.com/codex/tasks/task_e_68f1e5b922688323bd6745e53ecfadd8