### PR TITLE
Add server signing option for access token signatures

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -11,6 +11,7 @@ from .picker_import_task import PickerImportTask
 from .totp import TOTPCredential
 from .service_account import ServiceAccount
 from .service_account_api_key import ServiceAccountApiKey, ServiceAccountApiKeyLog
+from .system_setting import SystemSetting
 
 __all__ = [
     'User',
@@ -30,4 +31,5 @@ __all__ = [
     'ServiceAccount',
     'ServiceAccountApiKey',
     'ServiceAccountApiKeyLog',
+    'SystemSetting',
 ]

--- a/core/models/system_setting.py
+++ b/core/models/system_setting.py
@@ -1,0 +1,24 @@
+"""System-wide configuration persisted in the database."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from core.db import db
+
+
+class SystemSetting(db.Model):
+    """Simple key-value store for system configuration."""
+
+    __tablename__ = "system_settings"
+
+    key = db.Column(db.String(120), primary_key=True)
+    value = db.Column(db.Text, nullable=True)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+__all__ = ["SystemSetting"]

--- a/migrations/versions/1f0a4c2b8d7e_add_system_settings_table.py
+++ b/migrations/versions/1f0a4c2b8d7e_add_system_settings_table.py
@@ -1,0 +1,30 @@
+"""Add system settings table for persisted configuration."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "1f0a4c2b8d7e"
+down_revision = ("4f0b8a5d9c12", "2f6e4c3b1a2d")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(length=120), primary_key=True),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("system_settings")

--- a/tests/test_token_service_signing.py
+++ b/tests/test_token_service_signing.py
@@ -1,0 +1,79 @@
+import jwt
+import pytest
+
+from core.models.user import User
+from features.certs.application.use_cases import IssueCertificateForGroupUseCase
+from features.certs.domain.usage import UsageType
+from features.certs.infrastructure.models import CertificateGroupEntity
+from webapp.extensions import db
+from webapp.services.system_setting_service import SystemSettingService
+from webapp.services.token_service import TokenService
+
+
+@pytest.mark.usefixtures("app_context")
+def test_generate_access_token_with_server_signing():
+    user = User(email="server-sign@example.com")
+    user.set_password("secret")
+    db.session.add(user)
+    db.session.commit()
+
+    group = CertificateGroupEntity(
+        group_code="server-signing",
+        display_name="Server Signing",
+        auto_rotate=False,
+        rotation_threshold_days=30,
+        key_type="RSA",
+        key_curve=None,
+        key_size=2048,
+        subject={"CN": "Server Signing"},
+        usage_type=UsageType.SERVER_SIGNING.value,
+    )
+    db.session.add(group)
+    db.session.commit()
+
+    issued = IssueCertificateForGroupUseCase().execute(group.group_code)
+    SystemSettingService.update_access_token_signing_setting("server_signing", kid=issued.kid)
+
+    token = TokenService.generate_access_token(user)
+    header = jwt.get_unverified_header(token)
+    assert header.get("alg") == issued.jwk.get("alg")
+    assert header.get("kid") == issued.kid
+
+    verification = TokenService.verify_access_token(token)
+    assert verification is not None
+    verified_user, scopes = verification
+    assert verified_user.id == user.id
+    assert scopes == set()
+
+
+@pytest.mark.usefixtures("app_context")
+def test_verify_builtin_token_after_switch_to_server_signing():
+    user = User(email="legacy@example.com")
+    user.set_password("secret")
+    db.session.add(user)
+    db.session.commit()
+
+    legacy_token = TokenService.generate_access_token(user)
+
+    group = CertificateGroupEntity(
+        group_code="server-signing-legacy",
+        display_name="Server Signing Legacy",
+        auto_rotate=False,
+        rotation_threshold_days=30,
+        key_type="RSA",
+        key_curve=None,
+        key_size=2048,
+        subject={"CN": "Server Signing Legacy"},
+        usage_type=UsageType.SERVER_SIGNING.value,
+    )
+    db.session.add(group)
+    db.session.commit()
+
+    issued = IssueCertificateForGroupUseCase().execute(group.group_code)
+    SystemSettingService.update_access_token_signing_setting("server_signing", kid=issued.kid)
+
+    verification = TokenService.verify_access_token(legacy_token)
+    assert verification is not None
+    verified_user, scopes = verification
+    assert verified_user.id == user.id
+    assert scopes == set()

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -40,6 +40,71 @@
 </ul>
 
 <h3>{{ _('Config Settings') }}</h3>
