### PR TITLE
Use toast notifications when copying API keys

### DIFF
--- a/webapp/admin/templates/admin/service_account_api_keys.html
+++ b/webapp/admin/templates/admin/service_account_api_keys.html
@@ -797,9 +797,17 @@
     if (!revealValue) return;
     const value = revealValue.textContent || '';
     navigator.clipboard.writeText(value).then(() => {
-      showAlert(text.copied, 'success');
+      if (typeof window.showSuccessToast === 'function') {
+        window.showSuccessToast(text.copied);
+      } else {
+        showAlert(text.copied, 'success');
+      }
     }).catch(() => {
-      showAlert(text.copyFailed, 'warning');
+      if (typeof window.showWarningToast === 'function') {
+        window.showWarningToast(text.copyFailed);
+      } else {
+        showAlert(text.copyFailed, 'warning');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- update the service account API key management page to show toast notifications when copying a new key
- fall back to the existing alert banner only if toast helpers are unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f28690bde083239cfd54e6283d98d6