### PR TITLE
Show key usage in certificate details

### DIFF
--- a/features/certs/presentation/ui/api_client.py
+++ b/features/certs/presentation/ui/api_client.py
@@ -65,6 +65,7 @@ class CertificateSummary:
     group_code: str | None
     auto_rotated_from_kid: str | None
     key_usage: list[str] = field(default_factory=list, init=False)
+    extended_key_usage: list[str] = field(default_factory=list, init=False)
 
     @property
     def is_revoked(self) -> bool:
@@ -509,6 +510,11 @@ class CertsApiClient:
             key_usage = [str(item) for item in raw_key_usage if item]
         else:
             key_usage = []
+        raw_extended_key_usage = payload.get("extendedKeyUsage")
+        if isinstance(raw_extended_key_usage, (list, tuple)):
+            extended_key_usage = [str(item) for item in raw_extended_key_usage if item]
+        else:
+            extended_key_usage = []
         summary = CertificateSummary(
             kid=str(payload.get("kid", "")),
             usage_type=_parse_usage(payload.get("usageType")),
@@ -521,6 +527,7 @@ class CertsApiClient:
             auto_rotated_from_kid=payload.get("autoRotatedFromKid"),
         )
         summary.key_usage = key_usage
+        summary.extended_key_usage = extended_key_usage
         return summary
 
     def _parse_detail(self, payload: dict[str, Any]) -> CertificateDetail:
@@ -542,6 +549,7 @@ class CertsApiClient:
             not_after=_parse_datetime(payload.get("notAfter")),
         )
         detail.key_usage = list(summary.key_usage)
+        detail.extended_key_usage = list(summary.extended_key_usage)
         return detail
 
     def _parse_group(self, payload: dict[str, Any]) -> CertificateGroupData:

--- a/features/certs/presentation/ui/routes.py
+++ b/features/certs/presentation/ui/routes.py
@@ -39,6 +39,19 @@ _KEY_USAGE_CHOICES: list[tuple[str, str]] = [
     ("decipherOnly", _("decipherOnly - decipher only")),
 ]
 
+_EXTENDED_KEY_USAGE_CHOICES: list[tuple[str, str]] = [
+    ("serverAuth", _("serverAuth - TLS WWW server authentication")),
+    ("clientAuth", _("clientAuth - TLS WWW client authentication")),
+    ("codeSigning", _("codeSigning - Code signing")),
+    ("emailProtection", _("emailProtection - E-mail protection")),
+    ("timeStamping", _("timeStamping - Time stamping")),
+    ("ocspSigning", _("ocspSigning - OCSP signing")),
+    ("ipsecEndSystem", _("ipsecEndSystem - IPsec end system")),
+    ("ipsecTunnel", _("ipsecTunnel - IPsec tunnel")),
+    ("ipsecUser", _("ipsecUser - IPsec user")),
+    ("anyExtendedKeyUsage", _("anyExtendedKeyUsage - Any extended key usage")),
+]
+
 _SUBJECT_FIELD_DEFINITIONS: list[tuple[str, str, str, bool]] = [
     ("C", "subject_c", _("Country (C)"), True),
     ("ST", "subject_st", _("State or Province (ST)"), False),
@@ -713,6 +726,7 @@ def detail(kid: str):
         "issuer": certificate.issuer,
         "jwk_json": json.dumps(certificate.jwk, indent=2, ensure_ascii=False),
         "key_usage_labels": dict(_KEY_USAGE_CHOICES),
+        "extended_key_usage_labels": dict(_EXTENDED_KEY_USAGE_CHOICES),
     }
     return render_template("certs/detail.html", **detail_context)
 

--- a/features/certs/presentation/ui/templates/certs/detail.html
+++ b/features/certs/presentation/ui/templates/certs/detail.html
@@ -62,6 +62,20 @@
             <span class="text-muted">-</span>
             {% endif %}
           </dd>
+          <dt class="col-sm-4">{{ _('Extended Key Usage') }}</dt>
+          <dd class="col-sm-8">
+            {% if certificate.extended_key_usage %}
+            <ul class="list-inline mb-0">
+              {% for usage in certificate.extended_key_usage %}
+              <li class="list-inline-item">
+                <span class="badge text-bg-light">{{ extended_key_usage_labels.get(usage, usage) }}</span>
+              </li>
+              {% endfor %}
+            </ul>
+            {% else %}
+            <span class="text-muted">-</span>
+            {% endif %}
+          </dd>
           <dt class="col-sm-4">{{ _('Validity Period') }}</dt>
           <dd class="col-sm-8">{{ not_before }} {{ _('to') }} {{ not_after }}</dd>
         </dl>

--- a/tests/features/certs/test_api.py
+++ b/tests/features/certs/test_api.py
@@ -205,6 +205,7 @@ def test_generate_sign_and_jwks_flow(app_context):
     assert detail["kid"] == signed["kid"]
     assert detail["certificatePem"].startswith("-----BEGIN CERTIFICATE-----")
     assert detail["keyUsage"] == ["digitalSignature", "keyEncipherment"]
+    assert detail["extendedKeyUsage"] == ["serverAuth"]
 
     revoke_resp = client.post(
         f"/api/certs/{signed['kid']}/revoke",
@@ -215,12 +216,14 @@ def test_generate_sign_and_jwks_flow(app_context):
     assert revoked["revokedAt"] is not None
     assert revoked["revocationReason"] == "compromised"
     assert revoked["keyUsage"] == ["digitalSignature", "keyEncipherment"]
+    assert revoked["extendedKeyUsage"] == ["serverAuth"]
 
     detail_after_resp = client.get(f"/api/certs/{signed['kid']}")
     assert detail_after_resp.status_code == 200
     detail_after = detail_after_resp.get_json()["certificate"]
     assert detail_after["revokedAt"] is not None
     assert detail_after["keyUsage"] == ["digitalSignature", "keyEncipherment"]
+    assert detail_after["extendedKeyUsage"] == ["serverAuth"]
 
     search_resp = client.get("/api/certs/search", query_string={"kid": signed["kid"]})
     assert search_resp.status_code == 200


### PR DESCRIPTION
## Summary
- include keyUsage information in certificate API responses and client parsing
- display selected key usages on the certificate details screen
- extend API tests to cover the new key usage payload

## Testing
- pytest tests/features/certs/test_api.py::test_generate_sign_and_jwks_flow

------
https://chatgpt.com/codex/tasks/task_e_68f25d38f6288323877b870758647511