### PR TITLE
Add select-all for filtered permissions on role edit page

### DIFF
--- a/webapp/admin/templates/admin/role_edit.html
+++ b/webapp/admin/templates/admin/role_edit.html
@@ -83,15 +83,20 @@
                   <h2 class="h5 mb-0">{{ _('Permissions') }}</h2>
                   <span class="text-muted small">{{ _('Select the capabilities that should be included in this role.') }}</span>
                 </div>
-                <div class="permission-search input-group">
-                  <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
-                  <input
-                    type="search"
-                    id="permission-filter"
-                    class="form-control"
-                    placeholder="{{ _('Search permissions...') }}"
-                    aria-label="{{ _('Search permissions') }}"
-                  >
+                <div class="d-flex flex-column flex-md-row gap-2 align-items-stretch">
+                  <div class="permission-search input-group">
+                    <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
+                    <input
+                      type="search"
+                      id="permission-filter"
+                      class="form-control"
+                      placeholder="{{ _('Search permissions...') }}"
+                      aria-label="{{ _('Search permissions') }}"
+                    >
+                  </div>
+                  <button type="button" id="select-visible-permissions" class="btn btn-outline-primary">
+                    <i class="fas fa-check-double me-1"></i>{{ _('Select all shown permissions') }}
+                  </button>
                 </div>
               </div>
             </div>
@@ -154,6 +159,7 @@
     const permissionItems = Array.from(document.querySelectorAll('.permission-item-wrapper'));
     const countElement = document.getElementById('selected-permission-count');
     const noResults = document.getElementById('no-permission-results');
+    const selectVisibleButton = document.getElementById('select-visible-permissions');
 
     function updateCount() {
       const selectedCount = permissionItems.filter((item) => {
@@ -163,6 +169,22 @@
 
       if (countElement) {
         countElement.textContent = selectedCount;
+      }
+    }
+
+    function selectVisiblePermissions() {
+      let changed = false;
+      permissionItems.forEach((wrapper) => {
+        const checkbox = wrapper.querySelector('input[type="checkbox"]');
+        const isVisible = wrapper.style.display !== 'none';
+        if (checkbox && isVisible && !checkbox.checked) {
+          checkbox.checked = true;
+          changed = true;
+        }
+      });
+
+      if (changed) {
+        updateCount();
       }
     }
 
@@ -183,6 +205,10 @@
       if (noResults) {
         noResults.style.display = visible === 0 ? 'block' : 'none';
       }
+
+      if (selectVisibleButton) {
+        selectVisibleButton.disabled = visible === 0;
+      }
     }
 
     permissionItems.forEach((wrapper) => {
@@ -198,6 +224,11 @@
       });
     }
 
+    if (selectVisibleButton) {
+      selectVisibleButton.addEventListener('click', selectVisiblePermissions);
+    }
+
+    filterPermissions(permissionFilter ? permissionFilter.value : '');
     updateCount();
   });
 </script>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1055,6 +1055,9 @@ msgstr "Usage Type"
 msgid "Select usage type"
 msgstr "Select usage type"
 
+msgid "Select all shown permissions"
+msgstr "Select all shown permissions"
+
 msgid "Key Size"
 msgstr "Key Size"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -3009,6 +3009,9 @@ msgstr "用途タイプ"
 msgid "Select usage type"
 msgstr "用途タイプを選択"
 
+msgid "Select all shown permissions"
+msgstr "表示されている権限をすべて選択"
+
 msgid "Key Size"
 msgstr "鍵長"
 


### PR DESCRIPTION
## Summary
- add a button to select all permissions currently shown by the filter on the role edit screen
- hook the new control into the client-side filtering logic so the button is disabled when no results are visible and updates the selection counter
- add English and Japanese translation strings for the new action label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4d514d9cc832397fbb1bba85e35d9