### PR TITLE
Fix Swagger UI docs by removing stale SRI attributes

### DIFF
--- a/webapp/api/templates/swagger_ui.html
+++ b/webapp/api/templates/swagger_ui.html
@@ -6,7 +6,6 @@
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
-      integrity="sha256-B3K9yk1qUzlfauD2hYVW3b3uag6X9Fsw3a+XJsiXu1w="
       crossorigin="anonymous"
     />
     <style>
@@ -25,12 +24,10 @@
     <div id="swagger-ui"></div>
     <script
       src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
-      integrity="sha256-fbd0J6MnIm4iEBiZAUA0YFmAyTd3H+nYG+zqyivhPXg="
       crossorigin="anonymous"
     ></script>
     <script
       src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
-      integrity="sha256-mLT0ZptDCbmH7zqveVKNJF4lHqtA/7/k3RvJO8rww8M="
       crossorigin="anonymous"
     ></script>
     <script>


### PR DESCRIPTION
## Summary
- remove outdated integrity attributes from the Swagger UI template so the CDN assets load correctly

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f379213c348323beea391a3dc119c8