### PR TITLE
Restore environment fallbacks for configuration secrets

### DIFF
--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from types import ModuleType
@@ -9,43 +10,75 @@ from core.system_settings_defaults import DEFAULT_APPLICATION_SETTINGS
 load_dotenv()
 
 
-def _default(name: str):
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def _coerce_env_value(name: str, raw: str):
+    default = DEFAULT_APPLICATION_SETTINGS.get(name)
+
+    if isinstance(default, bool):
+        return raw.lower() in _TRUTHY_VALUES
+    if isinstance(default, int) and not isinstance(default, bool):
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+    if isinstance(default, float):
+        try:
+            return float(raw)
+        except ValueError:
+            return default
+    if isinstance(default, (list, dict)):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return default
+
+    return raw
+
+
+def _setting(name: str, *, env_name: str | None = None):
+    env_key = env_name or name
+    if env_key:
+        raw = os.environ.get(env_key)
+        if raw is not None:
+            return _coerce_env_value(name, raw)
     return DEFAULT_APPLICATION_SETTINGS.get(name)
 
 
 class Config:
     """Base configuration populated from persisted system settings."""
 
-    SECRET_KEY = _default("SECRET_KEY")
-    JWT_SECRET_KEY = _default("JWT_SECRET_KEY")
-    ACCESS_TOKEN_ISSUER = _default("ACCESS_TOKEN_ISSUER")
-    ACCESS_TOKEN_AUDIENCE = _default("ACCESS_TOKEN_AUDIENCE")
+    SECRET_KEY = _setting("SECRET_KEY")
+    JWT_SECRET_KEY = _setting("JWT_SECRET_KEY")
+    ACCESS_TOKEN_ISSUER = _setting("ACCESS_TOKEN_ISSUER")
+    ACCESS_TOKEN_AUDIENCE = _setting("ACCESS_TOKEN_AUDIENCE")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     db_uri = os.environ.get("DATABASE_URI", "sqlite://")
     SQLALCHEMY_DATABASE_URI = db_uri
 
     # Session settings
-    PERMANENT_SESSION_LIFETIME = _default("PERMANENT_SESSION_LIFETIME")
-    SESSION_COOKIE_SECURE = _default("SESSION_COOKIE_SECURE")
-    SESSION_COOKIE_HTTPONLY = _default("SESSION_COOKIE_HTTPONLY")
-    SESSION_COOKIE_SAMESITE = _default("SESSION_COOKIE_SAMESITE")
+    PERMANENT_SESSION_LIFETIME = _setting("PERMANENT_SESSION_LIFETIME")
+    SESSION_COOKIE_SECURE = _setting("SESSION_COOKIE_SECURE")
+    SESSION_COOKIE_HTTPONLY = _setting("SESSION_COOKIE_HTTPONLY")
+    SESSION_COOKIE_SAMESITE = _setting("SESSION_COOKIE_SAMESITE")
 
     # URL generation and external services
-    PREFERRED_URL_SCHEME = _default("PREFERRED_URL_SCHEME")
-    CERTS_API_TIMEOUT = _default("CERTS_API_TIMEOUT")
+    PREFERRED_URL_SCHEME = _setting("PREFERRED_URL_SCHEME")
+    CERTS_API_TIMEOUT = _setting("CERTS_API_TIMEOUT")
 
     SQLALCHEMY_BINDS = {}
-    dashboard_db = _default("DASHBOARD_DB_URI")
+    dashboard_db = _setting("DASHBOARD_DB_URI")
     if dashboard_db:
         SQLALCHEMY_BINDS["dashboard"] = dashboard_db
 
     # Internationalisation
-    LANGUAGES = list(_default("LANGUAGES") or ["ja", "en"])
+    LANGUAGES = list(_setting("LANGUAGES") or ["ja", "en"])
     BABEL_TRANSLATION_DIRECTORIES = os.path.join(
         os.path.dirname(__file__), "translations"
     )
