### PR TITLE
Remove legacy service account API permission aliases

### DIFF
--- a/tests/test_service_account_api_keys.py
+++ b/tests/test_service_account_api_keys.py
@@ -194,7 +194,24 @@ def test_service_account_api_allows_with_read_permission(app_context):
 
 
 @pytest.mark.usefixtures("app_context")
-def test_service_account_api_rejects_removed_legacy_permission(app_context):
+def test_service_account_api_rejects_removed_legacy_read_permission(app_context):
+    account_id = _create_service_account("maintenance:read")
+    client = app_context.test_client()
+    user = _create_user_with_permissions("service_account_api:read")
+    _login(client, user)
+
+    response = client.get(f"/api/service_accounts/{account_id}/keys")
+    assert response.status_code == 403
+
+    response = client.post(
+        f"/api/service_accounts/{account_id}/keys",
+        json={"scopes": ["maintenance:read"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("app_context")
+def test_service_account_api_rejects_removed_legacy_manage_permission(app_context):
     account_id = _create_service_account("maintenance:read")
     client = app_context.test_client()
     user = _create_user_with_permissions("service_account_api:manage")

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -51,9 +51,7 @@ def _can_read_api_keys() -> bool:
         return False
     if _can_manage_api_keys():
         return True
-    return current_user.can("api_key:read") or current_user.can(
-        "service_account_api:read"
-    )
+    return current_user.can("api_key:read")
 
 
 # サービスアカウント管理

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -44,9 +44,7 @@ def _has_read_permission() -> bool:
         return False
     if _has_manage_permission():
         return True
-    return current_user.can("api_key:read") or current_user.can(
-        "service_account_api:read"
-    )
+    return current_user.can("api_key:read")
 
 
 @bp.route("/service_accounts/<int:account_id>/keys", methods=["GET"])

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -68,7 +68,7 @@
           {% set show_admin_only = current_user.has_role('admin') %}
           {% set show_user_manage = current_user.can('user:manage') %}
           {% set show_service_accounts = current_user.can('service_account:manage') %}
-          {% set show_api_key_management = current_user.can('api_key:manage') or current_user.can('api_key:read') or current_user.can('service_account_api:read') %}
+          {% set show_api_key_management = current_user.can('api_key:manage') or current_user.can('api_key:read') %}
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.profile') }}">
               <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}


### PR DESCRIPTION
## Summary
- remove remaining references to the deprecated `service_account_api:*` permission aliases in the API key management template and views
- add regression coverage to ensure legacy permission aliases no longer grant access to service account API endpoints

## Testing
- pytest tests/test_service_account_api_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68f1fb3c361083238671d91c93f7c00f