### PR TITLE
Preserve next redirect after role selection

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -32,6 +32,9 @@
     </div>
     
     <form method="post" class="login-form" id="loginForm">
+      {% if next_value %}
+      <input type="hidden" name="next" value="{{ next_value }}">
+      {% endif %}
       <div class="form-group">
         <label for="email" class="form-label">
           <i class="fas fa-envelope"></i>


### PR DESCRIPTION
## Summary
- ensure the login view keeps a validated `next` parameter available when rendering the form
- add a hidden field in the login template so the browser posts the `next` redirect target
- cover the regression with a role-selection test that asserts the redirect after choosing a role

## Testing
- pytest tests/test_auth_role_selection.py

------
https://chatgpt.com/codex/tasks/task_e_68f25b5536b0832382884fe2a053dc37