### PR TITLE
Adjust layout of permission filters in role editor

### DIFF
--- a/webapp/admin/templates/admin/role_edit.html
+++ b/webapp/admin/templates/admin/role_edit.html
@@ -83,7 +83,7 @@
                   <h2 class="h5 mb-0">{{ _('Permissions') }}</h2>
                   <span class="text-muted small">{{ _('Select the capabilities that should be included in this role.') }}</span>
                 </div>
-                <div class="d-flex flex-column flex-md-row gap-2 align-items-stretch">
+                <div class="d-flex flex-column gap-2 align-items-stretch">
                   <div class="permission-search input-group">
                     <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
                     <input


### PR DESCRIPTION
## Summary
- stack the permission search input and bulk-select button vertically on the role edit page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4e263ea188323916f09b7f0dd7bc0