### PR TITLE
Fix create API key modal layout for scrollability

### DIFF
--- a/webapp/admin/templates/admin/service_account_api_keys.html
+++ b/webapp/admin/templates/admin/service_account_api_keys.html
@@ -190,8 +190,8 @@
         <h5 class="modal-title">{{ _('Issue API Key') }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
       </div>
-      <form id="create-api-key-form" class="needs-validation" novalidate>
-        <div class="modal-body">
+      <div class="modal-body">
+        <form id="create-api-key-form" class="needs-validation" novalidate>
           <div class="mb-3">
             <label class="form-label">{{ _('Select scopes for this API key') }}</label>
             <p class="text-muted small mb-3">{{ _('Only scopes already granted to the service account can be chosen.') }}</p>
@@ -208,15 +208,15 @@
             <div class="invalid-feedback" id="create-api-key-expires-error"></div>
           </div>
           <div class="alert alert-danger d-none" id="create-api-key-error"></div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
-          <button type="submit" class="btn btn-primary" id="create-api-key-submit">
-            <i class="bi bi-check-circle me-1"></i>
-            {{ _('Issue API Key') }}
-          </button>
-        </div>
-      </form>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
+        <button type="submit" class="btn btn-primary" id="create-api-key-submit" form="create-api-key-form">
+          <i class="bi bi-check-circle me-1"></i>
+          {{ _('Issue API Key') }}
+        </button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- move the create API key form into the modal body so the dialog can scroll
- keep the submit button in the modal footer by targeting the relocated form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4b193d07c832396d30cdfafb2497c