### PR TITLE
Update access token subject formatting and claims

### DIFF
--- a/tests/test_api_service_account_token_exchange.py
+++ b/tests/test_api_service_account_token_exchange.py
@@ -153,8 +153,9 @@ def test_service_account_token_exchange_success(app_context):
         options={"verify_signature": False, "verify_aud": False},
     )
     assert decoded["subject_type"] == "system"
-    assert decoded["service_account"] == account.name
-    assert decoded["service_account_id"] == account.service_account_id
+    assert decoded["sub"] == f"s+{account.service_account_id}"
+    assert "service_account" not in decoded
+    assert "service_account_id" not in decoded
     assert decoded["scope"] == expected_scope
 
 

--- a/tests/test_token_service_signing.py
+++ b/tests/test_token_service_signing.py
@@ -57,6 +57,9 @@ def test_generate_access_token_with_server_signing():
     )
     assert claims["iss"] == settings.access_token_issuer
     assert claims["aud"] == settings.access_token_audience
+    assert claims["sub"] == f"i+{user.id}"
+    assert claims["subject_type"] == "individual"
+    assert "email" not in claims
 
     verification = TokenService.verify_access_token(token)
     assert verification is not None


### PR DESCRIPTION
## Summary
- prefix access token subjects for individual and system principals and drop the legacy email/service account claims
- adjust access token verification to understand the new subject format
- update service account and signing tests to assert the revised JWT payload

## Testing
- PYTHONPATH=. pytest tests/test_token_service_signing.py tests/test_api_service_account_token_exchange.py *(fails: ImportError caused by circular import when loading core.models.user)*

------
https://chatgpt.com/codex/tasks/task_e_68f7511c814c8323bf69d2a71828ce1a