### PR TITLE
Ensure updated CORS settings apply immediately

### DIFF
--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -147,6 +147,11 @@ def test_update_cors_config_success(client):
     html = response.data.decode("utf-8")
     assert "CORS allowed origins updated." in html
 
+    assert client.application.config["CORS_ALLOWED_ORIGINS"] == (
+        "https://admin.example.com",
+        "https://app.example.com",
+    )
+
     config = SystemSettingService.load_cors_config()
     assert config["allowedOrigins"] == [
         "https://admin.example.com",

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -607,6 +607,9 @@ def show_config():
                         flash(message, "danger")
                 else:
                     SystemSettingService.update_cors_settings(updates, remove_keys=remove_keys)
+                    from webapp import _apply_persisted_settings
+
+                    _apply_persisted_settings(current_app)
                     flash(_(u"CORS allowed origins updated."), "success")
                     return redirect(url_for("admin.show_config"))
 


### PR DESCRIPTION
## Summary
- refresh persisted settings after updating the admin CORS configuration so newly allowed origins are applied without restarting the app
- extend the admin configuration test to verify the Flask CORS settings are reloaded after a successful update

## Testing
- pytest tests/test_admin_config.py::test_update_cors_config_success

------
https://chatgpt.com/codex/tasks/task_e_68f5a2b8002083239165962eeb555e13