### PR TITLE
Fix principal handling when revoking refresh tokens

### DIFF
--- a/webapp/services/token_service.py
+++ b/webapp/services/token_service.py
@@ -392,11 +392,18 @@ class TokenService:
                 )
                 return
 
-            target_user = User.query.get(subject.id)
+            user_id = subject.subject_id
+            if user_id is None:
+                current_app.logger.debug(
+                    "Refresh token revoke skipped: principal missing subject_id",
+                )
+                return
+
+            target_user = User.query.get(user_id)
             if target_user is None:
                 current_app.logger.debug(
                     "Refresh token revoke skipped: user not found (id=%s)",
-                    subject.id,
+                    user_id,
                 )
                 return
         elif isinstance(subject, User):


### PR DESCRIPTION
## Summary
- resolve the user ID from `AuthenticatedPrincipal.subject_id` when revoking refresh tokens
- guard against principals without a subject ID and keep logging consistent when no user exists

## Testing
- pytest tests/test_token_service_revocation.py

------
https://chatgpt.com/codex/tasks/task_e_68f79dd58e8483239a30b3d82e73c1c7