### PR TITLE
Expose service account signing API endpoint

### DIFF
--- a/tests/test_service_account_login_flow.py
+++ b/tests/test_service_account_login_flow.py
@@ -1,24 +1,18 @@
 from __future__ import annotations
 
 import base64
-import binascii
 import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from flask import jsonify, request
-from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from core.db import db
-from features.certs.application.dto import SignGroupPayloadInput
 from features.certs.application.use_cases import (
     IssueCertificateForGroupUseCase,
     ListJwksUseCase,
-    SignGroupPayloadUseCase,
 )
 from features.certs.domain.usage import UsageType
 from features.certs.infrastructure.models import CertificateGroupEntity
-from webapp.auth.api_key_auth import require_api_key_scopes
 from webapp.services.service_account_api_key_service import ServiceAccountApiKeyService
 from webapp.services.service_account_service import ServiceAccountService
 
@@ -47,14 +41,14 @@ def test_service_account_end_to_end_login_flow(app_context):
         name="maintenance-bot",
         description="",
         certificate_group_code=group.group_code,
-        scope_names="maintenance:read",
+        scope_names=["maintenance:read", "certificate:sign"],
         active=True,
-        allowed_scopes=["maintenance:read"],
+        allowed_scopes=["maintenance:read", "certificate:sign"],
     )
 
     _, api_key_value = ServiceAccountApiKeyService.create_key(
         account.service_account_id,
-        scopes="maintenance:read",
+        scopes="certificate:sign",
         expires_at=None,
         created_by="admin@example.com",
     )
@@ -63,41 +57,6 @@ def test_service_account_end_to_end_login_flow(app_context):
 
     def _b64url(data: bytes) -> str:
         return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-    @app.route("/internal/sign-jws", methods=["POST"])
-    @require_api_key_scopes(["maintenance:read"])
-    def sign_jws_endpoint():
-        payload = request.get_json(silent=True) or {}
-        encoded_input = payload.get("signingInput")
-        if not isinstance(encoded_input, str) or not encoded_input.strip():
-            return jsonify({"error": "signingInput is required"}), 400
-        try:
-            signing_input_bytes = base64.b64decode(encoded_input.strip(), validate=True)
-        except (binascii.Error, ValueError):
-            return jsonify({"error": "signingInput must be base64 encoded"}), 400
-
-        sign_input = SignGroupPayloadInput(
-            group_code=group.group_code,
-            payload=signing_input_bytes,
-            kid=issued.kid,
-            hash_algorithm="SHA256",
-        )
-        result = SignGroupPayloadUseCase().execute(sign_input)
-        signature_bytes = result.signature
-        if result.algorithm.startswith("ES"):
-            component_size = int(result.algorithm[2:]) // 8
-            r_value, s_value = decode_dss_signature(signature_bytes)
-            signature_bytes = r_value.to_bytes(component_size, "big") + s_value.to_bytes(
-                component_size, "big"
-            )
-        signature_segment = _b64url(signature_bytes)
-        return jsonify(
-            {
-                "signature": signature_segment,
-                "kid": result.kid,
-                "algorithm": result.algorithm,
-            }
-        )
 
     client = app.test_client()
 
@@ -123,12 +82,18 @@ def test_service_account_end_to_end_login_flow(app_context):
     signing_input_encoded = base64.b64encode(signing_input).decode("ascii")
 
     sign_response = client.post(
-        "/internal/sign-jws",
-        json={"signingInput": signing_input_encoded},
+        "/api/service_accounts/signatures",
+        json={
+            "signingInput": signing_input_encoded,
+            "signingInputEncoding": "base64",
+            "kid": issued.kid,
+        },
         headers={"Authorization": f"ApiKey {api_key_value}"},
     )
     assert sign_response.status_code == 200
-    signature_segment = sign_response.get_json()["signature"]
+    signature_payload = sign_response.get_json()
+    signature_segment = signature_payload["signature"]
+    assert signature_payload["kid"] == issued.kid
 
     token = f"{header_segment}.{payload_segment}.{signature_segment}"
 

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -10,6 +10,7 @@ from . import version  # noqa
 from . import upload  # noqa
 from . import maintenance  # noqa
 from . import service_account_keys  # noqa
+from . import service_account_signing  # noqa
 
 # picker_session Blueprintをapi Blueprintに登録
 from .picker_session import bp as picker_session_bp

