### PR TITLE
Handle service account profile role display

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -548,16 +548,26 @@ def profile():
     server_time_utc = datetime.now(timezone.utc)
     localized_time = convert_to_timezone(server_time_utc, tzinfo)
 
+    raw_roles = list(getattr(current_user, "roles", []) or [])
+    role_options = [
+        role
+        for role in raw_roles
+        if hasattr(role, "id") and getattr(role, "id", None) is not None
+    ]
     if request.method == "POST":
         action = request.form.get("action", "update-preferences")
         if action == "switch-role":
             response = make_response(redirect(url_for("auth.profile")))
             role_choice = request.form.get("active_role")
-            available_roles = {str(role.id): role for role in current_user.roles}
+            available_roles = {str(role.id): role for role in role_options}
 
             if role_choice and role_choice in available_roles:
                 session["active_role_id"] = available_roles[role_choice].id
                 flash(_("Active role switched to %(role)s.", role=available_roles[role_choice].name), "success")
+                return response
+
+            if not role_options:
+                flash(_("Role switching is not available for this account."), "error")
                 return response
 
             flash(_("Invalid role selection."), "error")
@@ -629,7 +639,8 @@ def profile():
         selected_timezone=selected_timezone,
         server_time_utc=server_time_utc,
         localized_time=localized_time,
-        active_role=current_user.active_role,
+        active_role=getattr(current_user, "active_role", None),
+        role_options=role_options,
     )
 
 

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -46,8 +46,8 @@
           </div>
         </div>
 
-        {% if current_user.roles %}
-        {% set role_count = current_user.roles|length %}
+        {% if role_options %}
+        {% set role_count = role_options|length %}
         <div class="profile-section mb-4">
           <h2 class="h5 mb-3">{{ _('Role settings') }}</h2>
           {% if role_count > 1 %}
@@ -56,7 +56,7 @@
             <div class="mb-3">
               <label for="active-role" class="form-label">{{ _('Active role') }}</label>
               <select class="form-select" id="active-role" name="active_role" required data-role-switcher-select>
-                {% for role in current_user.roles %}
+                {% for role in role_options %}
                   {% set is_selected = (active_role and role.id == active_role.id) or (not active_role and loop.first) %}
                   <option value="{{ role.id }}" data-role-permissions='{{ role.permissions|map(attribute="code")|list|tojson }}'
                           {% if is_selected %}selected{% endif %}>{{ role.name }}</option>
@@ -72,7 +72,7 @@
           <div class="profile-summary">
             <span class="text-muted small text-uppercase">{{ _('Current Roles') }}</span>
             <div class="d-flex flex-wrap gap-2 mt-1">
-              {% for role in current_user.roles %}
+              {% for role in role_options %}
                 <span class="badge bg-secondary">{{ role.name }}</span>
               {% endfor %}
             </div>

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1331,3 +1331,6 @@ msgstr "Internal Server Error"
 msgid "Error"
 msgstr "Error"
 
+msgid "Role switching is not available for this account."
+msgstr "Role switching is not available for this account."
+

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1439,6 +1439,9 @@ msgstr "期限切れ"
 msgid "Error"
 msgstr "エラー"
 
+msgid "Role switching is not available for this account."
+msgstr "このアカウントではロール切り替えを利用できません。"
+
 #: webapp/photo-view/templates/photo-view/home.html:52
 #: webapp/photo-view/templates/photo-view/session_detail.html:73
 msgid "Failed"


### PR DESCRIPTION
## Summary
- avoid accessing unavailable role attributes for service-account principals in the profile view
- hide role switching UI when no role objects are present and provide a fallback message if switching is attempted
- add translation entries for the new flash message in English and Japanese

## Testing
- pytest tests/test_auth_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68f79a52d2cc832381635b9244bce382