### PR TITLE
Refactor layout templates for sticky headers

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,9 +1,52 @@
-body { 
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
+:root {
+  --global-header-height: 4rem;
+  --feature-header-height: 3rem;
+  --global-header-background: #ffffff;
+  --feature-header-background: #f8f9fa;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
   min-height: 100vh;
   margin: 0;
   padding: 0;
+}
+
+.global-header {
+  position: sticky;
+  top: 0;
+  z-index: 1030;
+  background: var(--global-header-background);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.global-header .navbar {
+  margin-bottom: 0;
+  min-height: var(--global-header-height);
+}
+
+.feature-header {
+  position: sticky;
+  top: var(--global-header-height);
+  z-index: 1020;
+  background: var(--feature-header-background);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.feature-header:empty {
+  display: none;
+}
+
+.feature-header__inner {
+  min-height: var(--feature-header-height);
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.layout-content {
+  padding-bottom: 3rem;
 }
 
 .form-narrow {
@@ -13,9 +56,12 @@ body {
 /* Modern Login Page Styles */
 body.login-page {
   overflow-x: hidden;
+  padding-top: 0;
 }
 
-body.login-page footer {
+body.login-page #global-header,
+body.login-page #feature-header,
+body.login-page #global-footer {
   display: none;
 }
 

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -13,159 +13,46 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body{% block body_attributes %}{% endblock %}>
+  <header id="global-header" class="global-header">
+    {% block global_header %}
+      {% include "layouts/global_header.html" %}
+    {% endblock %}
+  </header>
 
-<header>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('AppName') }}</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav me-auto">
-        {% if current_user.is_authenticated %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('index') }}">{{ _('Home') }}</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('dashboard.dashboard') }}">{{ _('Dashboard') }}</a>
-        </li>
-        {% if current_user.can('media:view') %}
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="photoNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            {{ _('Photo View') }}
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="photoNavDropdown">
-            <li><a class="dropdown-item" href="{{ url_for('photo_view.home') }}">{{ _('Sessions') }}</a></li>
-            <li><a class="dropdown-item" href="{{ url_for('photo_view.media_list') }}">{{ _('Media Gallery') }}</a></li>
-            {% if current_user.can('album:view') %}
-            <li><a class="dropdown-item" href="{{ url_for('photo_view.albums') }}">{{ _('Albums') }}</a></li>
-            {% endif %}
-            <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="{{ url_for('photo_view.settings') }}">{{ _('Settings') }}</a></li>
-          </ul>
-        </li>
-        {% endif %}
-        {% if current_user.can('wiki:read') %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('wiki.index') }}">
-            <i class="fas fa-book"></i> Wiki
-          </a>
-        </li>
-        {% endif %}
-        {% if current_user.can('certificate:manage') %}
-        <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('certs_ui.index') }}">
-            <i class="bi bi-award me-1"></i>{{ _('Certificates') }}
-          </a>
-        </li>
-        {% endif %}
-        {% endif %}
-      </ul>
-      <ul class="navbar-nav">
-        {% if current_user.is_authenticated %}
-          {% set show_system_manage = current_user.can('system:manage') %}
-          {% set show_user_manage = current_user.can('user:manage') %}
-          {% set show_service_accounts = current_user.can('service_account:manage') %}
-          {% set show_api_key_management = current_user.can('api_key:manage') or current_user.can('api_key:read') %}
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('auth.profile') }}">
-              <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
-            </a>
-          </li>
-          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_system_manage %}
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              {{ _('Management') }}
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="managementNavDropdown">
-              {% if show_user_manage %}
-              <li><a class="dropdown-item" href="{{ url_for('admin.user') }}">{{ _('User Management') }}</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin.google_accounts') }}">{{ _('Google Accounts') }}</a></li>
-              {% endif %}
-              {% if show_service_accounts %}
-              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
-              {% elif show_api_key_management %}
-              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('API Key Management') }}</a></li>
-              {% endif %}
-              {% if show_user_manage %}
-              <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin.show_config') }}">{{ _('Config Settings') }}</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('admin.show_version') }}">{{ _('Version Info') }}</a></li>
-              {% endif %}
-              {% if current_user.can('role:manage') %}
-              <li><a class="dropdown-item" href="{{ url_for('admin.roles') }}">{{ _('Roles') }}</a></li>
-              {% endif %}
-              {% if current_user.can('permission:manage') %}
-              <li><a class="dropdown-item" href="{{ url_for('admin.permissions') }}">{{ _('Permissions') }}</a></li>
-              {% endif %}
-              {% if current_user.can('totp:view') %}
-              <li><a class="dropdown-item" href="{{ url_for('totp.index') }}">{{ _('TOTP Management') }}</a></li>
-              {% endif %}
-              {% if show_system_manage %}
-              <li><hr class="dropdown-divider"></li>
-              <li>
-                <a class="dropdown-item" href="{{ url_for('admin.show_data_files') }}">
-                  <i class="bi bi-hdd-stack me-2"></i>{{ _('Data Files') }}
-                </a>
-              </li>
-              {% endif %}
-              {% if show_system_manage %}
-              {% if not show_system_manage %}
-              <li><hr class="dropdown-divider"></li>
-              {% endif %}
-              <li><a class="dropdown-item" href="{{ url_for('photo_view.settings') }}">{{ _('Photo View Settings') }}</a></li>
-              <li><a class="dropdown-item" href="{{ url_for('photo_view.admin_exports') }}">{{ _('Photo Exports') }}</a></li>
-              {% endif %}
-            </ul>
-          </li>
-          {% endif %}
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('auth.logout') }}">{{ _('Logout') }}</a>
-          </li>
-        {% else %}
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('auth.login') }}">{{ _('Login') }}</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('auth.register') }}">{{ _('Register') }}</a>
-          </li>
-        {% endif %}
-      </ul>
+  <div id="feature-header" class="feature-header">
+    {%- block feature_header -%}{%- endblock -%}
+  </div>
+
+  <main id="content" class="layout-content container-fluid mt-4">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="flash-messages">
+          {% for cat, msg in messages %}
+            <div class="alert alert-{{ 'danger' if cat == 'error' else cat }} alert-dismissible fade show" role="alert">
+              {{ msg }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    {% block content %}{% endblock %}
+  </main>
+
+  <!-- Toast Container -->
+  <div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" id="toast-container">
+      <!-- Toasts will be dynamically added here -->
     </div>
   </div>
-</nav>
-</header>
 
-<main class="container-fluid mt-4">
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      <div class="flash-messages">
-        {% for cat, msg in messages %}
-          <div class="alert alert-{{ 'danger' if cat == 'error' else cat }} alert-dismissible fade show" role="alert">
-            {{ msg }}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  <footer id="global-footer" class="global-footer">
+    {% block global_footer %}
+      {% include "layouts/global_footer.html" %}
+    {% endblock %}
+  </footer>
 
-  {% block content %}{% endblock %}
-</main>
-
-<!-- Toast Container -->
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-  <div class="toast-container position-fixed bottom-0 end-0 p-3" id="toast-container">
-    <!-- Toasts will be dynamically added here -->
-  </div>
-</div>
-
-  <hr class="mt-5 mb-4">
-<footer class="text-center mb-3">
-  <p class="text-muted">&copy; 2025 {{ _('AppName') }}</p>
-  <p class="text-muted small">Version: {{ app_version }}</p>
-</footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.0/dist/mermaid.min.js"></script>
   <script src="{{ url_for('static', filename='js/i18n-helper.js') }}"></script>

--- a/webapp/templates/feature_base.html
+++ b/webapp/templates/feature_base.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block feature_header %}
+  {% set feature_header_html %}{% block feature_header_content %}{% include "layouts/feature_header.html" %}{% endblock %}{% endset %}
+  {% if feature_header_html.strip() %}
+    <div class="feature-header__inner container-fluid">
+      {{ feature_header_html | safe }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/webapp/templates/layouts/feature_header.html
+++ b/webapp/templates/layouts/feature_header.html
@@ -1,0 +1,1 @@
+{# Default feature header is intentionally empty. Override `feature_header_content` in child templates. #}

--- a/webapp/templates/layouts/global_footer.html
+++ b/webapp/templates/layouts/global_footer.html
@@ -1,0 +1,5 @@
+<hr class="mt-5 mb-4">
+<div class="text-center mb-3">
+  <p class="text-muted">&copy; 2025 {{ _('AppName') }}</p>
+  <p class="text-muted small">Version: {{ app_version }}</p>
+</div>

--- a/webapp/templates/layouts/global_header.html
+++ b/webapp/templates/layouts/global_header.html
@@ -1,0 +1,120 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('AppName') }}</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto">
+        {% if current_user.is_authenticated %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('index') }}">{{ _('Home') }}</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('dashboard.dashboard') }}">{{ _('Dashboard') }}</a>
+        </li>
+        {% if current_user.can('media:view') %}
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="photoNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {{ _('Photo View') }}
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="photoNavDropdown">
+            <li><a class="dropdown-item" href="{{ url_for('photo_view.home') }}">{{ _('Sessions') }}</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('photo_view.media_list') }}">{{ _('Media Gallery') }}</a></li>
+            {% if current_user.can('album:view') %}
+            <li><a class="dropdown-item" href="{{ url_for('photo_view.albums') }}">{{ _('Albums') }}</a></li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="{{ url_for('photo_view.settings') }}">{{ _('Settings') }}</a></li>
+          </ul>
+        </li>
+        {% endif %}
+        {% if current_user.can('wiki:read') %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('wiki.index') }}">
+            <i class="fas fa-book"></i> Wiki
+          </a>
+        </li>
+        {% endif %}
+        {% if current_user.can('certificate:manage') %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('certs_ui.index') }}">
+            <i class="bi bi-award me-1"></i>{{ _('Certificates') }}
+          </a>
+        </li>
+        {% endif %}
+        {% endif %}
+      </ul>
+      <ul class="navbar-nav">
+        {% if current_user.is_authenticated %}
+          {% set show_system_manage = current_user.can('system:manage') %}
+          {% set show_user_manage = current_user.can('user:manage') %}
+          {% set show_service_accounts = current_user.can('service_account:manage') %}
+          {% set show_api_key_management = current_user.can('api_key:manage') or current_user.can('api_key:read') %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('auth.profile') }}">
+              <i class="fas fa-user-circle me-1"></i>{{ current_user.display_name }}
+            </a>
+          </li>
+          {% if current_user.can('user:manage') or current_user.can('role:manage') or current_user.can('permission:manage') or show_service_accounts or show_system_manage %}
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="managementNavDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              {{ _('Management') }}
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="managementNavDropdown">
+              {% if show_user_manage %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.user') }}">{{ _('User Management') }}</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin.google_accounts') }}">{{ _('Google Accounts') }}</a></li>
+              {% endif %}
+              {% if show_service_accounts %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('Service Accounts') }}</a></li>
+              {% elif show_api_key_management %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.service_accounts') }}">{{ _('API Key Management') }}</a></li>
+              {% endif %}
+              {% if show_user_manage %}
+              <li><hr class="dropdown-divider"></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin.show_config') }}">{{ _('Config Settings') }}</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin.show_version') }}">{{ _('Version Info') }}</a></li>
+              {% endif %}
+              {% if current_user.can('role:manage') %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.roles') }}">{{ _('Roles') }}</a></li>
+              {% endif %}
+              {% if current_user.can('permission:manage') %}
+              <li><a class="dropdown-item" href="{{ url_for('admin.permissions') }}">{{ _('Permissions') }}</a></li>
+              {% endif %}
+              {% if current_user.can('totp:view') %}
+              <li><a class="dropdown-item" href="{{ url_for('totp.index') }}">{{ _('TOTP Management') }}</a></li>
+              {% endif %}
+              {% if show_system_manage %}
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item" href="{{ url_for('admin.show_data_files') }}">
+                  <i class="bi bi-hdd-stack me-2"></i>{{ _('Data Files') }}
+                </a>
+              </li>
+              {% endif %}
+              {% if show_system_manage %}
+              {% if not show_system_manage %}
+              <li><hr class="dropdown-divider"></li>
+              {% endif %}
+              <li><a class="dropdown-item" href="{{ url_for('photo_view.settings') }}">{{ _('Photo View Settings') }}</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('photo_view.admin_exports') }}">{{ _('Photo Exports') }}</a></li>
+              {% endif %}
+            </ul>
+          </li>
+          {% endif %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('auth.logout') }}">{{ _('Logout') }}</a>
+          </li>
+        {% else %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('auth.login') }}">{{ _('Login') }}</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('auth.register') }}">{{ _('Register') }}</a>
+          </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- reorganize the base template to delegate the global header and footer to dedicated layout partials and expose a feature header block
- add a feature-level base template and default partial to support reusable sticky headers per feature
- style the new global and feature headers so they remain sticky, while keeping login pages free of the shared chrome

## Testing
- pytest *(fails: tests/test_local_import_duplicate_refresh.py::test_duplicate_refresh_realigns_playback_paths, then interrupted after ~41% due to KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68f72a50db188323a199907a0e096235