### PR TITLE
Fix OpenAPI server URL detection behind proxies

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -16,7 +16,21 @@ class TestOpenAPIDocs:
         assert login_post['summary'] == 'ユーザー認証してJWTを発行'
         assert login_post['operationId'].endswith('_post')
         assert login_post['responses']['200']['description']
-        assert payload['servers'][0]['url'].startswith('http://')
+        assert payload['servers'][0]['url'] == 'http://localhost'
+
+    def test_openapi_spec_respects_forwarded_proto(self, app_context):
+        client = app_context.test_client()
+        response = client.get(
+            '/api/openapi.json',
+            headers={
+                'X-Forwarded-Proto': 'https',
+                'X-Forwarded-Host': 'nolumia.com',
+            },
+        )
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['servers'][0]['url'] == 'https://nolumia.com'
 
     def test_swagger_ui_served(self, app_context):
         client = app_context.test_client()


### PR DESCRIPTION
## Summary
- derive the OpenAPI server URL with proxy headers so HTTPS deployments avoid mixed content
- cover forwarded header handling in the OpenAPI spec tests

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f3836746d88323b3e8a04c4c83726b