### PR TITLE
Restore user id in logout log payload

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -710,6 +710,7 @@ def logout():
         "message": "User logged out",
         "subject_type": getattr(user, "subject_type", None),
         "subject_id": getattr(user, "subject_id", None),
+        "id": getattr(user, "id", None),
         "user_id": getattr(user, "user_id", None),
         "service_account_id": getattr(user, "service_account_id", None),
         "name": getattr(user, "name", None),


### PR DESCRIPTION
## Summary
- include the concrete user `id` in the logout logging payload so numeric identifiers remain in the audit trail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f796cae5d883238429d8151e7baa5d