+
+<h4 class="mt-4">{{ _('Access Token Signing') }}</h4>
+<form method="post" class="mb-4">
+  <div class="form-check mb-2">
+    <input
+      class="form-check-input"
+      type="radio"
+      name="access_token_signing"
+      id="access-token-signing-builtin"
+      value="builtin"
+      {% if signing_setting.is_builtin %}checked{% endif %}
+    >
+    <label class="form-check-label" for="access-token-signing-builtin">
+      {{ _('Built-in secret (HS256)') }}
+    </label>
+    <div class="form-text">
+      {{ _('Use the built-in JWT secret key configured in the application settings.') }}
+    </div>
+  </div>
+
+  <div class="mt-3">
+    <label class="form-label" for="access-token-signing-server">
+      {{ _('Server signing certificates') }}
+    </label>
+    {% if server_signing_certificates %}
+      <div class="list-group">
+        {% for cert in server_signing_certificates %}
+        <label class="list-group-item">
+          <input
+            class="form-check-input me-2"
+            type="radio"
+            name="access_token_signing"
+            value="server_signing:{{ cert.kid }}"
+            {% if signing_setting.is_server_signing and signing_setting.kid == cert.kid %}checked{% endif %}
+          >
+          <span class="fw-bold">{{ cert.group_label or cert.group_code or _('Unnamed group') }}</span>
+          <span class="text-muted ms-2">{{ cert.kid }}</span>
+          <div class="small text-muted mt-1">
+            {% if cert.algorithm %}
+              {{ _('Algorithm: %(algorithm)s', algorithm=cert.algorithm) }}
+            {% endif %}
+            {% if cert.expires_at %}
+              <span class="ms-2">
+                {{ _('Expires at: %(timestamp)s', timestamp=cert.expires_at|localtime('%Y-%m-%d %H:%M')) }}
+              </span>
+            {% endif %}
+          </div>
+          {% if cert.subject %}
+            <div class="small text-muted">{{ cert.subject }}</div>
+          {% endif %}
+        </label>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="text-muted mb-0">
+        {{ _('No server signing certificates are available. Issue a certificate in the certificate management section first.') }}
+      </p>
+    {% endif %}
+  </div>
+
+  <button type="submit" class="btn btn-primary mt-3">
+    {{ _('Save signing settings') }}
+  </button>
+</form>
+
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/webapp/services/access_token_signing.py
+++ b/webapp/services/access_token_signing.py
@@ -1,0 +1,145 @@
+"""Helpers to resolve keys for access token signing and verification."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from flask import current_app
+from jwt import algorithms as jwt_algorithms
+
+from features.certs.application.services import default_certificate_services
+from features.certs.application.use_cases import GetIssuedCertificateUseCase
+from features.certs.domain.exceptions import (
+    CertificateNotFoundError,
+    CertificatePrivateKeyNotFoundError,
+)
+from features.certs.domain.usage import UsageType
+from webapp.services.system_setting_service import (
+    AccessTokenSigningSetting,
+    SystemSettingService,
+)
+
+
+_ALLOWED_RSA_ALGORITHMS = {"RS256", "RS384", "RS512"}
+_ALLOWED_EC_ALGORITHMS = {"ES256", "ES384", "ES512"}
+_ALLOWED_SERVER_ALGORITHMS = _ALLOWED_RSA_ALGORITHMS | _ALLOWED_EC_ALGORITHMS
+
+
+class AccessTokenSigningError(RuntimeError):
+    """Raised when signing configuration prevents issuing a token."""
+
+
+class AccessTokenVerificationError(RuntimeError):
+    """Raised when a token cannot be verified because key resolution failed."""
+
+
+@dataclass(slots=True)
+class SigningMaterial:
+    """Resolved information for producing a signed JWT."""
+
+    algorithm: str
+    key: str | bytes
+    headers: dict[str, str] | None
+    kid: str | None
+    setting: AccessTokenSigningSetting
+
+
+def resolve_signing_material() -> SigningMaterial:
+    """Return the key, algorithm, and headers for issuing an access token."""
+
+    setting = SystemSettingService.get_access_token_signing_setting()
+    if setting.is_builtin:
+        secret = current_app.config["JWT_SECRET_KEY"]
+        return SigningMaterial(
+            algorithm="HS256",
+            key=secret,
+            headers=None,
+            kid=None,
+            setting=setting,
+        )
+
+    if not setting.kid:
+        raise AccessTokenSigningError("Server signing configuration is missing a certificate identifier.")
+
+    certificate = _load_active_server_signing_certificate(setting.kid)
+    try:
+        key_record = default_certificate_services.private_key_store.get(certificate.kid)
+    except CertificatePrivateKeyNotFoundError as exc:
+        raise AccessTokenSigningError("Private key for configured certificate is not available.") from exc
+
+    algorithm = str(certificate.jwk.get("alg") or "").strip()
+    if algorithm not in _ALLOWED_SERVER_ALGORITHMS:
+        raise AccessTokenSigningError(f"Unsupported server signing algorithm: {algorithm or 'unknown'}")
+
+    headers = {"kid": certificate.kid}
+    return SigningMaterial(
+        algorithm=algorithm,
+        key=key_record.private_key_pem,
+        headers=headers,
+        kid=certificate.kid,
+        setting=setting,
+    )
+
+
+def resolve_verification_key(algorithm: str, kid: str | None):
+    """Resolve the key required to verify an access token."""
+
+    if algorithm == "HS256":
+        return current_app.config["JWT_SECRET_KEY"]
+
+    normalized_alg = (algorithm or "").strip()
+    if normalized_alg not in _ALLOWED_SERVER_ALGORITHMS:
+        raise AccessTokenVerificationError(f"Unsupported JWT algorithm: {normalized_alg or 'unknown'}")
+
+    if not kid:
+        raise AccessTokenVerificationError("Missing key identifier for server signed token.")
+
+    certificate = _load_active_server_signing_certificate(kid)
+    jwk_payload = json.dumps(certificate.jwk)
+
+    if normalized_alg in _ALLOWED_RSA_ALGORITHMS:
+        return jwt_algorithms.RSAAlgorithm.from_jwk(jwk_payload)
+    if normalized_alg in _ALLOWED_EC_ALGORITHMS:
+        return jwt_algorithms.ECAlgorithm.from_jwk(jwk_payload)
+
+    raise AccessTokenVerificationError(f"Unsupported JWT algorithm: {normalized_alg}")
+
+
+def _load_active_server_signing_certificate(kid: str):
+    try:
+        certificate = GetIssuedCertificateUseCase().execute(kid)
+    except CertificateNotFoundError as exc:
+        raise AccessTokenSigningError("Configured certificate does not exist.") from exc
+
+    if certificate.usage_type != UsageType.SERVER_SIGNING:
+        raise AccessTokenSigningError("Configured certificate is not marked for server signing usage.")
+
+    now = datetime.now(timezone.utc)
+    revoked_at = _to_utc(certificate.revoked_at)
+    if revoked_at is not None and revoked_at <= now:
+        raise AccessTokenSigningError("Configured certificate has been revoked.")
+    expires_at = _to_utc(certificate.expires_at)
+    if expires_at is not None and expires_at <= now:
+        raise AccessTokenSigningError("Configured certificate is expired.")
+    if certificate.group is None:
+        raise AccessTokenSigningError("Configured certificate is not assigned to a group.")
+
+    return certificate
+
+
+def _to_utc(value):
+    if value is None:
+        return None
+    if getattr(value, "tzinfo", None) is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+__all__ = [
+    "AccessTokenSigningError",
+    "AccessTokenVerificationError",
+    "SigningMaterial",
+    "resolve_signing_material",
+    "resolve_verification_key",
+]

--- a/webapp/services/system_setting_service.py
+++ b/webapp/services/system_setting_service.py
@@ -1,0 +1,166 @@
+"""Services for managing persisted system settings."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from flask_babel import gettext as _
+
+from core.db import db
+from core.models.system_setting import SystemSetting
+from features.certs.application.services import default_certificate_services
+from features.certs.application.use_cases import GetIssuedCertificateUseCase
+from features.certs.domain.exceptions import (
+    CertificateNotFoundError,
+    CertificatePrivateKeyNotFoundError,
+)
+from features.certs.domain.usage import UsageType
+
+
+class SystemSettingError(RuntimeError):
+    """Base exception for system setting operations."""
+
+
+class AccessTokenSigningValidationError(SystemSettingError):
+    """Raised when updating the access token signing configuration fails."""
+
+
+@dataclass(slots=True)
+class AccessTokenSigningSetting:
+    """Structured representation of the access token signing configuration."""
+
+    mode: str
+    kid: str | None = None
+    group_code: str | None = None
+
+    @property
+    def is_builtin(self) -> bool:
+        return self.mode == "builtin"
+
+    @property
+    def is_server_signing(self) -> bool:
+        return self.mode == "server_signing"
+
+
+class SystemSettingService:
+    """Read and update persistent system settings."""
+
+    _ACCESS_TOKEN_SIGNING_KEY = "access_token_signing"
+    _DEFAULT_ACCESS_TOKEN_SIGNING = AccessTokenSigningSetting(mode="builtin")
+
+    @classmethod
+    def get_access_token_signing_setting(cls) -> AccessTokenSigningSetting:
+        record = SystemSetting.query.get(cls._ACCESS_TOKEN_SIGNING_KEY)
+        if record is None or not record.value:
+            return cls._DEFAULT_ACCESS_TOKEN_SIGNING
+
+        try:
+            payload = json.loads(record.value)
+        except (TypeError, json.JSONDecodeError):
+            return cls._DEFAULT_ACCESS_TOKEN_SIGNING
+
+        mode = str(payload.get("mode") or "builtin").strip()
+        if mode != "server_signing":
+            return cls._DEFAULT_ACCESS_TOKEN_SIGNING
+
+        kid = payload.get("kid")
+        group_code = payload.get("groupCode")
+        if not isinstance(kid, str) or not kid.strip():
+            return cls._DEFAULT_ACCESS_TOKEN_SIGNING
+
+        return AccessTokenSigningSetting(mode="server_signing", kid=kid.strip(), group_code=group_code)
+
+    @classmethod
+    def update_access_token_signing_setting(
+        cls,
+        mode: str,
+        *,
+        kid: str | None = None,
+    ) -> AccessTokenSigningSetting:
+        normalized_mode = (mode or "").strip()
+        if normalized_mode == "builtin":
+            value = {"mode": "builtin"}
+            return cls._persist_access_token_signing(value, AccessTokenSigningSetting(mode="builtin"))
+
+        if normalized_mode != "server_signing":
+            raise AccessTokenSigningValidationError(_("Unsupported signing mode was specified."))
+
+        if not kid or not kid.strip():
+            raise AccessTokenSigningValidationError(_("Please select a certificate for signing."))
+
+        certificate = cls._load_server_signing_certificate(kid.strip())
+
+        group_code = certificate.group.group_code if certificate.group else None
+        value = {
+            "mode": "server_signing",
+            "kid": certificate.kid,
+            "groupCode": group_code,
+        }
+        setting = AccessTokenSigningSetting(
+            mode="server_signing",
+            kid=certificate.kid,
+            group_code=group_code,
+        )
+        return cls._persist_access_token_signing(value, setting)
+
+    @classmethod
+    def _load_server_signing_certificate(cls, kid: str):
+        try:
+            certificate = GetIssuedCertificateUseCase().execute(kid)
+        except CertificateNotFoundError as exc:
+            raise AccessTokenSigningValidationError(_("The selected certificate could not be found.")) from exc
+
+        if certificate.usage_type != UsageType.SERVER_SIGNING:
+            raise AccessTokenSigningValidationError(
+                _("The certificate is not issued for server signing usage."),
+            )
+
+        now = datetime.now(timezone.utc)
+        revoked_at = cls._to_utc(certificate.revoked_at)
+        if revoked_at is not None and revoked_at <= now:
+            raise AccessTokenSigningValidationError(_("The certificate has been revoked."))
+        expires_at = cls._to_utc(certificate.expires_at)
+        if expires_at is not None and expires_at <= now:
+            raise AccessTokenSigningValidationError(_("The certificate has expired."))
+        if certificate.group is None:
+            raise AccessTokenSigningValidationError(_("The certificate is not associated with a group."))
+
+        try:
+            default_certificate_services.private_key_store.get(certificate.kid)
+        except CertificatePrivateKeyNotFoundError as exc:
+            raise AccessTokenSigningValidationError(
+                _("The private key for the selected certificate is missing."),
+            ) from exc
+
+        return certificate
+
+    @classmethod
+    def _persist_access_token_signing(
+        cls,
+        value: dict,
+        setting: AccessTokenSigningSetting,
+    ) -> AccessTokenSigningSetting:
+        record = SystemSetting.query.get(cls._ACCESS_TOKEN_SIGNING_KEY)
+        if record is None:
+            record = SystemSetting(key=cls._ACCESS_TOKEN_SIGNING_KEY)
+        record.value = json.dumps(value, ensure_ascii=False)
+        db.session.add(record)
+        db.session.commit()
+        return setting
+
+    @staticmethod
+    def _to_utc(value):
+        if value is None:
+            return None
+        if getattr(value, "tzinfo", None) is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+
+__all__ = [
+    "SystemSettingError",
+    "AccessTokenSigningValidationError",
+    "AccessTokenSigningSetting",
+    "SystemSettingService",
+]

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1179,3 +1179,39 @@ msgstr "Back to Group"
 
 msgid "Are you sure you want to issue a new certificate for this group?"
 msgstr "Are you sure you want to issue a new certificate for this group?"
