### PR TITLE
Fix escaping in OpenAPI server URLs

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -81,7 +81,7 @@ _SANITIZE_SERVER_URL_PATTERN = re.compile(r"\\([:/])")
 def _sanitize_openapi_server_url(url: Optional[str]) -> str:
     if not url:
         return ""
-    return _SANITIZE_SERVER_URL_PATTERN.sub(r"\\1", url)
+    return _SANITIZE_SERVER_URL_PATTERN.sub(r"\1", url)
 
 
 def _is_sensitive_key(key):


### PR DESCRIPTION
## Summary
- sanitize OpenAPI server URLs to remove stray backslash escapes
- ensure deduplication uses sanitized URLs to keep the Swagger UI server list clean

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f5d453b088832390e8b97c8f9f52cf