### PR TITLE
Preserve next parameter across role selection login flow

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -235,12 +235,15 @@ document.addEventListener('DOMContentLoaded', function() {
     try {
       const formData = new FormData(form);
       const storedRedirectPath = localStorage.getItem('redirect_after_login');
+      const rawNextValue = formData.get('next');
+      const normalizedNextValue = typeof rawNextValue === 'string' ? rawNextValue.trim() : '';
+      const nextValue = normalizedNextValue || storedRedirectPath || null;
       const emailValue = (formData.get('email') || '').trim().toLowerCase();
       const loginData = {
         email: formData.get('email'),
         password: formData.get('password'),
         token: formData.get('token') || null,
-        next: storedRedirectPath || null
+        next: nextValue
       };
 
       let scopeStorageKey = null;


### PR DESCRIPTION
## Summary
- ensure the login API submission forwards the requested `next` URL so role selection keeps the redirect target

## Testing
- pytest tests/test_auth_role_selection.py

------
https://chatgpt.com/codex/tasks/task_e_68f716818c108323a6852781e910bd0b