### PR TITLE
Echo endpoint returns headers and raw body

### DIFF
--- a/tests/test_echo_api.py
+++ b/tests/test_echo_api.py
@@ -1,0 +1,62 @@
+"""Echo APIのテスト。"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from webapp import create_app
+
+
+class TestEchoAPI:
+    """Echo APIの挙動を検証するテストケース。"""
+
+    @pytest.fixture
+    def client(self):
+        app = create_app()
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            yield client
+
+    def test_echo_returns_headers_and_json_payload(self, client):
+        payload = {"message": "こんにちは", "value": 42}
+        extra_headers = {"X-Debug": "1"}
+
+        response = client.post("/api/echo", json=payload, headers=extra_headers)
+
+        assert response.status_code == 200
+        assert response.content_type == "application/json"
+
+        response_body = response.get_json()
+        assert response_body["json"] == payload
+        assert json.loads(response_body["body"]) == payload
+        assert response_body["headers"]["Content-Type"] == "application/json"
+        assert response_body["headers"]["X-Debug"] == "1"
+
+    def test_echo_accepts_non_json_payload(self, client):
+        response = client.post(
+            "/api/echo",
+            data="plain text",
+            content_type="text/plain",
+        )
+
+        assert response.status_code == 200
+        response_body = response.get_json()
+        assert response_body["json"] is None
+        assert response_body["body"] == "plain text"
+        assert response_body["headers"]["Content-Type"] == "text/plain"
+
+    def test_echo_supports_json_array(self, client):
+        payload = [1, 2, {"nested": True}]
+
+        response = client.post("/api/echo", json=payload)
+
+        assert response.status_code == 200
+        response_body = response.get_json()
+        assert response_body["json"] == payload
+        assert json.loads(response_body["body"]) == payload
+
+    def test_echo_does_not_allow_get_method(self, client):
+        response = client.get("/api/echo")
+
+        assert response.status_code == 405

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -9,6 +9,7 @@ from . import openapi  # noqa
 from . import version  # noqa
 from . import upload  # noqa
 from . import maintenance  # noqa
+from . import echo  # noqa
 from . import service_account_keys  # noqa
 from . import service_account_signing  # noqa
 

--- a/webapp/api/echo.py
+++ b/webapp/api/echo.py
@@ -1,0 +1,21 @@
+"""リクエスト内容をそのまま返すAPIエンドポイント。"""
+from __future__ import annotations
+
+from flask import Response, jsonify, request
+
+from . import bp
+
+
+@bp.route("/echo", methods=["POST"])
+def echo() -> Response:
+    """受信したリクエストのヘッダとボディをまとめて返す。"""
+    json_payload = request.get_json(silent=True)
+    raw_body = request.get_data(as_text=True)
+
+    response_body = {
+        "headers": dict(request.headers),
+        "body": raw_body,
+        "json": json_payload,
+    }
+
+    return jsonify(response_body)


### PR DESCRIPTION
## Summary
- update the /api/echo handler to return request headers alongside the raw body and parsed JSON
- allow the debug echo endpoint to accept non-JSON payloads while still parsing JSON when present
- refresh the echo API tests to cover headers, non-JSON payloads, and JSON arrays

## Testing
- pytest tests/test_echo_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f391a84e708323a8153b60b328d1de