### PR TITLE
Ensure all 5xx errors use the server error handler

### DIFF
--- a/webapp/error_handlers.py
+++ b/webapp/error_handlers.py
@@ -1,0 +1,78 @@
+"""Centralized HTTP error handling for HTML requests."""
+from flask import current_app, flash, jsonify, redirect, request, url_for
+from flask_babel import gettext as _
+
+
+def _is_api_request() -> bool:
+    """Return True when the current request targets the API."""
+    path = request.path or ""
+    return path == "/api" or path.startswith("/api/")
+
+
+def _handle_html_error(error, *, is_server_error: bool):
+    """Return a redirect response for HTML errors while logging appropriately."""
+
+    code = getattr(error, "code", 500 if is_server_error else 400)
+
+    if _is_api_request():
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "code": code,
+                    "message": getattr(error, "description", "Unexpected error"),
+                }
+            ),
+            code,
+        )
+
+    logger = current_app.logger.error if is_server_error else current_app.logger.warning
+    log_kwargs = {"exc_info": error} if is_server_error else {}
+    logger("%s %s (%s)", code, request.path, request.remote_addr, **log_kwargs)
+
+    if is_server_error:
+        flash(_("An unexpected error occurred. Please try again later."), "error")
+
+    return redirect(url_for("index"))
+
+
+def register_error_handlers(app):
+    """Register global error handlers for HTML responses.
+
+    API endpoints keep returning JSON errors as before.
+    """
+
+    @app.errorhandler(403)
+    @app.errorhandler(404)
+    @app.errorhandler(405)
+    def handle_client_errors(error):
+        """Handle 4xx errors by redirecting to the top page."""
+
+        return _handle_html_error(error, is_server_error=False)
+
+    def handle_server_errors(error):
+        """Handle 5xx errors by redirecting to the top page."""
+
+        return _handle_html_error(error, is_server_error=True)
+
+    for status_code in range(500, 600):
+        app.register_error_handler(status_code, handle_server_errors)
+
+    @app.errorhandler(401)
+    def handle_unauthorized(error):
+        """Handle authentication failures by redirecting to the login page."""
+        if _is_api_request():
+            return (
+                jsonify(
+                    {
+                        "status": "unauthorized",
+                        "code": 401,
+                        "message": "Authentication required.",
+                    }
+                ),
+                401,
+            )
+
+        current_app.logger.info("401 %s -> redirect login", request.path)
+        return redirect(url_for("auth.login"))
+

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -265,6 +265,10 @@ msgstr "This page requires login."
 msgid "Please log in to access this page."
 msgstr "Please log in to access this page."
 
+#: webapp/error_handlers.py:45
+msgid "An unexpected error occurred. Please try again later."
+msgstr "An unexpected error occurred. Please try again later."
+
 msgid "If you cannot scan the QR code, add this secret manually in your app:"
 msgstr "If you cannot scan the QR code, add this secret manually in your app:"
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -22,6 +22,10 @@ msgstr ""
 msgid "Please log in to access this page."
 msgstr "このページにアクセスするにはログインが必要です。"
 
+#: webapp/error_handlers.py:45
+msgid "An unexpected error occurred. Please try again later."
+msgstr "予期せぬエラーが発生しました。しばらくしてから再度お試しください。"
+
 #: webapp/__init__.py:262 webapp/auth/templates/auth/login.html:2
 #: webapp/templates/base.html:98
 msgid "Login"


### PR DESCRIPTION
## Summary
- split the shared error handler into dedicated client and server variants with a private helper
- ensure every 5xx status code is registered with the server error handler so they log at error level, flash the message, and redirect to the top page
- keep API endpoints returning JSON error payloads consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8145fad9c83238ae960d540eaa07c