### PR TITLE
Preserve script root in OpenAPI server URL

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -32,6 +32,35 @@ class TestOpenAPIDocs:
         payload = response.get_json()
         assert payload['servers'][0]['url'] == 'https://nolumia.com'
 
+    def test_openapi_spec_preserves_script_root_without_forwarded_prefix(self, app_context):
+        client = app_context.test_client()
+        response = client.get(
+            '/api/openapi.json',
+            environ_overrides={'SCRIPT_NAME': '/app'},
+        )
+
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['servers'][0]['url'] == 'http://localhost/app'
+
+    def test_openapi_spec_deduplicates_forwarded_prefix_and_script_root(self, app_context):
+        client = app_context.test_client()
+        response = client.get(
+            '/api/openapi.json',
+            headers={
+                'X-Forwarded-Proto': 'https',
+                'X-Forwarded-Host': 'nolumia.com',
+                'X-Forwarded-Prefix': '/app',
+            },
+            environ_overrides={'SCRIPT_NAME': '/app'},
+        )
+
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['servers'][0]['url'] == 'https://nolumia.com/app'
+
     def test_swagger_ui_served(self, app_context):
         client = app_context.test_client()
         response = client.get('/api/docs')


### PR DESCRIPTION
## Summary
- incorporate Flask's script_root into the OpenAPI server URL resolution while avoiding duplicate prefixes
- extend OpenAPI documentation tests to cover script root only deployments and mixed forwarded prefix scenarios

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f394d3f3ec8323b5ae5fbd2419ebb9