### PR TITLE
Fix OpenAPI server prefix sanitization

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -71,6 +71,19 @@ class TestOpenAPIDocs:
             payload = openapi_spec().get_json()
         assert payload['servers'][0]['url'] == 'http://localhost/proxy/app'
 
+    def test_openapi_spec_handles_absolute_forwarded_prefix(self, app_context):
+        with app_context.test_request_context(
+            '/api/openapi.json',
+            headers={
+                'X-Forwarded-Proto': 'https',
+                'X-Forwarded-Host': 'nolumia.com',
+                'X-Forwarded-Prefix': 'https://nolumia.com/api',
+            },
+        ):
+            payload = openapi_spec().get_json()
+        servers = [server['url'] for server in payload['servers']]
+        assert servers[0] == 'https://nolumia.com/api'
+
     def test_swagger_ui_served(self, app_context):
         client = app_context.test_client()
         response = client.get('/api/docs')

--- a/webapp/api/openapi.py
+++ b/webapp/api/openapi.py
@@ -9,6 +9,7 @@ from typing import Iterable
 
 from flask import current_app, jsonify, render_template, request, url_for
 from flask_babel import gettext as _
+from urllib.parse import urlsplit
 
 from . import bp
 
@@ -180,6 +181,9 @@ def _resolve_server_urls() -> list[str]:
         prefix_header = request.headers.get("X-Forwarded-Prefix")
         if prefix_header:
             raw_prefix = prefix_header.split(",")[0].strip()
+            if "://" in raw_prefix:
+                parsed_prefix = urlsplit(raw_prefix)
+                raw_prefix = parsed_prefix.path or ""
         else:
             raw_prefix = ""
         prefix_segments = _split_path_segments(raw_prefix)


### PR DESCRIPTION
## Summary
- sanitize absolute URLs in `X-Forwarded-Prefix` before building OpenAPI server entries
- add a regression test that covers the absolute forwarded prefix scenario

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f3a45f7aa88323bed15f389c575f1f