### PR TITLE
Follow-up: include script root in OpenAPI server URL resolution

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -60,3 +60,15 @@ class TestOpenAPIDocs:
             response = openapi_spec()
         payload = response.get_json()
         assert payload['servers'][0]['url'] == 'http://localhost/proxy/app'
+
+    def test_openapi_spec_avoids_duplicate_script_root_when_forwarded_prefix_contains_it(
+        self, app_context
+    ):
+        with app_context.test_request_context(
+            '/api/openapi.json',
+            headers={'X-Forwarded-Prefix': '/proxy/app'},
+            environ_overrides={'SCRIPT_NAME': '/app'},
+        ):
+            response = openapi_spec()
+        payload = response.get_json()
+        assert payload['servers'][0]['url'] == 'http://localhost/proxy/app'

--- a/webapp/api/openapi.py
+++ b/webapp/api/openapi.py
@@ -178,7 +178,16 @@ def _resolve_server_url() -> str:
         if not base_path:
             base_path = prefix
         elif not base_path.startswith(prefix):
-            base_path = f"{prefix}{base_path}"
+            script_segments = [segment for segment in base_path.split("/") if segment]
+            prefix_segments = [segment for segment in prefix.split("/") if segment]
+            if (
+                script_segments
+                and len(prefix_segments) >= len(script_segments)
+                and prefix_segments[-len(script_segments) :] == script_segments
+            ):
+                base_path = prefix
+            else:
+                base_path = f"{prefix}{base_path}"
 
     return f"{scheme}://{host}{base_path}".rstrip("/")
 


### PR DESCRIPTION
## Summary
- ensure `_resolve_server_url` retains Flask's script root alongside any forwarded prefix
- add OpenAPI spec tests that cover script root and proxy prefix combinations

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f394cb0f90832389bbaf695985a5c3