--- a/webapp/api/service_account_signing.py
+++ b/webapp/api/service_account_signing.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from http import HTTPStatus
+
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+from flask import g, jsonify, request
+from flask_babel import gettext as _
+
+from features.certs.application.dto import SignGroupPayloadInput
+from features.certs.application.use_cases import SignGroupPayloadUseCase
+from features.certs.domain.exceptions import (
+    CertificateError,
+    CertificateGroupNotFoundError,
+    CertificateNotFoundError,
+    CertificateValidationError,
+)
+from webapp.auth.api_key_auth import require_api_key_scopes
+
+from . import bp
+
+
+def _json_error(message: str, status: HTTPStatus):
+    return jsonify({"error": message}), status
+
+
+def _decode_signing_input(value: str, encoding: str) -> bytes:
+    normalized = encoding.strip().lower() if isinstance(encoding, str) else ""
+    if normalized not in {"base64", "base64url"}:
+        raise CertificateValidationError(_("signingInputEncoding must be \"base64\" or \"base64url\"."))
+
+    value = value.strip()
+    try:
+        if normalized == "base64url":
+            padding_length = (-len(value)) % 4
+            return base64.urlsafe_b64decode(value + ("=" * padding_length))
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise CertificateValidationError(_("signingInput must be valid base64 data.")) from exc
+
+
+@bp.route("/service_accounts/signatures", methods=["POST"])
+@require_api_key_scopes(["certificate:sign"])
+def create_service_account_signature():
+    account = getattr(g, "service_account", None)
+    if account is None:
+        return _json_error(_("Authentication required."), HTTPStatus.UNAUTHORIZED)
+
+    if not account.certificate_group_code:
+        return _json_error(
+            _("The service account is not linked to a certificate group."),
+            HTTPStatus.BAD_REQUEST,
+        )
+
+    payload = request.get_json(silent=True) or {}
+
+    signing_input = payload.get("signingInput")
+    if not isinstance(signing_input, str) or not signing_input.strip():
+        return _json_error(_("signingInput must be a base64-encoded string."), HTTPStatus.BAD_REQUEST)
+
+    encoding_value = payload.get("signingInputEncoding", "base64")
+    if encoding_value is not None and not isinstance(encoding_value, str):
+        return _json_error(_("signingInputEncoding must be \"base64\" or \"base64url\"."), HTTPStatus.BAD_REQUEST)
+
+    kid_value = payload.get("kid")
+    if not isinstance(kid_value, str) or not kid_value.strip():
+        return _json_error(_("kid must be provided."), HTTPStatus.BAD_REQUEST)
+
+    hash_algorithm_value = payload.get("hashAlgorithm")
+    if hash_algorithm_value is not None and not isinstance(hash_algorithm_value, str):
+        return _json_error(_("hashAlgorithm must be a string."), HTTPStatus.BAD_REQUEST)
+
+    try:
+        signing_input_bytes = _decode_signing_input(signing_input, encoding_value or "base64")
+    except CertificateValidationError as exc:
+        return _json_error(str(exc), HTTPStatus.BAD_REQUEST)
+
+    dto = SignGroupPayloadInput(
+        group_code=account.certificate_group_code,
+        payload=signing_input_bytes,
+        kid=kid_value.strip(),
+        hash_algorithm=(hash_algorithm_value.strip() if isinstance(hash_algorithm_value, str) else "SHA256"),
+    )
+
+    try:
+        result = SignGroupPayloadUseCase().execute(dto, actor=account.name)
+    except CertificateGroupNotFoundError as exc:
+        return _json_error(str(exc), HTTPStatus.NOT_FOUND)
+    except CertificateNotFoundError as exc:
+        return _json_error(str(exc), HTTPStatus.NOT_FOUND)
+    except CertificateValidationError as exc:
+        return _json_error(str(exc), HTTPStatus.BAD_REQUEST)
+    except CertificateError as exc:
+        return _json_error(str(exc), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    signature_bytes = result.signature
+    if result.algorithm.startswith("ES"):
+        component_size = int(result.algorithm[2:]) // 8
+        r_value, s_value = decode_dss_signature(signature_bytes)
+        signature_bytes = r_value.to_bytes(component_size, "big") + s_value.to_bytes(component_size, "big")
+
+    signature_segment = base64.urlsafe_b64encode(signature_bytes).rstrip(b"=").decode("ascii")
+
+    return jsonify(
+        {
+            "groupCode": account.certificate_group_code,
+            "kid": result.kid,
+            "algorithm": result.algorithm,
+            "hashAlgorithm": result.hash_algorithm,
+            "signature": signature_segment,
+        }
+    )


### PR DESCRIPTION
## Summary
- add an authenticated `/api/service_accounts/signatures` endpoint that signs pre-encoded JWS inputs for service accounts using their Client Signing keys
- register the new service account signing routes with the API blueprint
- exercise the new endpoint in the service account end-to-end test and ensure signing scopes are configured

## Testing
- pytest tests/test_service_account_login_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68f2ebfbc43c8323a98f4437f9db9a84