### PR TITLE
Restore SRI integrity for Swagger UI assets

### DIFF
--- a/webapp/api/templates/swagger_ui.html
+++ b/webapp/api/templates/swagger_ui.html
@@ -5,7 +5,8 @@
     <title>{{ _('AppName') }} API Docs</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.10.5/swagger-ui.css"
+      integrity="sha384-fggJG3d/1uo8FjBTP7/QTfjIzaMS1AWDUnQarNCJZzqQlqjGLP0Kx8Un9XXsiv2q"
       crossorigin="anonymous"
     />
     <style>
@@ -23,11 +24,13 @@
   <body>
     <div id="swagger-ui"></div>
     <script
-      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
+      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.10.5/swagger-ui-bundle.js"
+      integrity="sha384-scCk4H/owymn3wdPNx4OQh/3JuTclN1cRMh0Rbj4htBKPImeXEghC5zPAFLZnTts"
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
+      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.10.5/swagger-ui-standalone-preset.js"
+      integrity="sha384-azzkurII4f+bjmZvm3hWhj7JezshyXtwobwneRyWCCIksK61Xi0Ry3xA2am9/TWp"
       crossorigin="anonymous"
     ></script>
     <script>


### PR DESCRIPTION
## Summary
- pin the Swagger UI CDN assets to version 5.10.5
- restore integrity hashes for the stylesheet and scripts to keep tamper protection intact

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f3830cbed4832393a93ead396e16a7