### PR TITLE
Add Swagger UI and dynamic OpenAPI documentation

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.mark.usefixtures('app_context')
+class TestOpenAPIDocs:
+    def test_openapi_spec_includes_login_endpoint(self, app_context):
+        client = app_context.test_client()
+        response = client.get('/api/openapi.json')
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['openapi'] == '3.0.3'
+
+        login_path = payload['paths']['/api/login']
+        login_post = login_path['post']
+        assert login_post['summary'] == 'ユーザー認証してJWTを発行'
+        assert login_post['operationId'].endswith('_post')
+        assert login_post['responses']['200']['description']
+        assert payload['servers'][0]['url'].startswith('http://')
+
+    def test_swagger_ui_served(self, app_context):
+        client = app_context.test_client()
+        response = client.get('/api/docs')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'SwaggerUIBundle' in html
+        assert '/api/openapi.json' in html

--- a/webapp/api/openapi.py
+++ b/webapp/api/openapi.py
@@ -1,42 +1,173 @@
-from flask import jsonify
+"""OpenAPIエンドポイントとSwagger UIを提供するモジュール。"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections import OrderedDict
+from typing import Iterable
+
+from flask import current_app, jsonify, render_template, request, url_for
 from flask_babel import gettext as _
 
 from . import bp
 
 
-@bp.get('/openapi.json')
+_HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+_PATH_PARAMETER_PATTERN = re.compile(r"<(?:[^:<>]+:)?([^<>]+)>")
+_EXCLUDED_ENDPOINTS = {"api.openapi_spec", "api.swagger_ui"}
+
+_CONVERTER_SCHEMA_OVERRIDES = {
+    "IntegerConverter": {"type": "integer"},
+    "FloatConverter": {"type": "number"},
+    "UUIDConverter": {"type": "string", "format": "uuid"},
+}
+
+
+def _convert_rule_to_openapi_path(rule) -> str:
+    """FlaskのURLルールをOpenAPI互換のパス形式へ変換する。"""
+
+    return _PATH_PARAMETER_PATTERN.sub(r"{\1}", rule.rule)
+
+
+def _operation_docs(view_func) -> tuple[str | None, str | None]:
+    """ビューのdocstringからsummary/descriptionを抽出する。"""
+
+    if view_func is None:
+        return None, None
+    doc = inspect.getdoc(view_func)
+    if not doc:
+        return None, None
+    lines = [line.strip() for line in doc.splitlines() if line.strip()]
+    if not lines:
+        return None, None
+    summary = lines[0]
+    description_lines = lines[1:]
+    description = "\n".join(description_lines).strip() if description_lines else None
+    return summary, description or None
+
+
+def _derive_tag(path: str) -> str | None:
+    """パスから最上位セグメントをタグ名として推定する。"""
+
+    segments = [segment for segment in path.split("/") if segment]
+    if segments and segments[0] == "api":
+        segments = segments[1:]
+    for segment in segments:
+        if segment.startswith("{"):
+            continue
+        label = segment.replace("-", " ").replace("_", " ")
+        label = label.title()
+        return label
+    return None
+
+
+def _build_parameters(rule) -> list[dict]:
+    """FlaskルールからOpenAPIのパスパラメータ定義を生成する。"""
+
+    parameters: list[dict] = []
+    arguments = sorted(rule.arguments)
+    if not arguments:
+        return parameters
+
+    converters = getattr(rule, "_converters", {})
+    for argument in arguments:
+        converter = converters.get(argument)
+        schema = {"type": "string"}
+        if converter is not None:
+            override = _CONVERTER_SCHEMA_OVERRIDES.get(type(converter).__name__)
+            if override:
+                schema = override.copy()
+        parameters.append(
+            {
+                "name": argument,
+                "in": "path",
+                "required": True,
+                "schema": schema,
+            }
+        )
+    return parameters
+
+
+def _iter_api_rules() -> Iterable:
+    """OpenAPIに含めるFlaskルールを抽出する。"""
+
+    rules = sorted(current_app.url_map.iter_rules(), key=lambda rule: rule.rule)
+    for rule in rules:
+        if not rule.rule.startswith("/api"):
+            continue
+        if rule.endpoint in _EXCLUDED_ENDPOINTS:
+            continue
+        if rule.endpoint == "static":
+            continue
+        yield rule
+
+
+def _build_paths() -> OrderedDict:
+    """OpenAPI pathsセクションを構築する。"""
+
+    paths: dict[str, dict] = {}
+    for rule in _iter_api_rules():
+        methods = sorted(method for method in rule.methods if method in _HTTP_METHODS)
+        if not methods:
+            continue
+        openapi_path = _convert_rule_to_openapi_path(rule)
+        path_item = paths.setdefault(openapi_path, {})
+        view_func = current_app.view_functions.get(rule.endpoint)
+        summary, description = _operation_docs(view_func)
+        tag = _derive_tag(openapi_path)
+        parameters = _build_parameters(rule)
+        for method in methods:
+            operation: dict[str, object] = {
+                "operationId": f"{rule.endpoint.replace('.', '_')}_{method.lower()}",
+                "responses": {
+                    "200": {"description": _("Successful response")},
+                },
+            }
+            if summary:
+                operation["summary"] = summary
+            else:
+                operation["summary"] = f"{method.title()} {openapi_path}"
+            if description:
+                operation["description"] = description
+            if tag:
+                operation["tags"] = [tag]
+            if parameters:
+                operation["parameters"] = parameters
+            path_item[method.lower()] = operation
+    ordered_paths = OrderedDict(sorted(paths.items()))
+    return ordered_paths
+
+
+@bp.get("/openapi.json")
 def openapi_spec():
-    """簡易OpenAPI仕様を返す"""
+    """OpenAPI仕様ドキュメントを生成して返す。"""
+
     spec = {
         "openapi": "3.0.3",
         "info": {"title": f"{_('AppName')} API", "version": "1.0.0"},
-        "paths": {
-            "/api/login": {
-                "post": {
-                    "summary": "JWTログイン",
-                    "responses": {"200": {"description": "OK"}},
-                }
-            },
-            "/api/google/accounts": {
-                "get": {
-                    "summary": "Googleアカウント一覧",
-                    "security": [{"cookieAuth": []}, {"bearerAuth": []}],
-                    "responses": {"200": {"description": "OK"}},
-                }
-            },
-            "/api/auth/check": {
-                "get": {
-                    "summary": "JWTまたはCookieでの認証状態チェック",
-                    "security": [{"cookieAuth": []}, {"bearerAuth": []}],
-                    "responses": {"200": {"description": "OK"}},
-                }
-            },
-        },
+        "servers": [{"url": request.url_root.rstrip("/")}],
+        "paths": _build_paths(),
         "components": {
             "securitySchemes": {
-                "bearerAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"},
-                "cookieAuth": {"type": "apiKey", "in": "cookie", "name": "access_token"},
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "bearerFormat": "JWT",
+                },
+                "cookieAuth": {
+                    "type": "apiKey",
+                    "in": "cookie",
+                    "name": "access_token",
+                },
             }
         },
     }
     return jsonify(spec)
+
+
+@bp.get("/docs")
+def swagger_ui():
+    """Swagger UIを提供する。"""
+
+    return render_template("swagger_ui.html", spec_url=url_for("api.openapi_spec"))

--- a/webapp/api/templates/swagger_ui.html
+++ b/webapp/api/templates/swagger_ui.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ _('AppName') }} API Docs</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
+      integrity="sha256-B3K9yk1qUzlfauD2hYVW3b3uag6X9Fsw3a+XJsiXu1w="
+      crossorigin="anonymous"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #swagger-ui {
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
+      integrity="sha256-fbd0J6MnIm4iEBiZAUA0YFmAyTd3H+nYG+zqyivhPXg="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
+      integrity="sha256-mLT0ZptDCbmH7zqveVKNJF4lHqtA/7/k3RvJO8rww8M="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      window.addEventListener('load', () => {
+        SwaggerUIBundle({
+          url: '{{ spec_url }}',
+          dom_id: '#swagger-ui',
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: 'BaseLayout',
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- generate OpenAPI paths dynamically from the registered Flask routes and expose a Swagger UI entrypoint
- document API metadata including servers, security schemes, tags, and path parameters for better discoverability
- add regression tests covering the OpenAPI spec endpoint and Swagger UI delivery

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f2e81c5ac48323b8e1156380bb378a