### PR TITLE
Add Redis-backed jti replay protection for service account JWTs

### DIFF
--- a/webapp/auth/service_account_auth.py
+++ b/webapp/auth/service_account_auth.py
@@ -86,12 +86,12 @@ class _ServiceAccountJTIStore:
         client = cls._get_client()
 
         try:
-            if client.exists(key):
+            stored = client.set(key, "used", ex=ttl_seconds, nx=True)
+            if not stored:
                 raise ServiceAccountJWTError(
                     "ReplayDetected",
                     _("The token has already been used."),
                 )
-            client.setex(key, ttl_seconds, "used")
         except RedisError as exc:
             raise ServiceAccountJWTError(
                 "JTICheckFailed",


### PR DESCRIPTION
## Summary
- require service account JWTs to include a UUID `jti` claim and validate it during verification
- record JWT identifiers in Redis with a capped TTL to prevent replay attacks on `/api/login`
- expand the service account JWT tests with an in-memory Redis stub covering missing, invalid, and reused tokens

## Testing
- pytest tests/test_service_account_jwt.py

------
https://chatgpt.com/codex/tasks/task_e_68f4dcbd62cc83238c7b64522f41a1da