### PR TITLE
Enforce explicit API auth decorators

### DIFF
--- a/tests/test_api_auth_enforcement.py
+++ b/tests/test_api_auth_enforcement.py
@@ -1,0 +1,58 @@
+from flask import Flask
+import pytest
+
+from flask import Flask
+import pytest
+
+from webapp.api.blueprint import AuthEnforcedBlueprint
+from webapp.api.health import skip_auth
+from webapp.api.routes import login_or_jwt_required
+from webapp.auth.service_account_auth import require_service_account_scopes
+
+
+def _register_routes(blueprint):
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+
+
+def test_route_registration_requires_auth_decorator():
+    bp = AuthEnforcedBlueprint("test", __name__)
+
+    with pytest.raises(RuntimeError):
+
+        @bp.get("/forbidden")
+        def forbidden_route():
+            return "nope"
+
+
+def test_route_registration_allows_skip_auth():
+    bp = AuthEnforcedBlueprint("test", __name__)
+
+    @bp.get("/health")
+    @skip_auth
+    def health_route():
+        return "ok"
+
+    _register_routes(bp)
+
+
+def test_route_registration_allows_login_or_jwt_required():
+    bp = AuthEnforcedBlueprint("test", __name__)
+
+    @bp.get("/secure")
+    @login_or_jwt_required
+    def secure_route():
+        return "ok"
+
+    _register_routes(bp)
+
+
+def test_route_registration_allows_service_account_auth():
+    bp = AuthEnforcedBlueprint("test", __name__)
+
+    @bp.get("/maintenance")
+    @require_service_account_scopes(["maintenance:read"], audience=lambda _: "test")
+    def maintenance_route():
+        return "ok"
+
+    _register_routes(bp)

--- a/webapp/api/__init__.py
+++ b/webapp/api/__init__.py
@@ -1,6 +1,6 @@
-from flask_smorest import Blueprint
+from .blueprint import AuthEnforcedBlueprint
 
-bp = Blueprint("api", __name__, description="nolumia API")
+bp = AuthEnforcedBlueprint("api", __name__, description="nolumia API")
 
 from . import routes  # noqa: E402,F401
 from . import health  # noqa: E402,F401

