### PR TITLE
Allow collapsing the admin config sidebar

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -41,11 +41,29 @@
 
 <h3>{{ _('Config Settings') }}</h3>
 
-<div class="row g-4 align-items-start">
-  <div class="col-xl-3">
+<div class="row g-4 align-items-start" data-config-layout>
+  <div class="col-xl-3" data-config-tree-sidebar>
     <div class="card shadow-sm config-sidebar sticky-top">
       <div class="card-body">
-        <nav class="config-tree" data-config-tree aria-label="{{ _('Configuration navigation') }}">
+        <div class="config-sidebar__actions">
+          <span class="config-sidebar__title">{{ _('Configuration navigation') }}</span>
+          <button
+            type="button"
+            class="btn btn-outline-secondary btn-sm"
+            data-config-tree-collapse
+            aria-expanded="true"
+            aria-controls="config-navigation"
+          >
+            <i class="fas fa-angle-left" aria-hidden="true"></i>
+            <span class="ms-2">{{ _('Hide navigation') }}</span>
+          </button>
+        </div>
+        <nav
+          class="config-tree"
+          id="config-navigation"
+          data-config-tree
+          aria-label="{{ _('Configuration navigation') }}"
+        >
           <ul class="list-unstyled mb-0">
             <li
               class="config-tree__item"
@@ -132,7 +150,19 @@
       </div>
     </div>
   </div>
-  <div class="col-xl-9">
+  <div class="col-xl-9" data-config-tree-content>
+    <div class="config-sidebar__show" data-config-tree-expand-container>
+      <button
+        type="button"
+        class="btn btn-outline-secondary btn-sm"
+        data-config-tree-expand
+        aria-expanded="false"
+        aria-controls="config-navigation"
+      >
+        <i class="fas fa-angle-right" aria-hidden="true"></i>
+        <span class="ms-2">{{ _('Show navigation') }}</span>
+      </button>
+    </div>
     <div class="config-search mb-4 d-flex justify-content-lg-end">
       <div class="config-search__field">
         <label class="form-label" for="config-search">{{ _('Search settings') }}</label>

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -12,6 +12,81 @@
 
   let reapplySearchFilter = null;
 
+  const layoutContainer = document.querySelector('[data-config-layout]');
+  if (layoutContainer) {
+    const collapseButton = layoutContainer.querySelector('[data-config-tree-collapse]');
+    const expandButton = layoutContainer.querySelector('[data-config-tree-expand]');
+    const expandContainer = layoutContainer.querySelector('[data-config-tree-expand-container]');
+    const storageKey = 'admin-config-sidebar-collapsed';
+
+    const getStoredCollapsed = () => {
+      try {
+        if (!window.localStorage) {
+          return null;
+        }
+        const value = window.localStorage.getItem(storageKey);
+        if (value === 'true') {
+          return true;
+        }
+        if (value === 'false') {
+          return false;
+        }
+      } catch (error) {
+        console.warn('Failed to read sidebar state from storage', error);
+      }
+      return null;
+    };
+
+    const setStoredCollapsed = (collapsed) => {
+      try {
+        if (!window.localStorage) {
+          return;
+        }
+        window.localStorage.setItem(storageKey, collapsed ? 'true' : 'false');
+      } catch (error) {
+        console.warn('Failed to persist sidebar state', error);
+      }
+    };
+
+    const applyCollapsedState = (collapsed) => {
+      layoutContainer.classList.toggle('config-layout--tree-collapsed', collapsed);
+      if (collapseButton) {
+        collapseButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      }
+      if (expandButton) {
+        expandButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      }
+      if (expandContainer) {
+        expandContainer.setAttribute('aria-hidden', collapsed ? 'false' : 'true');
+      }
+    };
+
+    const setCollapsed = (collapsed, { focusTarget } = {}) => {
+      applyCollapsedState(collapsed);
+      setStoredCollapsed(collapsed);
+      if (focusTarget === 'expand' && expandButton) {
+        expandButton.focus();
+      } else if (focusTarget === 'collapse' && collapseButton) {
+        collapseButton.focus();
+      }
+    };
+
+    const storedCollapsed = getStoredCollapsed();
+    applyCollapsedState(storedCollapsed === true);
+
+    if (collapseButton) {
+      collapseButton.addEventListener('click', () => {
+        setCollapsed(true, { focusTarget: 'expand' });
+      });
+    }
+
+    if (expandButton) {
+      expandButton.addEventListener('click', () => {
+        setCollapsed(false, { focusTarget: 'collapse' });
+      });
+    }
+  }
+
   const cssEscape = (value) => {
     if (window.CSS && typeof window.CSS.escape === 'function') {
       return window.CSS.escape(value);

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -186,6 +186,43 @@ body.login-page footer {
   overflow-y: auto;
 }
 
+.config-sidebar__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.config-sidebar__actions .btn {
+  white-space: nowrap;
+}
+
+.config-sidebar__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.config-sidebar__show {
+  display: none;
+  margin-bottom: 1rem;
+}
+
+[data-config-layout].config-layout--tree-collapsed [data-config-tree-sidebar] {
+  display: none;
+}
+
+[data-config-layout].config-layout--tree-collapsed [data-config-tree-content] {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+[data-config-layout].config-layout--tree-collapsed .config-sidebar__show {
+  display: block;
+}
+
 .config-tree__heading {
   font-size: 0.75rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add collapse/expand controls to the admin configuration navigation tree
- adjust layout styles so the main content expands when the tree is hidden
- remember the sidebar visibility preference between visits

## Testing
- pytest *(fails: ImportError: cannot import name 'User' from partially initialized module 'core.models.user')*


------
https://chatgpt.com/codex/tasks/task_e_68f74bf743988323964008a48b11e2ea