### PR TITLE
Add migration to ensure service accounts have certificate group column

### DIFF
--- a/migrations/versions/9b1e5f7c8d6e_ensure_service_account_certificate_group.py
+++ b/migrations/versions/9b1e5f7c8d6e_ensure_service_account_certificate_group.py
@@ -1,0 +1,50 @@
+"""Ensure certificate group column exists for service accounts."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9b1e5f7c8d6e"
+down_revision = "2f6e4c3b1a2d"
+branch_labels = None
+depends_on = None
+
+
+def _get_table_state(table_name: str) -> tuple[set[str], set[str]]:
+    """Return column names and foreign key names for the given table."""
+    inspector = sa.inspect(op.get_bind())
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    foreign_keys = {fk["name"] for fk in inspector.get_foreign_keys(table_name)}
+    return columns, foreign_keys
+
+
+def upgrade() -> None:
+    columns, foreign_keys = _get_table_state("service_account")
+
+    with op.batch_alter_table("service_account", schema=None) as batch_op:
+        if "certificate_group_code" not in columns:
+            batch_op.add_column(
+                sa.Column("certificate_group_code", sa.String(length=64), nullable=True)
+            )
+        if "fk_service_account_certificate_group" not in foreign_keys:
+            batch_op.create_foreign_key(
+                "fk_service_account_certificate_group",
+                "certificate_groups",
+                ["certificate_group_code"],
+                ["group_code"],
+                ondelete="SET NULL",
+            )
+
+
+def downgrade() -> None:
+    columns, foreign_keys = _get_table_state("service_account")
+
+    with op.batch_alter_table("service_account", schema=None) as batch_op:
+        if "fk_service_account_certificate_group" in foreign_keys:
+            batch_op.drop_constraint(
+                "fk_service_account_certificate_group", type_="foreignkey"
+            )
+        if "certificate_group_code" in columns:
+            batch_op.drop_column("certificate_group_code")


### PR DESCRIPTION
## Summary
- add a new Alembic migration after the current head to add the certificate_group_code column when missing
- create the certificate group foreign key if it is absent so legacy databases match the model

## Testing
- pytest tests/test_service_account_jwt.py

------
https://chatgpt.com/codex/tasks/task_e_68f2857fafbc832395573bbe3c5567ad