### PR TITLE
Make organization optional when creating certificate groups

### DIFF
--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -43,7 +43,7 @@ _SUBJECT_FIELD_DEFINITIONS: list[tuple[str, str, str, bool]] = [
     ("C", "subject_c", _("Country (C)"), True),
     ("ST", "subject_st", _("State or Province (ST)"), False),
     ("L", "subject_l", _("Locality (L)"), False),
-    ("O", "subject_o", _("Organization (O)"), True),
+    ("O", "subject_o", _("Organization (O)"), False),
     ("OU", "subject_ou", _("Organizational Unit (OU)"), False),
     ("CN", "subject_cn", _("Common Name (CN)"), True),
     ("emailAddress", "subject_email", _("Email Address"), False),


### PR DESCRIPTION
## Summary
- make the Organization (O) subject attribute optional in the certificate group UI so the field is no longer required when creating or editing groups

## Testing
- pytest tests/features/certs


------
https://chatgpt.com/codex/tasks/task_e_68f25ace765c8323be3b8aee37a16ed5