+
+msgid "Access token signing will use the built-in secret."
+msgstr "Access token signing will use the built-in secret."
+
+msgid "Access token signing certificate updated."
+msgstr "Access token signing certificate updated."
+
+msgid "Failed to update the access token signing configuration."
+msgstr "Failed to update the access token signing configuration."
+
+msgid "Access Token Signing"
+msgstr "Access Token Signing"
+
+msgid "Built-in secret (HS256)"
+msgstr "Built-in secret (HS256)"
+
+msgid "Use the built-in JWT secret key configured in the application settings."
+msgstr "Use the built-in JWT secret key configured in the application settings."
+
+msgid "Server signing certificates"
+msgstr "Server signing certificates"
+
+msgid "Unnamed group"
+msgstr "Unnamed group"
+
+msgid "Algorithm: %(algorithm)s"
+msgstr "Algorithm: %(algorithm)s"
+
+msgid "Expires at: %(timestamp)s"
+msgstr "Expires at: %(timestamp)s"
+
+msgid "No server signing certificates are available. Issue a certificate in the certificate management section first."
+msgstr "No server signing certificates are available. Issue a certificate in the certificate management section first."
+
+msgid "Save signing settings"
+msgstr "Save signing settings"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -3200,3 +3200,39 @@ msgstr "指定したグループに証明書が存在しません"
 
 msgid "Are you sure you want to issue a new certificate for this group?"
 msgstr "このグループに新しい証明書を発行します。よろしいですか？"
