### PR TITLE
Use subject identifiers for actor metadata

### DIFF
--- a/features/certs/presentation/api/routes.py
+++ b/features/certs/presentation/api/routes.py
@@ -78,14 +78,17 @@ def _require_sign_permission():
 
 def _resolve_actor() -> str:
     if current_user.is_authenticated:
+        subject_id = getattr(current_user, "subject_id", None)
+        if isinstance(subject_id, str) and subject_id.strip():
+            return subject_id.strip()
+        if hasattr(current_user, "get_id"):
+            identifier = current_user.get_id()
+            if isinstance(identifier, str) and identifier.strip():
+                return identifier.strip()
         display_name = getattr(current_user, "display_name", None)
         if isinstance(display_name, str) and display_name.strip():
             return display_name.strip()
-        if hasattr(current_user, "get_id"):
-            identifier = current_user.get_id()
-        else:
-            identifier = None
-        return str(identifier or "unknown")
+        return "unknown"
     return "system"
 
 

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -38,15 +38,20 @@ def _parse_iso_datetime(raw: Any) -> datetime | None:
 def _resolve_actor_identifier() -> str:
     """現在の主体を表す文字列表現を取得する。"""
 
+    subject_id = getattr(current_user, "subject_id", None)
+    if isinstance(subject_id, str) and subject_id.strip():
+        return subject_id.strip()
+
+    if hasattr(current_user, "get_id"):
+        identifier = current_user.get_id()
+        if isinstance(identifier, str) and identifier.strip():
+            return identifier.strip()
+
     display_name = getattr(current_user, "display_name", None)
     if isinstance(display_name, str) and display_name.strip():
         return display_name.strip()
 
-    if hasattr(current_user, "get_id"):
-        identifier = current_user.get_id()
-    else:
-        identifier = None
-    return str(identifier or "unknown")
+    return "unknown"
 
 
 def _has_manage_permission() -> bool:


### PR DESCRIPTION
## Summary
- ensure actor resolution prefers the authenticated subject identifier in service account key APIs
- apply the same subject-based resolution to certificate management API events while keeping legacy fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7803602a883238a178a83d01b8ce5