### PR TITLE
Link service accounts to certificate groups

### DIFF
--- a/core/models/service_account.py
+++ b/core/models/service_account.py
@@ -20,7 +20,9 @@ class ServiceAccount(db.Model):
     service_account_id = db.Column(BigInt, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
     description = db.Column(db.String(255), nullable=True)
-    jwt_endpoint = db.Column(db.String(500), nullable=True)
+    certificate_group_code = db.Column(
+        db.String(64), db.ForeignKey("certificate_groups.group_code"), nullable=True
+    )
     scope_names = db.Column(db.String(1000), nullable=False, default="")
     active_flg = db.Column(db.Boolean, nullable=False, default=True)
     reg_dttm = db.Column(
@@ -63,7 +65,7 @@ class ServiceAccount(db.Model):
             "service_account_id": self.service_account_id,
             "name": self.name,
             "description": self.description,
-            "jwt_endpoint": self.jwt_endpoint,
+            "certificate_group_code": self.certificate_group_code,
             "scope_names": self.scope_names,
             "active_flg": self.active_flg,
             "reg_dttm": self.reg_dttm.isoformat() if self.reg_dttm else None,

--- a/migrations/versions/4f0b8a5d9c12_service_account_use_certificate_groups.py
+++ b/migrations/versions/4f0b8a5d9c12_service_account_use_certificate_groups.py
@@ -1,0 +1,36 @@
+"""Link service accounts to certificate groups."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4f0b8a5d9c12"
+down_revision = "b8c4a5d5630a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("service_account", schema=None) as batch_op:
+        batch_op.drop_column("jwt_endpoint")
+        batch_op.add_column(
+            sa.Column("certificate_group_code", sa.String(length=64), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_service_account_certificate_group",
+            "certificate_groups",
+            ["certificate_group_code"],
+            ["group_code"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("service_account", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_service_account_certificate_group", type_="foreignkey"
+        )
+        batch_op.drop_column("certificate_group_code")
+        batch_op.add_column(sa.Column("jwt_endpoint", sa.String(length=500), nullable=True))

--- a/webapp/admin/templates/admin/service_account_api_keys.html
+++ b/webapp/admin/templates/admin/service_account_api_keys.html
@@ -97,8 +97,19 @@
             </div>
           </div>
           <div class="col-md-6">
-            <span class="text-muted small">{{ _('JWT endpoint URL') }}</span>
-            <div class="mt-1 text-break">{{ account.jwt_endpoint or '-' }}</div>
+            <span class="text-muted small">{{ _('Certificate Group') }}</span>
+            <div class="mt-1 text-break">
+              {% if account.certificate_group_code %}
+                {% if account.certificate_group_display_name %}
+                  <div>{{ account.certificate_group_display_name }}</div>
+                  <div class="text-muted small">{{ account.certificate_group_code }}</div>
+                {% else %}
+                  {{ account.certificate_group_code }}
+                {% endif %}
+              {% else %}
+                -
+              {% endif %}
+            </div>
           </div>
           <div class="col-12">
             <span class="text-muted small">{{ _('Description') }}</span>

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -113,6 +113,7 @@
         <thead class="table-light">
           <tr>
             <th scope="col">{{ _('Name') }}</th>
+            <th scope="col">{{ _('Certificate Group') }}</th>
             <th scope="col">{{ _('Scopes') }}</th>
             <th scope="col">{{ _('Status') }}</th>
             <th scope="col">{{ _('Registered At') }}</th>
@@ -153,10 +154,15 @@
             <textarea class="form-control" id="service-account-description" rows="2" maxlength="255"></textarea>
           </div>
           <div class="mb-3">
-            <label for="service-account-jwt-endpoint" class="form-label">{{ _('JWT endpoint URL') }}</label>
-            <input type="url" class="form-control" id="service-account-jwt-endpoint" required maxlength="500">
-            <div class="form-text">{{ _('Specify the JWKS endpoint used to verify tokens for this service account.') }}</div>
-            <div class="invalid-feedback" data-field="jwt_endpoint"></div>
+            <label for="service-account-certificate-group" class="form-label">{{ _('Certificate Group (client_signing)') }}</label>
+            <select class="form-select" id="service-account-certificate-group" required></select>
+            <div
+              class="form-text"
+              id="service-account-certificate-group-help"
+              data-default-text="{{ _('Choose the certificate group whose keys will verify JWTs for this service account.') }}"
+              data-empty-text="{{ _('No client_signing certificate groups are available. Create one in the certificate management section first.') }}"
+            >{{ _('Choose the certificate group whose keys will verify JWTs for this service account.') }}</div>
+            <div class="invalid-feedback" data-field="certificate_group_code"></div>
           </div>
           <div class="mb-3" data-scope-selection>
             <label class="form-label fw-semibold" for="service-account-scope-search">{{ _('Scopes') }}</label>
@@ -223,8 +229,8 @@
           <dd class="col-sm-9" id="detail-description"></dd>
           <dt class="col-sm-3">{{ _('Scopes') }}</dt>
           <dd class="col-sm-9" id="detail-scopes"></dd>
-          <dt class="col-sm-3">{{ _('JWT endpoint URL') }}</dt>
-          <dd class="col-sm-9" id="detail-jwt-endpoint"></dd>
+          <dt class="col-sm-3">{{ _('Certificate Group') }}</dt>
+          <dd class="col-sm-9" id="detail-certificate-group"></dd>
           <dt class="col-sm-3">{{ _('Registered At') }}</dt>
           <dd class="col-sm-9" id="detail-registered"></dd>
           <dt class="col-sm-3">{{ _('Updated At') }}</dt>
@@ -244,6 +250,7 @@
 (function() {
   const initialAccounts = {{ accounts|tojson }};
   const availableScopes = {{ available_scopes|tojson }};
+  const certificateGroups = {{ certificate_groups|tojson }};
   const canManageAccounts = {{ can_manage_accounts|tojson }};
   const canAccessApiKeys = {{ can_access_api_keys|tojson }};
 
@@ -269,14 +276,79 @@
   const scopeSelectionCard = document.getElementById('service-account-scope-card');
   const noScopesAvailableText = {{ _('You do not have any scopes that can be assigned yet.')|tojson }};
   const lockedScopeNote = {{ _('This scope cannot be modified with your current permissions.')|tojson }};
+  const certificateGroupSelect = document.getElementById('service-account-certificate-group');
+  const certificateGroupHelp = document.getElementById('service-account-certificate-group-help');
+  const certificateGroupPlaceholder = {{ _('Select a certificate group')|tojson }};
 
   const state = {
     accounts: initialAccounts,
     editingId: null,
   };
 
+  const certificateGroupMap = new Map(
+    (certificateGroups || []).map(group => [group.group_code, group])
+  );
+
   const scopeCheckboxes = new Map();
   let scopeOptionCounter = 0;
+
+  function formatCertificateGroup(code) {
+    if (!code) {
+      return '-';
+    }
+    const group = certificateGroupMap.get(code);
+    if (!group) {
+      return code;
+    }
+    if (group.display_name && group.display_name !== group.group_code) {
+      return `${group.display_name} (${group.group_code})`;
+    }
+    return group.group_code;
+  }
+
+  function populateCertificateGroupSelect(selectedCode = '') {
+    if (!certificateGroupSelect) {
+      return;
+    }
+
+    certificateGroupSelect.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = certificateGroupPlaceholder;
+    placeholder.disabled = true;
+    placeholder.selected = !selectedCode;
+    certificateGroupSelect.appendChild(placeholder);
+
+    (certificateGroups || []).forEach((group) => {
+      const option = document.createElement('option');
+      option.value = group.group_code;
+      option.textContent = formatCertificateGroup(group.group_code);
+      option.selected = group.group_code === selectedCode;
+      certificateGroupSelect.appendChild(option);
+    });
+
+    if (selectedCode && !certificateGroupMap.has(selectedCode)) {
+      const fallback = document.createElement('option');
+      fallback.value = selectedCode;
+      fallback.textContent = selectedCode;
+      fallback.selected = true;
+      certificateGroupSelect.appendChild(fallback);
+    }
+
+    const availableCount = (certificateGroups || []).length;
+    certificateGroupSelect.disabled = availableCount === 0;
+
+    if (certificateGroupHelp) {
+      const defaultText = certificateGroupHelp.dataset.defaultText || certificateGroupHelp.textContent;
+      const emptyText = certificateGroupHelp.dataset.emptyText || defaultText;
+      certificateGroupHelp.textContent = availableCount ? defaultText : emptyText;
+    }
+
+    if (newAccountButton) {
+      newAccountButton.disabled = availableCount === 0;
+    }
+  }
 
   function createScopeColumn(scope, { disabled = false, note = '', prepend = false } = {}) {
     if (!scopeListContainer) {
@@ -552,6 +624,7 @@
       const activeBadge = account.active_flg
         ? `<span class="badge bg-success">{{ _('Active') }}</span>`
         : `<span class="badge bg-secondary">{{ _('Disabled') }}</span>`;
+      const certificateGroupLabel = formatCertificateGroup(account.certificate_group_code);
       const scopes = account.scope_names
         ? account.scope_names.split(',').map(scope => `<span class="badge bg-light text-dark me-1">${scope}</span>`).join(' ')
         : '<span class="text-muted">-</span>';
@@ -587,6 +660,7 @@
 
       tr.innerHTML = `
         <td class="fw-semibold">${account.name}</td>
+        <td>${certificateGroupLabel}</td>
         <td>${scopes}</td>
         <td>${activeBadge}</td>
         <td><small>${formatDate(account.reg_dttm)}</small></td>
@@ -632,7 +706,11 @@
 
     document.getElementById('service-account-name').value = account ? account.name : '';
     document.getElementById('service-account-description').value = account?.description || '';
-    document.getElementById('service-account-jwt-endpoint').value = account ? account.jwt_endpoint || '' : '';
+    const selectedGroupCode = account ? account.certificate_group_code || '' : '';
+    populateCertificateGroupSelect(selectedGroupCode);
+    if (certificateGroupSelect) {
+      certificateGroupSelect.value = selectedGroupCode;
+    }
     document.getElementById('service-account-active').checked = account ? account.active_flg : true;
 
     if (scopeSearchInput) {
@@ -654,7 +732,10 @@
     document.getElementById('detail-scopes').innerHTML = account.scope_names
       ? account.scope_names.split(',').map(scope => `<span class="badge bg-secondary me-1">${scope}</span>`).join(' ')
       : '<span class="text-muted">-</span>';
-    document.getElementById('detail-jwt-endpoint').textContent = account.jwt_endpoint || '';
+    const detailGroup = document.getElementById('detail-certificate-group');
+    if (detailGroup) {
+      detailGroup.textContent = formatCertificateGroup(account.certificate_group_code);
+    }
     document.getElementById('detail-registered').textContent = formatDate(account.reg_dttm);
     document.getElementById('detail-updated').textContent = formatDate(account.mod_dttm);
     if (detailModal) {
@@ -670,7 +751,7 @@
     return {
       name: document.getElementById('service-account-name').value.trim(),
       description: document.getElementById('service-account-description').value.trim(),
-      jwt_endpoint: document.getElementById('service-account-jwt-endpoint').value.trim(),
+      certificate_group_code: certificateGroupSelect ? certificateGroupSelect.value : '',
       scope_names: Array.from(scopeCheckboxes.values())
         .filter((checkbox) => checkbox.checked)
         .map((checkbox) => checkbox.value)
@@ -712,7 +793,10 @@
                 feedback.classList.add('d-block');
                 scopeSelectionCard?.classList.add('border-danger', 'border-2');
               } else {
-                feedback.closest('.mb-3')?.querySelector('input,textarea')?.classList.add('is-invalid');
+                feedback
+                  .closest('.mb-3')
+                  ?.querySelector('input,textarea,select')
+                  ?.classList.add('is-invalid');
               }
             }
           } else {
@@ -803,6 +887,7 @@
 
   renderTable();
   renderAvailableScopes();
+  populateCertificateGroupSelect();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace service account JWT endpoint storage with a certificate group reference and validate that only client_signing groups are used
- load JWKS data via the certificate management use cases and update the admin UI/API key screens to select and display certificate groups
- add a migration and refresh the JWT/API key tests to exercise the new certificate group based flow

## Testing
- pytest tests/test_service_account_jwt.py tests/test_service_account_api_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68f26973f56883239b189faf5ed1026e