### PR TITLE
Disable profile editing for service accounts

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -650,6 +650,9 @@ def profile():
 @login_required
 def edit():
     is_service_account = bool(getattr(current_user, "is_service_account", False))
+    if is_service_account:
+        flash(_("Service accounts cannot edit profile details."), "warning")
+        return redirect(url_for("auth.profile"))
     if request.method == "POST":
         email = request.form.get("email")
         password = request.form.get("password")

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -106,9 +106,18 @@
             <button type="submit" class="btn btn-primary">
               <i class="fas fa-save me-2"></i>{{ _('Save preferences') }}
             </button>
-            <a href="{{ url_for('auth.edit') }}" class="btn btn-outline-secondary">
-              <i class="fas fa-user-edit me-2"></i>{{ _('Edit profile details') }}
-            </a>
+            {% if is_service_account %}
+              <button type="button" class="btn btn-outline-secondary" disabled>
+                <i class="fas fa-user-edit me-2"></i>{{ _('Edit profile details') }}
+              </button>
+              <div class="form-text text-muted small">
+                {{ _('Profile details are managed by administrators for service accounts.') }}
+              </div>
+            {% else %}
+              <a href="{{ url_for('auth.edit') }}" class="btn btn-outline-secondary">
+                <i class="fas fa-user-edit me-2"></i>{{ _('Edit profile details') }}
+              </a>
+            {% endif %}
             {% if not is_service_account and not current_user.totp_secret %}
               <a href="{{ url_for('auth.setup_totp', next=url_for('auth.profile')) }}" class="btn btn-outline-warning">
                 <i class="fas fa-mobile-alt me-2"></i>{{ _('Enable two-factor authentication') }}

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -486,6 +486,12 @@ msgstr "Two-factor authentication setup cancelled."
 msgid "Two-factor authentication is not available for service accounts."
 msgstr "Two-factor authentication is not available for service accounts."
 
+msgid "Service accounts cannot edit profile details."
+msgstr "Service accounts cannot edit profile details."
+
+msgid "Profile details are managed by administrators for service accounts."
+msgstr "Profile details are managed by administrators for service accounts."
+
 msgid "Registration session invalid. Please register again."
 msgstr "Registration session invalid. Please register again."
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -742,6 +742,12 @@ msgstr "二要素認証の設定がキャンセルされました。"
 msgid "Two-factor authentication is not available for service accounts."
 msgstr "サービスアカウントでは二要素認証を利用できません。"
 
+msgid "Service accounts cannot edit profile details."
+msgstr "サービスアカウントではプロフィール詳細を編集できません。"
+
+msgid "Profile details are managed by administrators for service accounts."
+msgstr "サービスアカウントのプロフィール詳細は管理者が管理します。"
+
 #: webapp/auth/routes.py:283
 msgid "Logged out"
 msgstr "ログアウトしました"


### PR DESCRIPTION
## Summary
- block service accounts from accessing the profile edit endpoint and show a warning
- hide the "Edit profile details" button for service accounts on the profile page with explanatory copy
- add English and Japanese localization strings for the new service-account messaging

## Testing
- pytest tests/test_auth_profile.py -q
- pytest tests/test_api_error_localization.py -q *(fails: API error responses lack the expected `error` field on the base branch)*

------
https://chatgpt.com/codex/tasks/task_e_68f821c3cafc83238ce2d6f5b9aa89e7