### PR TITLE
Fix Swagger UI spec URL to honor forwarded prefixes

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from webapp.api.openapi import openapi_spec
+from webapp.api.openapi import openapi_spec, swagger_ui
 
 
 @pytest.mark.usefixtures('app_context')
@@ -100,3 +100,14 @@ class TestOpenAPIDocs:
         html = response.get_data(as_text=True)
         assert 'SwaggerUIBundle' in html
         assert 'http://localhost/api/openapi.json' in html
+
+    def test_swagger_ui_respects_forwarded_prefix(self, app_context):
+        with app_context.test_request_context(
+            '/api/docs',
+            base_url='http://localhost/app',
+            headers={'X-Forwarded-Prefix': '/proxy'},
+        ):
+            html = swagger_ui()
+        if not isinstance(html, str):
+            html = html.get_data(as_text=True)
+        assert 'http://localhost/proxy/app/api/openapi.json' in html

--- a/webapp/api/openapi.py
+++ b/webapp/api/openapi.py
@@ -321,5 +321,11 @@ def swagger_ui():
     else:
         base_url = request.url_root.rstrip("/")
     spec_path = url_for("api.openapi_spec", _external=False)
-    spec_url = urljoin(base_url + "/", spec_path)
+    script_root = request.script_root.rstrip("/")
+    if script_root and spec_path.startswith(script_root):
+        spec_path = spec_path[len(script_root) :]
+    if _API_BLUEPRINT_PREFIX and spec_path.startswith(_API_BLUEPRINT_PREFIX):
+        spec_path = spec_path[len(_API_BLUEPRINT_PREFIX) :]
+    spec_path = spec_path.lstrip("/")
+    spec_url = urljoin(base_url.rstrip("/") + "/", spec_path)
     return render_template("swagger_ui.html", spec_url=spec_url)


### PR DESCRIPTION
## Summary
- normalize the Swagger UI spec path against the script root and blueprint prefix so proxy prefixes remain intact
- cover the regression with a Swagger UI test that exercises an X-Forwarded-Prefix deployment

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f3be22c5fc8323ad23106eb7b59933