### PR TITLE
Handle principal objects when revoking refresh tokens

### DIFF
--- a/webapp/services/token_service.py
+++ b/webapp/services/token_service.py
@@ -392,11 +392,12 @@ class TokenService:
                 )
                 return
 
-            target_user = User.query.get(subject.id)
+            user_id = subject.subject_id
+            target_user = User.query.get(user_id)
             if target_user is None:
                 current_app.logger.debug(
                     "Refresh token revoke skipped: user not found (id=%s)",
-                    subject.id,
+                    user_id,
                 )
                 return
         elif isinstance(subject, User):


### PR DESCRIPTION
## Summary
- allow `TokenService.revoke_refresh_token` to accept authenticated principals
- log and safely skip revocation when a backing user cannot be resolved
- resolve the refresh token revocation user lookup using `AuthenticatedPrincipal.subject_id`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f79de5e57883238e699f786448f179