--- a/webapp/api/blueprint.py
+++ b/webapp/api/blueprint.py
@@ -1,0 +1,86 @@
+"""Blueprint utilities for API authentication enforcement."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+import inspect
+from typing import Callable
+
+from flask.views import MethodView
+from flask_smorest import Blueprint as SmorestBlueprint
+
+
+def _iter_wrapped(callable_obj: Callable) -> Iterable[Callable]:
+    """Yield the callable and all wrappers referenced via ``__wrapped__``."""
+
+    current = callable_obj
+    seen: set[Callable] = set()
+    while current and current not in seen:
+        yield current
+        seen.add(current)
+        current = getattr(current, "__wrapped__", None)
+
+
+def _has_auth_marker(func: Callable) -> bool:
+    """Return ``True`` if the callable declares an authentication marker."""
+
+    for candidate in _iter_wrapped(func):
+        if getattr(candidate, "_skip_auth", False):
+            return True
+        if getattr(candidate, "_auth_enforced", False):
+            return True
+    return False
+
+
+class AuthEnforcedBlueprint(SmorestBlueprint):
+    """Blueprint that rejects routes without explicit auth configuration."""
+
+    def add_url_rule(  # type: ignore[override]
+        self,
+        rule,
+        endpoint=None,
+        view_func=None,
+        provide_automatic_options=None,
+        *,
+        parameters=None,
+        tags=None,
+        **options,
+    ):
+        if view_func is None:
+            raise TypeError("view_func must be provided")
+
+        self._ensure_authentication_marker(rule, endpoint, view_func)
+
+        return super().add_url_rule(  # pragma: no cover - exercised via decorators
+            rule,
+            endpoint=endpoint,
+            view_func=view_func,
+            provide_automatic_options=provide_automatic_options,
+            parameters=parameters,
+            tags=tags,
+            **options,
+        )
+
+    def _ensure_authentication_marker(self, rule, endpoint, view_func) -> None:
+        """Ensure that the registered view declares an auth strategy."""
+
+        candidates: list[Callable]
+
+        if inspect.isclass(view_func) and issubclass(view_func, MethodView):
+            name = endpoint or view_func.__name__
+            view_callable = view_func.as_view(name)
+            candidates = [view_callable]
+        else:
+            candidates = [view_func]
+
+        for func in candidates:
+            if _has_auth_marker(func):
+                return
+
+        view_name = endpoint or getattr(view_func, "__name__", "<unnamed>")
+        raise RuntimeError(
+            f"API route '{rule}' (endpoint '{view_name}') must declare an authentication decorator."
+        )
+
+
+__all__ = ["AuthEnforcedBlueprint"]
+

--- a/webapp/api/echo.py
+++ b/webapp/api/echo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from flask import Response, request
 
 from . import bp
+from .routes import login_or_jwt_required
 
 
 def _build_request_target() -> str:
@@ -35,6 +36,7 @@ def _format_request_as_plain_text() -> str:
     "/echo",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 )
+@login_or_jwt_required
 @bp.doc(
     methods=["POST", "PUT", "PATCH"],
     requestBody={

--- a/webapp/api/maintenance.py
+++ b/webapp/api/maintenance.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from flask import jsonify
-from flask_smorest import Blueprint
+from .blueprint import AuthEnforcedBlueprint
 
 from . import bp
 from ..auth.service_account_auth import require_service_account_scopes
 
-maintenance_bp = Blueprint("maintenance_api", __name__, url_prefix="/maintenance")
+maintenance_bp = AuthEnforcedBlueprint(
+    "maintenance_api", __name__, url_prefix="/maintenance"
+)
 
 
 def _default_audience(req) -> str:

--- a/webapp/api/picker_session.py
+++ b/webapp/api/picker_session.py
@@ -29,9 +29,9 @@ from .pagination import PaginationParams, paginate_and_respond
 from .routes import login_or_jwt_required  # JWT認証対応のデコレータをインポート
 from .concurrency import create_limiter, limit_concurrency
 from .openapi import json_request_body
-from flask_smorest import Blueprint
+from .blueprint import AuthEnforcedBlueprint
 
-bp = Blueprint('picker_session_api', __name__)
+bp = AuthEnforcedBlueprint('picker_session_api', __name__)
 
 
 def _json_response(payload, status: int = 200):
@@ -235,6 +235,7 @@ def api_picker_session_create():
 
 
 @bp.post("/picker/session/<path:session_id>/callback")
+@login_or_jwt_required
 @limit_concurrency(_picker_session_callback_limiter)
 @bp.doc(
     methods=["POST"],

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -5,10 +5,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 from flask import jsonify, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 from . import bp
 from .openapi import json_request_body
+from .routes import login_or_jwt_required
 from webapp.services.service_account_api_key_service import (
     ServiceAccountApiKeyNotFoundError,
     ServiceAccountApiKeyService,
@@ -49,7 +50,7 @@ def _has_read_permission() -> bool:
 
 
 @bp.route("/service_accounts/<int:account_id>/keys", methods=["GET"])
-@login_required
+@login_or_jwt_required
 def list_service_account_keys(account_id: int):
     if not _has_read_permission():
         return jsonify({"error": "forbidden"}), 403
@@ -65,7 +66,7 @@ def list_service_account_keys(account_id: int):
 
 
 @bp.route("/service_accounts/<int:account_id>/keys", methods=["POST"])
-@login_required
+@login_or_jwt_required
 @bp.doc(
     methods=["POST"],
     requestBody=json_request_body(
@@ -124,7 +125,7 @@ def create_service_account_key(account_id: int):
     "/service_accounts/<int:account_id>/keys/<int:key_id>/revoke",
     methods=["POST"],
 )
-@login_required
+@login_or_jwt_required
 def revoke_service_account_key(account_id: int, key_id: int):
     if not _has_manage_permission():
         return jsonify({"error": "forbidden"}), 403
@@ -142,7 +143,7 @@ def revoke_service_account_key(account_id: int, key_id: int):
 
 
 @bp.route("/service_accounts/<int:account_id>/keys/logs", methods=["GET"])
-@login_required
+@login_or_jwt_required
 def list_service_account_key_logs(account_id: int):
     if not _has_read_permission():
         return jsonify({"error": "forbidden"}), 403

--- a/webapp/api/version.py
+++ b/webapp/api/version.py
@@ -3,9 +3,11 @@
 """
 from flask import jsonify
 from . import bp
+from .health import skip_auth
 from core.version import get_version_info, get_version_string
 
 @bp.route('/version', methods=['GET'])
+@skip_auth
 def version():
     """バージョン情報を返す"""
     try:

--- a/webapp/auth/api_key_auth.py
+++ b/webapp/auth/api_key_auth.py
@@ -161,6 +161,7 @@ def require_api_key_scopes(scopes: Sequence[str] | None):
         wrapper._apidoc["manual_doc"] = manual_doc
         wrapper._required_api_key_scopes = required_scopes
         wrapper._requires_api_key_authentication = True
+        wrapper._auth_enforced = True
 
         return wrapper
 

--- a/webapp/auth/service_account_auth.py
+++ b/webapp/auth/service_account_auth.py
@@ -350,6 +350,7 @@ def require_service_account_scopes(
             )
             return func(*args, **kwargs)
 
+        wrapper._auth_enforced = True
         return wrapper
 
     return decorator


### PR DESCRIPTION
## Summary
- add an AuthEnforcedBlueprint that rejects route registration without an authentication marker and adopt it across the API packages
- mark auth-related decorators with enforcement metadata and annotate public endpoints with skip_auth or login_or_jwt_required
- cover the blueprint behaviour with unit tests alongside existing auth checks

## Testing
- pytest tests/test_api_auth_enforcement.py tests/test_api_auth_check.py

------
https://chatgpt.com/codex/tasks/task_e_68f6c4733db88323896ee2b89e064310