### PR TITLE
Ensure duplicate refresh realigns playback assets

### DIFF
--- a/core/tasks/local_import.py
+++ b/core/tasks/local_import.py
@@ -633,14 +633,13 @@ def _refresh_existing_media_metadata(
                 status="playback_path_realigned",
             )
 
-        if not preserve_original_path:
-            _update_media_playback_paths(
-                media,
-                old_relative_path=old_relative_path,
-                new_relative_path=new_relative_path,
-                session_id=session_id,
-                playback_entries=playback_entries or None,
-            )
+        _update_media_playback_paths(
+            media,
+            old_relative_path=old_relative_path,
+            new_relative_path=new_relative_path,
+            session_id=session_id,
+            playback_entries=playback_entries or None,
+        )
 
     apply_analysis_to_media_entity(media, analysis)
 


### PR DESCRIPTION
## Summary
- always call `_update_media_playback_paths` during duplicate refresh so playback assets realign even when the original path is preserved

## Testing
- pytest tests/test_local_import_duplicate_refresh.py::test_duplicate_refresh_realigns_playback_paths -q
- pytest tests/test_local_import_duplicate_refresh.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f72fa01b608323b9022e4a85fcdaf4