### PR TITLE
Improve admin config navigation usability

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -45,17 +45,6 @@
   <div class="col-xl-3">
     <div class="card shadow-sm config-sidebar sticky-top">
       <div class="card-body">
-        <div class="mb-3">
-          <label class="form-label" for="config-search">{{ _('Search settings') }}</label>
-          <input
-            type="search"
-            class="form-control form-control-sm"
-            id="config-search"
-            placeholder="{{ _('Filter by label, key, or description...') }}"
-            data-config-search
-          >
-          <div class="form-text">{{ _('Type keywords to filter settings across all categories.') }}</div>
-        </div>
         <nav class="config-tree" data-config-tree aria-label="{{ _('Configuration navigation') }}">
           <ul class="list-unstyled mb-0">
             <li
@@ -84,9 +73,26 @@
               data-section="{{ section.identifier }}"
               data-search-text="{{ section.search_text|e }}"
             >
-              <a class="config-tree__link" href="#{{ section.anchor_id }}">{{ section.label }}</a>
+              <div class="config-tree__section-header">
+                {% if section.fields %}
+                <button
+                  class="config-tree__toggle"
+                  type="button"
+                  data-config-tree-toggle
+                  aria-expanded="true"
+                  aria-controls="{{ section.anchor_id }}-tree"
+                >
+                  <span class="visually-hidden">{{ _('Toggle section visibility') }}</span>
+                </button>
+                {% endif %}
+                <a class="config-tree__link" href="#{{ section.anchor_id }}">{{ section.label }}</a>
+              </div>
               {% if section.fields %}
-              <ul class="list-unstyled config-tree__children">
+              <ul
+                class="list-unstyled config-tree__children"
+                id="{{ section.anchor_id }}-tree"
+                data-config-tree-children
+              >
                 {% for field in section.fields %}
                 <li
                   class="config-tree__item"
@@ -127,6 +133,19 @@
     </div>
   </div>
   <div class="col-xl-9">
+    <div class="config-search mb-4 d-flex justify-content-lg-end">
+      <div class="config-search__field">
+        <label class="form-label" for="config-search">{{ _('Search settings') }}</label>
+        <input
+          type="search"
+          class="form-control"
+          id="config-search"
+          placeholder="{{ _('Filter by label, key, or description...') }}"
+          data-config-search
+        >
+        <div class="form-text">{{ _('Type keywords to filter settings across all categories.') }}</div>
+      </div>
+    </div>
     <div class="alert alert-info d-none" data-config-empty-state>
       {{ _('No settings match your search. Try a different keyword.') }}
     </div>

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -263,6 +263,9 @@
     const treeSectionItems = Array.from(
       document.querySelectorAll('[data-config-tree-section]')
     );
+    const treeToggleButtons = Array.from(
+      document.querySelectorAll('[data-config-tree-toggle]')
+    );
     const treeNodeItems = Array.from(document.querySelectorAll('[data-config-tree-node]'));
     const emptyState = document.querySelector('[data-config-empty-state]');
 
@@ -272,6 +275,47 @@
       }
       return (element.dataset.searchText || '').toLowerCase();
     };
+
+    const setTreeSectionExpanded = (item, expanded) => {
+      if (!item) {
+        return;
+      }
+      const children = item.querySelector('[data-config-tree-children]');
+      if (!children) {
+        return;
+      }
+      const isExpanded = !!expanded;
+      item.classList.toggle('config-tree__item--collapsed', !isExpanded);
+      const toggle = item.querySelector('[data-config-tree-toggle]');
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+      }
+    };
+
+    treeSectionItems.forEach((item) => {
+      const children = item.querySelector('[data-config-tree-children]');
+      if (!children) {
+        return;
+      }
+      if (!item.dataset.treeExpanded) {
+        item.dataset.treeExpanded = 'true';
+      }
+      setTreeSectionExpanded(item, item.dataset.treeExpanded !== 'false');
+    });
+
+    treeToggleButtons.forEach((button) => {
+      const parentItem = button.closest('[data-config-tree-section]');
+      if (!parentItem) {
+        return;
+      }
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const currentExpanded = parentItem.dataset.treeExpanded !== 'false';
+        const nextExpanded = !currentExpanded;
+        parentItem.dataset.treeExpanded = nextExpanded ? 'true' : 'false';
+        setTreeSectionExpanded(parentItem, nextExpanded);
+      });
+    });
 
     const findRowByKey = (key) =>
       document.querySelector(`[data-app-key="${cssEscape(key)}"]`);
@@ -364,6 +408,16 @@
         const matches = !hasQuery || targetVisible || getSearchText(item).includes(query);
         item.classList.toggle('d-none', !matches);
       });
+
+      if (hasQuery) {
+        treeSectionItems.forEach((item) => {
+          setTreeSectionExpanded(item, true);
+        });
+      } else {
+        treeSectionItems.forEach((item) => {
+          setTreeSectionExpanded(item, item.dataset.treeExpanded !== 'false');
+        });
+      }
     };
 
     searchInput.addEventListener('input', () => {

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -199,6 +199,51 @@ body.login-page footer {
   margin-bottom: 0.25rem;
 }
 
+.config-tree__section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.config-tree__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: inherit;
+  padding: 0;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.config-tree__toggle::before {
+  content: '\25BC';
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+}
+
+.config-tree__toggle:hover,
+.config-tree__toggle:focus-visible {
+  background-color: rgba(13, 110, 253, 0.1);
+  color: var(--bs-primary, #0d6efd);
+}
+
+.config-tree__toggle:focus-visible {
+  outline: 2px solid var(--bs-primary, #0d6efd);
+  outline-offset: 2px;
+}
+
+.config-tree__item--collapsed > .config-tree__children {
+  display: none;
+}
+
+.config-tree__item--collapsed .config-tree__toggle::before {
+  transform: rotate(-90deg);
+}
+
 .config-tree__children {
   margin-top: 0.35rem;
   padding-left: 0.75rem;
@@ -226,6 +271,15 @@ body.login-page footer {
 .config-tree__hint {
   font-size: 0.75rem;
   color: var(--bs-secondary-color, #6c757d);
+}
+
+.config-search__field {
+  width: 100%;
+  max-width: 24rem;
+}
+
+.config-search .form-label {
+  margin-bottom: 0.35rem;
 }
 
 .config-section-card {

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -186,6 +186,10 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
+#: webapp/admin/templates/admin/config_view.html:88
+msgid "Toggle section visibility"
+msgstr "セクションの表示を切り替え"
+
 #: webapp/admin/templates/admin/admin_users.html:50
 #: webapp/admin/templates/admin/user_add.html:2
 #: webapp/admin/templates/admin/user_add.html:4

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -177,6 +177,10 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
+#: webapp/admin/templates/admin/config_view.html:88
+msgid "Toggle section visibility"
+msgstr ""
+
 #: webapp/admin/templates/admin/admin_users.html:50
 #: webapp/admin/templates/admin/user_add.html:2
 #: webapp/admin/templates/admin/user_add.html:4


### PR DESCRIPTION
## Summary
- move the admin configuration search controls into the main content column
- add collapsible controls to the configuration navigation tree and expand automatically while filtering
- update styles, scripts, and translations to support the new layout

## Testing
- pytest tests/test_admin_config.py

------
https://chatgpt.com/codex/tasks/task_e_68f728f9ebb88323b754cfdcabf68cd8