### PR TITLE
Improve API key scope selection UX

### DIFF
--- a/webapp/admin/templates/admin/service_account_api_keys.html
+++ b/webapp/admin/templates/admin/service_account_api_keys.html
@@ -15,16 +15,40 @@
   .scope-badge {
     font-size: 0.85rem;
   }
-  #create-api-key-scopes .form-check {
-    padding: 0.75rem;
-    border: 1px solid var(--bs-border-color);
+  #create-api-key-scopes .btn-check + .scope-option {
+    padding: 1rem;
     border-radius: 0.75rem;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    border: 1px solid var(--bs-border-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    box-shadow: 0 0 0 rgba(13, 110, 253, 0);
   }
-  #create-api-key-scopes .form-check:hover {
+  #create-api-key-scopes .scope-option-name {
+    font-weight: 600;
+    word-break: break-all;
+  }
+  #create-api-key-scopes .scope-option-icon {
+    opacity: 0;
+    color: rgba(13, 110, 253, 0.85);
+    transition: opacity 0.2s ease, color 0.2s ease;
+  }
+  #create-api-key-scopes .scope-option:hover {
     border-color: rgba(13, 110, 253, 0.45);
-    box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.1);
+    box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.12);
+  }
+  #create-api-key-scopes .btn-check:checked + .scope-option {
+    background-color: var(--bs-primary);
+    border-color: var(--bs-primary);
+    color: #fff;
+    box-shadow: 0 0.75rem 1.5rem rgba(13, 110, 253, 0.35);
+  }
+  #create-api-key-scopes .btn-check:checked + .scope-option .scope-option-icon {
+    opacity: 1;
+    color: rgba(255, 255, 255, 0.85);
   }
   #revealed-api-key {
     font-family: var(--bs-font-monospace);
@@ -306,6 +330,8 @@
     revokeSuccess: {{ _('API key has been revoked.')|tojson }},
     revokeError: {{ _('Failed to revoke the API key. Please try again.')|tojson }},
     createError: {{ _('Failed to issue the API key. Please review the form and try again.')|tojson }},
+    issueButtonDefault: {{ _('Issue API Key')|tojson }},
+    issueButtonWithCount: {{ _('Issue API Key ({count} selected)')|tojson }},
     emptyScopesHint: {{ _('Assign scopes to the service account before issuing new keys.')|tojson }},
   };
 
@@ -316,6 +342,8 @@
   };
 
   const accountScopes = Array.isArray(account.scopes) ? account.scopes.slice() : [];
+  const buttonIconHtml = '<i class="bi bi-check-circle me-1"></i>';
+  let isSubmitting = false;
 
   const tableBody = document.querySelector('#api-key-table tbody');
   const emptyState = document.getElementById('api-key-empty');
@@ -330,7 +358,6 @@
   const expiresError = document.getElementById('create-api-key-expires-error');
   const createError = document.getElementById('create-api-key-error');
   const createSubmit = document.getElementById('create-api-key-submit');
-  const createSubmitDefaultHtml = createSubmit ? createSubmit.innerHTML : '';
   const expirationInput = document.getElementById('api-key-expires-at');
   const clearExpirationButton = document.getElementById('btn-clear-expiration');
   const revealModalElement = document.getElementById('revealApiKeyModal');
@@ -484,6 +511,7 @@
         checkbox.checked = false;
       });
     }
+    updateSubmitState();
   }
 
   function buildScopeOptions() {
@@ -495,13 +523,14 @@
       message.className = 'alert alert-light border';
       message.textContent = text.noScopesAvailable;
       scopeContainer.appendChild(message);
-      createSubmit?.classList.add('disabled');
-      createSubmit?.setAttribute('disabled', 'disabled');
+      if (createSubmit) {
+        createSubmit.disabled = true;
+        createSubmit.classList.add('disabled');
+        createSubmit.setAttribute('disabled', 'disabled');
+        createSubmit.innerHTML = `${buttonIconHtml}${text.issueButtonDefault}`;
+      }
       return;
     }
-
-    createSubmit?.classList.remove('disabled');
-    createSubmit?.removeAttribute('disabled');
 
     const fragment = document.createDocumentFragment();
 
@@ -509,15 +538,17 @@
       const col = document.createElement('div');
       col.className = 'col-12 col-md-6';
       col.innerHTML = `
-        <label class="form-check" for="api-key-scope-${index}">
-          <input class="form-check-input me-2" type="checkbox" value="${scope}" id="api-key-scope-${index}">
-          <span class="form-check-label fw-semibold">${scope}</span>
+        <input class="btn-check" type="checkbox" value="${scope}" id="api-key-scope-${index}" autocomplete="off">
+        <label class="btn btn-outline-primary scope-option w-100 text-start" for="api-key-scope-${index}">
+          <span class="scope-option-name">${scope}</span>
+          <span class="scope-option-icon"><i class="bi bi-check-circle-fill"></i></span>
         </label>
       `;
       fragment.appendChild(col);
     });
 
     scopeContainer.appendChild(fragment);
+    updateSubmitState();
   }
 
   function collectSelectedScopes() {
@@ -525,6 +556,24 @@
     return Array.from(scopeContainer.querySelectorAll('input[type="checkbox"]:checked'))
       .map((checkbox) => checkbox.value)
       .filter(Boolean);
+  }
+
+  function updateSubmitState() {
+    if (!createSubmit || isSubmitting) return;
+    const selectedCount = collectSelectedScopes().length;
+    if (!selectedCount) {
+      createSubmit.disabled = true;
+      createSubmit.classList.add('disabled');
+      createSubmit.setAttribute('disabled', 'disabled');
+      createSubmit.innerHTML = `${buttonIconHtml}${text.issueButtonDefault}`;
+      return;
+    }
+
+    createSubmit.disabled = false;
+    createSubmit.classList.remove('disabled');
+    createSubmit.removeAttribute('disabled');
+    const buttonLabel = text.issueButtonWithCount.replace('{count}', selectedCount);
+    createSubmit.innerHTML = `${buttonIconHtml}${buttonLabel}`;
   }
 
   function toIsoString(value) {
@@ -577,6 +626,7 @@
       return;
     }
 
+    isSubmitting = true;
     createSubmit.disabled = true;
     createSubmit.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>{{ _('Issuing...') }}';
 
@@ -623,8 +673,9 @@
         createError.classList.remove('d-none');
       }
     } finally {
+      isSubmitting = false;
       createSubmit.disabled = false;
-      createSubmit.innerHTML = createSubmitDefaultHtml || '<i class="bi bi-check-circle me-1"></i>{{ _('Issue API Key') }}';
+      updateSubmitState();
     }
   }
 
@@ -758,6 +809,16 @@
 
   if (createForm) {
     createForm.addEventListener('submit', submitCreateForm);
+  }
+
+  if (scopeContainer) {
+    scopeContainer.addEventListener('change', () => {
+      if (scopeError && collectSelectedScopes().length) {
+        scopeError.classList.add('d-none');
+        scopeError.classList.remove('d-block');
+      }
+      updateSubmitState();
+    });
   }
 
   if (clearExpirationButton && expirationInput) {


### PR DESCRIPTION
## Summary
- restyle the scope picker in the Issue API Key modal to use button-style cards instead of plain checkboxes
- disable the submit button until at least one scope is selected and show the number of selected scopes for clarity

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1fccf25fc8323be1325b1a9bec5bb