### PR TITLE
Fix Swagger UI server dropdown sanitization

### DIFF
--- a/flask_smorest/spec/templates/swagger_ui.html
+++ b/flask_smorest/spec/templates/swagger_ui.html
@@ -23,11 +23,13 @@
      var override_config = {{ swagger_ui_config | tojson }};
      for (var attrname in override_config) { config[attrname] = override_config[attrname]; }
 
-     const initialServers = {{ servers | tojson }};
-     window.__INITIAL_OPENAPI_SERVERS__ = initialServers;
+    const initialServers = {{ servers | tojson }};
+    window.__INITIAL_OPENAPI_SERVERS__ = initialServers;
 
-     function sanitizeServerOptions() {
-       var selectElements = document.querySelectorAll('select[aria-label="Servers"]');
+    const SERVER_DROPDOWN_SELECTORS = 'select[aria-label="Servers"], select#servers';
+
+    function sanitizeServerOptions() {
+      var selectElements = document.querySelectorAll(SERVER_DROPDOWN_SELECTORS);
        if (!selectElements || selectElements.length === 0) {
          return;
        }
@@ -75,7 +77,7 @@
        });
      }
 
-     function observeServerDropdown() {
+    function observeServerDropdown() {
        if (typeof MutationObserver === 'undefined') {
          return;
        }
@@ -84,8 +86,8 @@
          sanitizeServerOptions();
        });
 
-       function connectObserver() {
-         var select = document.querySelector('select[aria-label="Servers"]');
+      function connectObserver() {
+        var select = document.querySelector(SERVER_DROPDOWN_SELECTORS);
          if (!select) {
            setTimeout(connectObserver, 100);
            return;


### PR DESCRIPTION
## Summary
- update the Swagger UI template to normalize server dropdown selectors including the legacy #servers id
- keep the sanitization routine active by using the shared selector constant in both the observer and sanitizer
- extend the OpenAPI docs tests to assert the selector constant and verify sanitized option values even when js2py is unavailable

## Testing
- pytest tests/test_openapi_docs.py --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68f49b888b10832394c5d631709d7e7b