### PR TITLE
Refactor actor identifier resolution into shared utility

### DIFF
--- a/features/certs/presentation/api/routes.py
+++ b/features/certs/presentation/api/routes.py
@@ -16,6 +16,8 @@ from flask_babel import gettext as _
 
 from flask_login import current_user
 
+from shared.application.auth import resolve_actor_identifier
+
 from features.certs.application.dto import (
     CertificateGroupInput,
     CertificateSearchFilters,
@@ -77,19 +79,9 @@ def _require_sign_permission():
 
 
 def _resolve_actor() -> str:
-    if current_user.is_authenticated:
-        subject_id = getattr(current_user, "subject_id", None)
-        if isinstance(subject_id, str) and subject_id.strip():
-            return subject_id.strip()
-        if hasattr(current_user, "get_id"):
-            identifier = current_user.get_id()
-            if isinstance(identifier, str) and identifier.strip():
-                return identifier.strip()
-        display_name = getattr(current_user, "display_name", None)
-        if isinstance(display_name, str) and display_name.strip():
-            return display_name.strip()
-        return "unknown"
-    return "system"
+    if not current_user.is_authenticated:
+        return "system"
+    return resolve_actor_identifier()
 
 
 def _normalize_group_code(

--- a/shared/application/auth/__init__.py
+++ b/shared/application/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication-related application utilities."""
+
+from .actor_utils import resolve_actor_identifier
+
+__all__ = ["resolve_actor_identifier"]

--- a/shared/application/auth/actor_utils.py
+++ b/shared/application/auth/actor_utils.py
@@ -1,0 +1,41 @@
+"""Utility helpers for resolving the current actor identifier."""
+from __future__ import annotations
+
+from flask_login import current_user
+
+
+def _normalize_identifier(value: object) -> str | None:
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            return trimmed
+    return None
+
+
+def resolve_actor_identifier() -> str:
+    """Return a stable identifier for the current actor.
+
+    The resolution order is::
+
+        subject_id > get_id() > display_name > "unknown"
+    """
+
+    user = current_user
+
+    subject_id = _normalize_identifier(getattr(user, "subject_id", None))
+    if subject_id:
+        return subject_id
+
+    if hasattr(user, "get_id"):
+        identifier = _normalize_identifier(user.get_id())
+        if identifier:
+            return identifier
+
+    display_name = _normalize_identifier(getattr(user, "display_name", None))
+    if display_name:
+        return display_name
+
+    return "unknown"
+
+
+__all__ = ["resolve_actor_identifier"]

--- a/tests/shared/test_actor_utils.py
+++ b/tests/shared/test_actor_utils.py
@@ -1,0 +1,52 @@
+"""Tests for shared.application.auth.actor_utils."""
+from __future__ import annotations
+
+import pytest
+
+from shared.application.auth import actor_utils
+
+
+class _StubUser:
+    def __init__(self, *, subject_id=None, identifier=None, display_name=None):
+        self.subject_id = subject_id
+        self._identifier = identifier
+        self.display_name = display_name
+
+    def get_id(self):
+        return self._identifier
+
+
+@pytest.fixture
+def set_current_user(monkeypatch):
+    def _apply(user):
+        monkeypatch.setattr(actor_utils, "current_user", user, raising=False)
+
+    return _apply
+
+
+def test_subject_id_is_prioritized(set_current_user):
+    user = _StubUser(subject_id="  user-subject  ", identifier="ignored", display_name="ignored")
+    set_current_user(user)
+
+    assert actor_utils.resolve_actor_identifier() == "user-subject"
+
+
+def test_get_id_used_when_subject_missing(set_current_user):
+    user = _StubUser(subject_id="  ", identifier="  login-id  ")
+    set_current_user(user)
+
+    assert actor_utils.resolve_actor_identifier() == "login-id"
+
+
+def test_display_name_used_as_fallback(set_current_user):
+    user = _StubUser(subject_id=None, identifier="", display_name="  Display Name  ")
+    set_current_user(user)
+
+    assert actor_utils.resolve_actor_identifier() == "Display Name"
+
+
+def test_unknown_returned_when_no_identifier_available(set_current_user):
+    user = _StubUser(subject_id="  ", identifier=None, display_name="  ")
+    set_current_user(user)
+
+    assert actor_utils.resolve_actor_identifier() == "unknown"

--- a/webapp/api/service_account_keys.py
+++ b/webapp/api/service_account_keys.py
@@ -7,6 +7,8 @@ from typing import Any
 from flask import jsonify, request
 from flask_login import current_user
 
+from shared.application.auth import resolve_actor_identifier
+
 from . import bp
 from .openapi import json_request_body
 from .routes import login_or_jwt_required
@@ -38,20 +40,7 @@ def _parse_iso_datetime(raw: Any) -> datetime | None:
 def _resolve_actor_identifier() -> str:
     """現在の主体を表す文字列表現を取得する。"""
 
-    subject_id = getattr(current_user, "subject_id", None)
-    if isinstance(subject_id, str) and subject_id.strip():
-        return subject_id.strip()
-
-    if hasattr(current_user, "get_id"):
-        identifier = current_user.get_id()
-        if isinstance(identifier, str) and identifier.strip():
-            return identifier.strip()
-
-    display_name = getattr(current_user, "display_name", None)
-    if isinstance(display_name, str) and display_name.strip():
-        return display_name.strip()
-
-    return "unknown"
+    return resolve_actor_identifier()
 
 
 def _has_manage_permission() -> bool:


### PR DESCRIPTION
## Summary
- extract a shared application-level helper to resolve the current actor identifier
- update the service account key and certificate APIs to use the shared helper
- add targeted unit tests to cover the actor identifier resolution logic

## Testing
- pytest tests/shared/test_actor_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68f786056e30832392cb6157e83fa8a5