### PR TITLE
Restore user id in logout payload

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -710,6 +710,7 @@ def logout():
         "message": "User logged out",
         "subject_type": getattr(user, "subject_type", None),
         "subject_id": getattr(user, "subject_id", None),
+        "id": getattr(user, "id", None),
         "user_id": getattr(user, "user_id", None),
         "service_account_id": getattr(user, "service_account_id", None),
         "name": getattr(user, "name", None),


### PR DESCRIPTION
## Summary
- include the primary `id` attribute when building the logout audit payload so normal users retain their identifier in logs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f796c0c2548323afd0b608c4009b56