### PR TITLE
Rename configuration class to BaseApplicationSettings

### DIFF
--- a/cli/src/celery/celery_app.py
+++ b/cli/src/celery/celery_app.py
@@ -13,7 +13,7 @@ from core.models.celery_task import CeleryTaskRecord, CeleryTaskStatus
 from core.models.job_sync import JobSync
 from core.logging_config import log_task_info
 from core.settings import settings
-from webapp.config import Config
+from webapp.config import BaseApplicationSettings
 
 # .envファイルを読み込み
 load_dotenv()
@@ -22,7 +22,7 @@ load_dotenv()
 def create_app():
     """Create and configure Flask app for Celery."""
     app = Flask(__name__)
-    app.config.from_object(Config)
+    app.config.from_object(BaseApplicationSettings)
     
     # Initialize database
     db.init_app(app)

--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -23,7 +23,7 @@ from core.tasks.thumbs_generate import (
     PLAYBACK_NOT_READY_NOTES,
     thumbs_generate as _thumbs_generate,
 )
-from webapp.config import Config
+from webapp.config import BaseApplicationSettings
 
 from features.photonest.application.local_import.file_importer import (
     LocalImportFileImporter,
@@ -1123,12 +1123,12 @@ def local_import_task(task_instance=None, session_id=None) -> Dict:
     try:
         import_dir = _resolve_directory('LOCAL_IMPORT_DIR')
     except RuntimeError:
-        import_dir = Config.LOCAL_IMPORT_DIR
+        import_dir = BaseApplicationSettings.LOCAL_IMPORT_DIR
 
     try:
         originals_dir = _resolve_directory('FPV_NAS_ORIGINALS_DIR')
     except RuntimeError:
-        originals_dir = Config.FPV_NAS_ORIGINALS_DIR
+        originals_dir = BaseApplicationSettings.FPV_NAS_ORIGINALS_DIR
 
     celery_task_id = None
     if task_instance is not None:

--- a/features/wiki/application/use_cases.py
+++ b/features/wiki/application/use_cases.py
@@ -42,7 +42,7 @@ from features.wiki.domain.exceptions import (
     WikiPageNotFoundError,
     WikiValidationError,
 )
-from webapp.config import Config
+from webapp.config import BaseApplicationSettings
 from webapp.services.upload_service import commit_uploads_to_directory
 
 
@@ -393,7 +393,7 @@ class WikiMediaUploadUseCase:
         if self._destination_dir is not None:
             base_dir = self._destination_dir
         else:
-            configured = settings.wiki_upload_directory or Config.WIKI_UPLOAD_DIR
+            configured = settings.wiki_upload_directory or BaseApplicationSettings.WIKI_UPLOAD_DIR
             base_dir = Path(configured)
 
         try:

--- a/tests/manual_test_local_import.py
+++ b/tests/manual_test_local_import.py
@@ -16,7 +16,7 @@ from webapp import create_app
 from core.tasks.local_import import local_import_task, scan_import_directory
 from core.models.picker_session import PickerSession
 from core.models.photo_models import PickerSelection
-from webapp.config import Config
+from webapp.config import BaseApplicationSettings
 from core.tasks.local_import import local_import_task, scan_import_directory
 
 def create_test_files(import_dir: str) -> list:

--- a/tests/test_api_login_scope.py
+++ b/tests/test_api_login_scope.py
@@ -38,9 +38,9 @@ def app(tmp_path):
     import webapp.config as config_module
 
     config_module = importlib.reload(config_module)
-    Config = config_module.Config
+    BaseApplicationSettings = config_module.BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_api_login_totp.py
+++ b/tests/test_api_login_totp.py
@@ -24,9 +24,9 @@ def app(tmp_path):
     import webapp.config as config_module
 
     config_module = importlib.reload(config_module)
-    Config = config_module.Config
+    BaseApplicationSettings = config_module.BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_api_refresh_token.py
+++ b/tests/test_api_refresh_token.py
@@ -10,8 +10,8 @@ def app(tmp_path_factory):
     os.environ["SECRET_KEY"] = "test"
     os.environ["JWT_SECRET_KEY"] = "jwt-secret"
     os.environ["DATABASE_URI"] = f"sqlite:///{db_path}"
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_api_totp_management.py
+++ b/tests/test_api_totp_management.py
@@ -23,9 +23,9 @@ def app(tmp_path):
     import webapp.config as config_module
 
     config_module = importlib.reload(config_module)
-    Config = config_module.Config
+    BaseApplicationSettings = config_module.BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_auth_role_selection.py
+++ b/tests/test_auth_role_selection.py
@@ -17,9 +17,9 @@ def app(tmp_path):
         original_env[key] = os.environ.get(key)
         os.environ[key] = value
 
-    from webapp.config import Config
+    from webapp.config import BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
 
     from webapp import create_app
 

--- a/tests/test_celery_app.py
+++ b/tests/test_celery_app.py
@@ -93,13 +93,13 @@ class TestFlaskAppCreation:
             assert db.app == app
     
     def test_flask_app_config_inheritance(self):
-        """Test that Flask app inherits from Config class."""
+        """Test that Flask app inherits from BaseApplicationSettings class."""
         from cli.src.celery.celery_app import flask_app
-        from webapp.config import Config
+        from webapp.config import BaseApplicationSettings
         
         # Test some basic config values that should be inherited
         assert hasattr(flask_app.config, 'SQLALCHEMY_TRACK_MODIFICATIONS')
-        assert flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] == Config.SQLALCHEMY_TRACK_MODIFICATIONS
+        assert flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] == BaseApplicationSettings.SQLALCHEMY_TRACK_MODIFICATIONS
 
 
 class TestContextTask:
