### PR TITLE
Remove unused AES_KEY configuration references

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ print(f'OAUTH_TOKEN_KEY=base64:{key}')
 ```env
 # セキュリティキー（必ず変更）
 SECRET_KEY=<your-strong-secret-key>
-AES_KEY=<your-32-byte-encryption-key>
 
 # データベース接続
 DATABASE_URI=mysql+pymysql://<user>:<pass>@<host>/<db>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     environment:
       - FLASK_ENV=production
       - SECRET_KEY=${SECRET_KEY}
-      - AES_KEY=${AES_KEY}
       - TZ=${TZ:-Asia/Tokyo}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
@@ -59,7 +58,6 @@ services:
     environment:
       - FLASK_ENV=production
       - SECRET_KEY=${SECRET_KEY}
-      - AES_KEY=${AES_KEY}
       - TZ=${TZ:-Asia/Tokyo}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
@@ -102,7 +100,6 @@ services:
     environment:
       - FLASK_ENV=production
       - SECRET_KEY=${SECRET_KEY}
-      - AES_KEY=${AES_KEY}
       - TZ=${TZ:-Asia/Tokyo}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,7 +154,6 @@ nano .env
 
 **必須変更項目:**
 - `SECRET_KEY`: 強力なランダム文字列
-- `AES_KEY`: 32バイトのランダムキー
 - `DB_ROOT_PASSWORD`: MariaDBのrootパスワード
 - `DB_PASSWORD`: アプリケーション用DBパスワード
 - `GOOGLE_CLIENT_ID`: Google OAuth設定

--- a/docs/synology-deployment.md
+++ b/docs/synology-deployment.md
@@ -104,7 +104,6 @@ Synology上で`/volume1/docker/photonest/.env`ファイルを作成します。
 ```env
 # 必ず変更が必要な項目
 SECRET_KEY=<your-very-strong-secret-key-here-change-this-immediately>
-AES_KEY=<your-32-byte-aes-encryption-key-change-this-now>
 JWT_SECRET_KEY=<your-jwt-secret-key-here>
 
 # 外部データベース設定（Synology MariaDB または別サーバー）


### PR DESCRIPTION
## Summary
- remove AES_KEY environment variable guidance from documentation
- drop AES_KEY environment entries from docker-compose configuration now that it is unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f59c08e0c8832399159f43138a6603