### PR TITLE
Ensure Swagger UI template receives context data

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -50,6 +50,8 @@ class TestOpenAPIDocs:
         assert '#servers' in selectors_literal
         assert 'SwaggerUIBundle' in html
         assert 'url: "/api/openapi.json"' in html
+        assert '<link rel="icon" type="image/x-icon" href="/static/favicon.ico">' in html
+        assert 'Version:' in html
 
     def test_openapi_spec_respects_forwarded_headers(self, app_context):
         client = app_context.test_client()


### PR DESCRIPTION
## Summary
- ensure the Swagger UI renderer forwards context processor values so globally injected variables like `app_version` are available
- extend the docs smoke test to assert the favicon link and version text are rendered

## Testing
- pytest tests/test_openapi_docs.py::TestOpenAPIDocs::test_swagger_ui_served

------
https://chatgpt.com/codex/tasks/task_e_68f4a4c13bc08323830a919a66576faa