@@ -303,7 +303,7 @@ class TestCeleryModuleImports:
     def test_webapp_modules_import(self):
         """Test that webapp modules can be imported in Celery context."""
         try:
-            from webapp.config import Config
+            from webapp.config import BaseApplicationSettings
             from webapp.extensions import migrate, login_manager, babel
             assert True  # If we get here, imports succeeded
         except ImportError as e:

--- a/tests/test_exchange_refresh_token.py
+++ b/tests/test_exchange_refresh_token.py
@@ -29,8 +29,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -27,9 +27,9 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
+    from webapp.config import BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_heic_picker_import_dimensions.py
+++ b/tests/test_heic_picker_import_dimensions.py
@@ -35,8 +35,8 @@ def picker_app(tmp_path):
     import webapp as webapp_module
     importlib.reload(webapp_module)
 
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_heic_support.py
+++ b/tests/test_heic_support.py
@@ -53,8 +53,8 @@ def local_import_app(tmp_path: Path):
     import webapp as webapp_module
     importlib.reload(webapp_module)
 
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_local_import.py
+++ b/tests/test_local_import.py
@@ -55,8 +55,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_media_api.py
+++ b/tests/test_media_api.py
@@ -38,8 +38,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_media_post_processing.py
+++ b/tests/test_media_post_processing.py
@@ -44,9 +44,9 @@ def app(tmp_path):
     importlib.reload(config_module)
     importlib.reload(webapp_module)
 
-    from webapp.config import Config
+    from webapp.config import BaseApplicationSettings
 
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
 
     from webapp import create_app
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -34,8 +34,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_photo_picker.py
+++ b/tests/test_photo_picker.py
@@ -15,8 +15,8 @@ def app(tmp_path, monkeypatch):
     monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "sec")
     key = base64.urlsafe_b64encode(b"0" * 32).decode()
     monkeypatch.setenv("OAUTH_TOKEN_KEY", key)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -33,8 +33,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_picker_session_api.py
+++ b/tests/test_picker_session_api.py
@@ -18,8 +18,8 @@ def app(tmp_path):
     os.environ["GOOGLE_CLIENT_SECRET"] = "sec"
     key = base64.urlsafe_b64encode(b"0" * 32).decode()
     os.environ["OAUTH_TOKEN_KEY"] = key
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_picker_session_selections.py
+++ b/tests/test_picker_session_selections.py
@@ -25,8 +25,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_picker_watchdog.py
+++ b/tests/test_picker_watchdog.py
@@ -30,8 +30,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_server_timing.py
+++ b/tests/test_server_timing.py
@@ -33,8 +33,8 @@ def app(tmp_path):
     import webapp as webapp_module
     importlib.reload(webapp_module)
     from webapp import create_app
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
 
     app = create_app()
     app.config.update(TESTING=True)

--- a/tests/test_thumbs_generate.py
+++ b/tests/test_thumbs_generate.py
@@ -35,8 +35,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -49,8 +49,8 @@ def app(tmp_path):
     importlib.reload(config_module)
     import webapp as webapp_module
     importlib.reload(webapp_module)
