### PR TITLE
Ensure OpenAPI server URLs honor preferred scheme

### DIFF
--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -9,14 +9,17 @@ from webapp.extensions import api as smorest_api
 class TestOpenAPIDocs:
     def test_openapi_spec_includes_login_endpoint(self, app_context):
         client = app_context.test_client()
-        response = client.get('/api/openapi.json')
+        response = client.get('/api/openapi.json', base_url='http://localhost')
         assert response.status_code == 200
 
         payload = response.get_json()
         assert payload['openapi'] == '3.0.3'
 
         servers = payload.get('servers', [])
-        assert servers == [{'url': 'http://localhost/api'}]
+        assert servers == [
+            {'url': 'https://localhost/api'},
+            {'url': 'http://localhost/api'},
+        ]
 
         assert '/login' in payload['paths']
         login_post = payload['paths']['/login']['post']

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -667,6 +667,8 @@ def _calculate_openapi_server_urls(prefix: str) -> List[str]:
 
     schemes: List[str] = []
 
+    add_scheme(settings.preferred_url_scheme)
+
     forwarded_header = request.headers.get("Forwarded", "")
     if forwarded_header:
         for part in forwarded_header.split(","):


### PR DESCRIPTION
## Summary
- add the configured preferred URL scheme when generating OpenAPI server URLs so HTTPS endpoints are published even for HTTP requests
- update the OpenAPI docs test to exercise an HTTP request and expect both HTTPS and HTTP server entries

## Testing
- pytest tests/test_openapi_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68f728aab72883239801f7775c5c446a