### PR TITLE
Fix service account modal form layout

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -123,8 +123,8 @@
         <h5 class="modal-title" id="serviceAccountModalLabel"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
       </div>
-      <form id="service-account-form" class="needs-validation" novalidate>
-        <div class="modal-body">
+      <div class="modal-body">
+        <form id="service-account-form" class="needs-validation" novalidate>
           <div class="mb-3">
             <label for="service-account-name" class="form-label">{{ _('Account Name') }}</label>
             <input type="text" class="form-control" id="service-account-name" required maxlength="100">
@@ -179,12 +179,12 @@
             <label class="form-check-label" for="service-account-active">{{ _('Enable this account') }}</label>
           </div>
           <div class="alert alert-danger mt-3 d-none" id="service-account-error"></div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
-          <button type="submit" class="btn btn-primary" id="service-account-submit"></button>
-        </div>
-      </form>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
+        <button type="submit" class="btn btn-primary" id="service-account-submit" form="service-account-form"></button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- move the service account form markup inside the modal body to keep the modal scrollable
- keep the footer submit button functional by targeting the relocated form explicitly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1f04aa6208323a75caaa7a0a8b548