### PR TITLE
Display service account IDs in admin UI

### DIFF
--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -112,6 +112,7 @@
       <table class="table table-hover align-middle mb-0" id="service-account-table">
         <thead class="table-light">
           <tr>
+            <th scope="col">{{ _('ID') }}</th>
             <th scope="col">{{ _('Name') }}</th>
             <th scope="col">{{ _('Certificate Group') }}</th>
             <th scope="col">{{ _('Scopes') }}</th>
@@ -223,6 +224,8 @@
       </div>
       <div class="modal-body">
         <dl class="row mb-0">
+          <dt class="col-sm-3">{{ _('ID') }}</dt>
+          <dd class="col-sm-9" id="detail-id"></dd>
           <dt class="col-sm-3">{{ _('Name') }}</dt>
           <dd class="col-sm-9" id="detail-name"></dd>
           <dt class="col-sm-3">{{ _('Description') }}</dt>
@@ -659,6 +662,7 @@
       }
 
       tr.innerHTML = `
+        <td><span class="text-muted">#${account.service_account_id}</span></td>
         <td class="fw-semibold">${account.name}</td>
         <td>${certificateGroupLabel}</td>
         <td>${scopes}</td>
@@ -727,6 +731,10 @@
   }
 
   function showDetail(account) {
+    const detailId = document.getElementById('detail-id');
+    if (detailId) {
+      detailId.textContent = `#${account.service_account_id}`;
+    }
     document.getElementById('detail-name').textContent = account.name;
     document.getElementById('detail-description').textContent = account.description || '-';
     document.getElementById('detail-scopes').innerHTML = account.scope_names


### PR DESCRIPTION
## Summary
- add the service account ID column to the listing table and details modal
- ensure the client-side rendering populates the ID values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f74f0acf3c83238d43c3ae07104a7f