### PR TITLE
Add token_type to access token API responses

### DIFF
--- a/tests/test_api_refresh_token.py
+++ b/tests/test_api_refresh_token.py
@@ -44,6 +44,7 @@ def login(client, app, *, token: str | None = None):
     data = res.get_json()
     assert data["requires_role_selection"] is False
     assert data["scope"] == ""
+    assert data["token_type"] == "Bearer"
     return data["access_token"], data["refresh_token"]
 
 
@@ -61,6 +62,7 @@ def test_refresh_works(client, app):
     assert data["access_token"] != old_access
     assert data["refresh_token"] != refresh
     assert data["scope"] == ""
+    assert data["token_type"] == "Bearer"
 
 
 def test_refresh_invalid_token(client, app):

--- a/tests/test_auth_role_selection.py
+++ b/tests/test_auth_role_selection.py
@@ -172,6 +172,7 @@ def test_api_login_requires_role_selection(client, app):
     assert data["requires_role_selection"] is True
     assert data["redirect_url"].endswith("/auth/select-role")
     assert "access_token" in data and "refresh_token" in data
+    assert data["token_type"] == "Bearer"
 
     with client.session_transaction() as sess:
         assert sess.get("role_selection_next") == "/dashboard/library"

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -32,6 +32,7 @@ class TestOpenAPIDocs:
         login_response = payload['components']['schemas']['LoginResponse']
         assert 'requires_role_selection' in login_response['properties']
         assert 'available_scopes' in login_response['properties']
+        assert login_response['properties']['token_type']['type'] == 'string'
 
     def test_swagger_ui_served(self, app_context):
         client = app_context.test_client()

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1526,6 +1526,7 @@ def api_login(data):
         response_payload = {
             "access_token": access_token,
             "refresh_token": refresh_token,
+            "token_type": "Bearer",
             "requires_role_selection": True,
             "redirect_url": url_for("auth.select_role"),
             "scope": scope_str,
@@ -1536,6 +1537,7 @@ def api_login(data):
         response_payload = {
             "access_token": access_token,
             "refresh_token": refresh_token,
+            "token_type": "Bearer",
             "requires_role_selection": False,
             "redirect_url": redirect_target,
             "scope": scope_str,
@@ -1589,6 +1591,7 @@ def api_refresh(data):
     resp = jsonify({
         "access_token": access_token,
         "refresh_token": new_refresh_token,
+        "token_type": "Bearer",
         "scope": scope_str,
     })
     resp.set_cookie(

--- a/webapp/api/schemas/auth.py
+++ b/webapp/api/schemas/auth.py
@@ -74,6 +74,7 @@ class LoginRequestSchema(Schema):
 class LoginResponseSchema(Schema):
     access_token = fields.String(required=True)
     refresh_token = fields.String(required=True)
+    token_type = fields.String(required=True, metadata={"description": "アクセストークンの種別"})
     requires_role_selection = fields.Boolean(required=True)
     redirect_url = fields.String(required=True)
     scope = fields.String(required=True)
@@ -92,6 +93,7 @@ class RefreshRequestSchema(Schema):
 class RefreshResponseSchema(Schema):
     access_token = fields.String(required=True)
     refresh_token = fields.String(required=True)
+    token_type = fields.String(required=True, metadata={"description": "アクセストークンの種別"})
     scope = fields.String(required=True)
 
 


### PR DESCRIPTION
## Summary
- include the `token_type` field in login and refresh API responses
- expose the new field via the authentication response schema
- adjust tests to cover the Bearer token type and OpenAPI schema

## Testing
- pytest tests/test_api_refresh_token.py tests/test_auth_role_selection.py tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f4daf084f483239a509ca893e988a5