+
+msgid "Access token signing will use the built-in secret."
+msgstr "アクセストークンの署名に組み込みシークレットを利用します。"
+
+msgid "Access token signing certificate updated."
+msgstr "アクセストークン署名証明書を更新しました。"
+
+msgid "Failed to update the access token signing configuration."
+msgstr "アクセストークン署名の設定を更新できませんでした。"
+
+msgid "Access Token Signing"
+msgstr "アクセストークン署名"
+
+msgid "Built-in secret (HS256)"
+msgstr "組み込みシークレット（HS256）"
+
+msgid "Use the built-in JWT secret key configured in the application settings."
+msgstr "アプリケーション設定の組み込みJWTシークレットキーを使用します。"
+
+msgid "Server signing certificates"
+msgstr "サーバー署名証明書"
+
+msgid "Unnamed group"
+msgstr "名称未設定のグループ"
+
+msgid "Algorithm: %(algorithm)s"
+msgstr "アルゴリズム: %(algorithm)s"
+
+msgid "Expires at: %(timestamp)s"
+msgstr "有効期限: %(timestamp)s"
+
+msgid "No server signing certificates are available. Issue a certificate in the certificate management section first."
+msgstr "サーバー署名証明書がありません。先に証明書管理セクションで証明書を発行してください。"
+
+msgid "Save signing settings"
+msgstr "署名設定を保存"


### PR DESCRIPTION
## Summary
- add a database-backed system setting for access token signing and helper services
- update the admin configuration page to choose between the built-in secret or a server signing certificate
- sign and verify JWT access tokens using the configured key and cover the behaviour with tests

## Testing
- pytest tests/test_token_service_signing.py

------
https://chatgpt.com/codex/tasks/task_e_68f2898dd61c8323bf2de3217dd34cc7