### PR TITLE
Fix server error handler registration

### DIFF
--- a/webapp/error_handlers.py
+++ b/webapp/error_handlers.py
@@ -1,6 +1,7 @@
 """Centralized HTTP error handling for HTML requests."""
 from flask import current_app, flash, jsonify, redirect, request, url_for
 from flask_babel import gettext as _
+from werkzeug.exceptions import InternalServerError, default_exceptions
 
 
 def _is_api_request() -> bool:
@@ -55,8 +56,14 @@ def register_error_handlers(app):
 
         return _handle_html_error(error, is_server_error=True)
 
-    for status_code in range(500, 600):
+    server_error_status_codes = [
+        status_code for status_code in default_exceptions if 500 <= status_code < 600
+    ]
+
+    for status_code in server_error_status_codes:
         app.register_error_handler(status_code, handle_server_errors)
+
+    app.register_error_handler(InternalServerError, handle_server_errors)
 
     @app.errorhandler(401)
     def handle_unauthorized(error):


### PR DESCRIPTION
## Summary
- restrict server error handler registration to Werkzeug-known 5xx codes to avoid invalid HTTP code errors
- register a fallback handler for InternalServerError so unexpected exceptions still reuse the HTML redirect flow

## Testing
- pytest *(fails: existing failures in tests/test_api_error_localization.py and tests/test_local_import_duplicate_refresh.py; run interrupted after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68f81f6accfc83239256698f249afa0c