-    from webapp.config import Config
-    Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+    from webapp.config import BaseApplicationSettings
+    BaseApplicationSettings.SQLALCHEMY_ENGINE_OPTIONS = {}
     from webapp import create_app
 
     app = create_app()

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -738,14 +738,14 @@ def _apply_persisted_settings(app: Flask) -> None:
 def create_app():
     """アプリケーションファクトリ"""
     from dotenv import load_dotenv
-    from .config import Config
+    from .config import BaseApplicationSettings
     from werkzeug.middleware.proxy_fix import ProxyFix
 
     # .env を読み込む（環境変数が未設定の場合のみ）
     load_dotenv()
 
     app = Flask(__name__)
-    app.config.from_object(Config)
+    app.config.from_object(BaseApplicationSettings)
     app.config.setdefault("LAST_BEAT_AT", None)
     app.config.setdefault("API_TITLE", "nolumia API")
     app.config.setdefault("API_VERSION", "1.0.0")

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -319,14 +319,14 @@ def _build_config_context(
         default_flags=cors_use_defaults,
     )
 
-    from webapp.config import Config
+    from webapp.config import BaseApplicationSettings
 
     public_keys = [
         k
-        for k in dir(Config)
+        for k in dir(BaseApplicationSettings)
         if not k.startswith("_") and k.isupper() and k not in ("SECRET_KEY")
     ]
-    config_dict = {k: getattr(Config, k) for k in public_keys}
+    config_dict = {k: getattr(BaseApplicationSettings, k) for k in public_keys}
 
     try:
         signing_setting = SystemSettingService.get_access_token_signing_setting()

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -3694,7 +3694,7 @@ def _prepare_local_import_path(path_value):
 
 
 def _resolve_local_import_config():
-    from webapp.config import Config
+    from webapp.config import BaseApplicationSettings
 
     directory_specs = [
         ("LOCAL_IMPORT_DIR", "import", settings.local_import_directory_configured),
@@ -3714,7 +3714,7 @@ def _resolve_local_import_config():
     directories: list[dict[str, Any]] = []
 
     for config_key, key, configured_value in directory_specs:
-        configured_value = configured_value or getattr(Config, config_key, None) or None
+        configured_value = configured_value or getattr(BaseApplicationSettings, config_key, None) or None
 
         candidates = storage_path_candidates(config_key)
         resolved_path = first_existing_storage_path(config_key)

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -13,8 +13,8 @@ def _default(name: str):
     return DEFAULT_APPLICATION_SETTINGS.get(name)
 
 
-class Config:
-    """Base configuration populated from persisted system settings."""
+class BaseApplicationSettings:
+    """Base Flask application configuration populated from persisted system settings."""
 
     SECRET_KEY = _default("SECRET_KEY")
     JWT_SECRET_KEY = _default("JWT_SECRET_KEY")
@@ -96,7 +96,7 @@ class Config:
     CORS_ALLOWED_ORIGINS: tuple[str, ...] = ()
 
 
-class TestConfig(Config):
+class TestConfig(BaseApplicationSettings):
     """テスト用の設定クラス"""
 
     TESTING = True

--- a/webapp/services/upload_service.py
+++ b/webapp/services/upload_service.py
@@ -14,7 +14,7 @@ from flask import current_app
 from werkzeug.datastructures import FileStorage
 
 from core.storage_paths import first_existing_storage_path
-from webapp.config import Config
+from webapp.config import BaseApplicationSettings
 from core.settings import settings
 
 
@@ -83,7 +83,7 @@ def _resolve_local_import_directory() -> Optional[Path]:
     candidate = first_existing_storage_path("LOCAL_IMPORT_DIR")
     if candidate is None:
         candidate = (
-            settings.local_import_directory_configured or Config.LOCAL_IMPORT_DIR
+            settings.local_import_directory_configured or BaseApplicationSettings.LOCAL_IMPORT_DIR
         )
     if not candidate:
         return None


### PR DESCRIPTION
## Summary
- rename the Flask configuration class to BaseApplicationSettings
- update the Flask app factory, Celery bootstrap, and services to consume the renamed class
- align tests and admin views with the new BaseApplicationSettings identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6e813f3c083239172d966601c95b5