### PR TITLE
Fix admin config form submission URL resolution

### DIFF
--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -244,7 +244,11 @@
 
       try {
         const formData = new FormData(form);
-        const response = await fetch(form.action || window.location.href, {
+        const actionAttribute = form.getAttribute('action');
+        const requestUrl = actionAttribute
+          ? new URL(actionAttribute, window.location.href).toString()
+          : window.location.href;
+        const response = await fetch(requestUrl, {
           method: form.method || 'POST',
           headers: {
             'X-Requested-With': 'XMLHttpRequest',


### PR DESCRIPTION
## Summary
- ensure the admin config AJAX submission resolves the form action attribute to a proper URL before sending the request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5ad023a84832394f536b99e55f4e3