### PR TITLE
Stabilize API auth fixtures and expose webapp.auth

### DIFF
--- a/flask_smorest/spec/templates/swagger_ui.html
+++ b/flask_smorest/spec/templates/swagger_ui.html
@@ -23,11 +23,13 @@
      var override_config = {{ swagger_ui_config | tojson }};
      for (var attrname in override_config) { config[attrname] = override_config[attrname]; }
 
-     const initialServers = {{ servers | tojson }};
-     window.__INITIAL_OPENAPI_SERVERS__ = initialServers;
+    const initialServers = {{ servers | tojson }};
+    window.__INITIAL_OPENAPI_SERVERS__ = initialServers;
 
-     function sanitizeServerOptions() {
-       var selectElements = document.querySelectorAll('select[aria-label="Servers"]');
+    const SERVER_DROPDOWN_SELECTORS = 'select[aria-label="Servers"], select#servers';
+
+    function sanitizeServerOptions() {
+      var selectElements = document.querySelectorAll(SERVER_DROPDOWN_SELECTORS);
        if (!selectElements || selectElements.length === 0) {
          return;
        }
@@ -75,7 +77,7 @@
        });
      }
 
-     function observeServerDropdown() {
+    function observeServerDropdown() {
        if (typeof MutationObserver === 'undefined') {
          return;
        }
@@ -84,8 +86,8 @@
          sanitizeServerOptions();
        });
 
-       function connectObserver() {
-         var select = document.querySelector('select[aria-label="Servers"]');
+      function connectObserver() {
+        var select = document.querySelector(SERVER_DROPDOWN_SELECTORS);
          if (!select) {
            setTimeout(connectObserver, 100);
            return;

--- a/tests/test_api_login_scope.py
+++ b/tests/test_api_login_scope.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import uuid
 
@@ -23,7 +24,10 @@ def app(tmp_path):
         original_env[key] = os.environ.get(key)
         os.environ[key] = value
 
-    from webapp.config import Config
+    import webapp.config as config_module
+
+    config_module = importlib.reload(config_module)
+    Config = config_module.Config
 
     Config.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app

--- a/tests/test_api_login_totp.py
+++ b/tests/test_api_login_totp.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import uuid
 
@@ -20,7 +21,10 @@ def app(tmp_path):
         original_env[key] = os.environ.get(key)
         os.environ[key] = value
 
-    from webapp.config import Config
+    import webapp.config as config_module
+
+    config_module = importlib.reload(config_module)
+    Config = config_module.Config
 
     Config.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app

--- a/tests/test_api_totp_management.py
+++ b/tests/test_api_totp_management.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import uuid
 
@@ -19,7 +20,10 @@ def app(tmp_path):
         original_env[key] = os.environ.get(key)
         os.environ[key] = value
 
-    from webapp.config import Config
+    import webapp.config as config_module
+
+    config_module = importlib.reload(config_module)
+    Config = config_module.Config
 
     Config.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -47,6 +47,7 @@ def app():
             'FPV_NAS_ORIGINALS_DIR': str(originals_dir),
             'FPV_TMP_DIR': str(temp_dir),
             'SQLALCHEMY_ENGINE_OPTIONS': {},
+            'BABEL_DEFAULT_LOCALE': 'en',
         }
         
         # 環境変数を一時的に設定

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1135,5 +1135,9 @@ def __getattr__(name: str):
         module = importlib.import_module("webapp.api")
         globals()[name] = module
         return module
+    if name == "auth":
+        module = importlib.import_module("webapp.auth")
+        globals()[name] = module
+        return module
     raise AttributeError(f"module 'webapp' has no attribute {name!r}")
 


### PR DESCRIPTION
## Summary
- reload the `webapp.config` module in the API login and TOTP fixtures so per-test secrets take effect
- set the local import UI fixture locale to English so the expected strings appear in rendered HTML
- lazily expose `webapp.auth` from `webapp.__getattr__` to support service account JWT tests

## Testing
- pytest tests/test_api_login_scope.py tests/test_api_login_totp.py tests/test_api_totp_management.py tests/test_local_import_ui.py tests/test_service_account_jwt.py tests/test_openapi_docs.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f49b888b10832394c5d631709d7e7b