### PR TITLE
Remove access token cookie issuance from login API

### DIFF
--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1785,15 +1785,7 @@ def api_login(data):
             "available_scopes": sorted(user_permissions),
         }
 
-    resp = jsonify(response_payload)
-    resp.set_cookie(
-        "access_token",
-        access_token,
-        httponly=True,
-        secure=settings.session_cookie_secure,
-        samesite="Lax",
-    )
-    return resp
+    return jsonify(response_payload)
 
 
 @bp.post("/logout")


### PR DESCRIPTION
## Summary
- remove the access token Set-Cookie response header from the /api/login endpoint

## Testing
- pytest tests/test_api_login_scope.py tests/test_api_login_totp.py

------
https://chatgpt.com/codex/tasks/task_e_68f726b453e08323b3382a2c39c19968