-    BABEL_DEFAULT_LOCALE = _default("BABEL_DEFAULT_LOCALE")
-    BABEL_DEFAULT_TIMEZONE = _default("BABEL_DEFAULT_TIMEZONE")
+    BABEL_DEFAULT_LOCALE = _setting("BABEL_DEFAULT_LOCALE")
+    BABEL_DEFAULT_TIMEZONE = _setting("BABEL_DEFAULT_TIMEZONE")
 
     # Database stability
     SQLALCHEMY_ENGINE_OPTIONS = {
@@ -62,36 +95,36 @@ class Config:
             SQLALCHEMY_ENGINE_OPTIONS["connect_args"] = {"connect_timeout": 10}
 
     # Google OAuth
-    GOOGLE_CLIENT_ID = _default("GOOGLE_CLIENT_ID")
-    GOOGLE_CLIENT_SECRET = _default("GOOGLE_CLIENT_SECRET")
+    GOOGLE_CLIENT_ID = _setting("GOOGLE_CLIENT_ID")
+    GOOGLE_CLIENT_SECRET = _setting("GOOGLE_CLIENT_SECRET")
 
     # Encryption for OAuth tokens
-    OAUTH_TOKEN_KEY = _default("OAUTH_TOKEN_KEY")
-    OAUTH_TOKEN_KEY_FILE = _default("OAUTH_TOKEN_KEY_FILE")
+    OAUTH_TOKEN_KEY = _setting("OAUTH_TOKEN_KEY")
+    OAUTH_TOKEN_KEY_FILE = _setting("OAUTH_TOKEN_KEY_FILE")
 
     # Download URL signing
-    FPV_DL_SIGN_KEY = _default("FPV_DL_SIGN_KEY")
-    FPV_URL_TTL_THUMB = _default("FPV_URL_TTL_THUMB")
-    FPV_URL_TTL_PLAYBACK = _default("FPV_URL_TTL_PLAYBACK")
-    FPV_URL_TTL_ORIGINAL = _default("FPV_URL_TTL_ORIGINAL")
-    UPLOAD_TMP_DIR = _default("UPLOAD_TMP_DIR")
-    UPLOAD_DESTINATION_DIR = _default("UPLOAD_DESTINATION_DIR")
-    UPLOAD_MAX_SIZE = _default("UPLOAD_MAX_SIZE")
-    WIKI_UPLOAD_DIR = _default("WIKI_UPLOAD_DIR")
-    FPV_NAS_THUMBS_DIR = _default("FPV_NAS_THUMBS_DIR")
-    FPV_NAS_PLAY_DIR = _default("FPV_NAS_PLAY_DIR")
-    FPV_ACCEL_THUMBS_LOCATION = _default("FPV_ACCEL_THUMBS_LOCATION")
-    FPV_ACCEL_PLAYBACK_LOCATION = _default("FPV_ACCEL_PLAYBACK_LOCATION")
-    FPV_ACCEL_ORIGINALS_LOCATION = _default("FPV_ACCEL_ORIGINALS_LOCATION")
-    FPV_ACCEL_REDIRECT_ENABLED = _default("FPV_ACCEL_REDIRECT_ENABLED")
+    FPV_DL_SIGN_KEY = _setting("FPV_DL_SIGN_KEY")
+    FPV_URL_TTL_THUMB = _setting("FPV_URL_TTL_THUMB")
+    FPV_URL_TTL_PLAYBACK = _setting("FPV_URL_TTL_PLAYBACK")
+    FPV_URL_TTL_ORIGINAL = _setting("FPV_URL_TTL_ORIGINAL")
+    UPLOAD_TMP_DIR = _setting("UPLOAD_TMP_DIR")
+    UPLOAD_DESTINATION_DIR = _setting("UPLOAD_DESTINATION_DIR")
+    UPLOAD_MAX_SIZE = _setting("UPLOAD_MAX_SIZE")
+    WIKI_UPLOAD_DIR = _setting("WIKI_UPLOAD_DIR")
+    FPV_NAS_THUMBS_DIR = _setting("FPV_NAS_THUMBS_DIR")
+    FPV_NAS_PLAY_DIR = _setting("FPV_NAS_PLAY_DIR")
+    FPV_ACCEL_THUMBS_LOCATION = _setting("FPV_ACCEL_THUMBS_LOCATION")
+    FPV_ACCEL_PLAYBACK_LOCATION = _setting("FPV_ACCEL_PLAYBACK_LOCATION")
+    FPV_ACCEL_ORIGINALS_LOCATION = _setting("FPV_ACCEL_ORIGINALS_LOCATION")
+    FPV_ACCEL_REDIRECT_ENABLED = _setting("FPV_ACCEL_REDIRECT_ENABLED")
 
     # Local import settings
-    LOCAL_IMPORT_DIR = _default("LOCAL_IMPORT_DIR")
-    FPV_NAS_ORIGINALS_DIR = _default("FPV_NAS_ORIGINALS_DIR")
+    LOCAL_IMPORT_DIR = _setting("LOCAL_IMPORT_DIR")
+    FPV_NAS_ORIGINALS_DIR = _setting("FPV_NAS_ORIGINALS_DIR")
 
     # Celery settings
-    broker_url = _default("CELERY_BROKER_URL")
-    result_backend = _default("CELERY_RESULT_BACKEND")
+    broker_url = _setting("CELERY_BROKER_URL")
+    result_backend = _setting("CELERY_RESULT_BACKEND")
     task_serializer = "json"
     result_serializer = "json"
     accept_content = ["json"]


### PR DESCRIPTION
## Summary
- add environment-variable fallbacks for configuration values while continuing to support persisted defaults
- coerce common data types when reading overrides to keep settings compatible with existing usage

## Testing
- pytest tests/test_celery_app.py::TestFlaskAppCreation::test_create_app_function -q

------
https://chatgpt.com/codex/tasks/task_e_68f58b811fbc8323b898bceea3d02652