### PR TITLE
Refine service login token extraction to enforce form submissions

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -171,15 +171,15 @@ def _extract_bearer_token() -> str | None:
         if candidate:
             return candidate
 
-    token_param = request.values.get("token") or request.values.get("access_token")
-    if not token_param and request.is_json:
-        payload = request.get_json(silent=True) or {}
-        token_param = payload.get("token") or payload.get("access_token")
-
-    if isinstance(token_param, str):
-        candidate = token_param.strip()
-        if candidate:
-            return candidate
+    if (
+        request.method == "POST"
+        and request.mimetype == "application/x-www-form-urlencoded"
+    ):
+        token_param = request.form.get("token") or request.form.get("access_token")
+        if isinstance(token_param, str):
+            candidate = token_param.strip()
+            if candidate:
+                return candidate
     return None
 
 


### PR DESCRIPTION
## Summary
- require service login token fallbacks to use POST application/x-www-form-urlencoded payloads instead of query parameters or JSON bodies
- add coverage ensuring query-provided tokens are rejected while form submissions still log users in successfully

## Testing
- pytest tests/test_api_login_scope.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f739b9fce083238dac28de45711c3a