### PR TITLE
Add closeable navigation sidebar to admin config view

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -42,10 +42,27 @@
 <h3>{{ _('Config Settings') }}</h3>
 
 <div class="row g-4 align-items-start">
-  <div class="col-xl-3">
+  <div class="col-12 col-xl-3" data-config-sidebar>
     <div class="card shadow-sm config-sidebar sticky-top">
       <div class="card-body">
-        <nav class="config-tree" data-config-tree aria-label="{{ _('Configuration navigation') }}">
+        <div class="config-sidebar__header">
+          <span class="config-sidebar__title">{{ _('Settings navigation') }}</span>
+          <button
+            type="button"
+            class="btn-close config-sidebar__close"
+            data-config-sidebar-close
+            aria-label="{{ _('Hide navigation') }}"
+            aria-controls="config-navigation"
+            aria-expanded="true"
+          ></button>
+        </div>
+        <nav
+          id="config-navigation"
+          class="config-tree"
+          data-config-tree
+          aria-label="{{ _('Configuration navigation') }}"
+          tabindex="-1"
+        >
           <ul class="list-unstyled mb-0">
             <li
               class="config-tree__item"
@@ -132,8 +149,19 @@
       </div>
     </div>
   </div>
-  <div class="col-xl-9">
-    <div class="config-search mb-4 d-flex justify-content-lg-end">
+  <div class="col-12 col-xl-9" data-config-content>
+    <button
+      type="button"
+      class="btn btn-outline-secondary btn-sm config-sidebar__open d-none mb-3"
+      data-config-sidebar-open
+      aria-controls="config-navigation"
+      aria-expanded="false"
+      aria-hidden="true"
+    >
+      <i class="fas fa-bars me-1" aria-hidden="true"></i>
+      {{ _('Show navigation') }}
+    </button>
+    <div class="config-search mb-4">
       <div class="config-search__field">
         <label class="form-label" for="config-search">{{ _('Search settings') }}</label>
         <input

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -12,6 +12,70 @@
 
   let reapplySearchFilter = null;
 
+  const sidebarColumn = document.querySelector('[data-config-sidebar]');
+  const contentColumn = document.querySelector('[data-config-content]');
+  const closeSidebarButton = document.querySelector('[data-config-sidebar-close]');
+  const openSidebarButton = document.querySelector('[data-config-sidebar-open]');
+  const configNavigation = document.querySelector('[data-config-tree]');
+
+  if (configNavigation && !configNavigation.id) {
+    configNavigation.id = 'config-navigation';
+  }
+  if (configNavigation) {
+    configNavigation.setAttribute('tabindex', '-1');
+  }
+  if (closeSidebarButton && configNavigation) {
+    closeSidebarButton.setAttribute('aria-controls', configNavigation.id);
+  }
+  if (openSidebarButton && configNavigation) {
+    openSidebarButton.setAttribute('aria-controls', configNavigation.id);
+  }
+
+  const applySidebarState = (hidden, { manageFocus = true } = {}) => {
+    if (sidebarColumn) {
+      sidebarColumn.classList.toggle('d-none', hidden);
+      sidebarColumn.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+    }
+    if (contentColumn) {
+      contentColumn.classList.toggle('col-xl-9', !hidden);
+      contentColumn.classList.toggle('col-xl-12', hidden);
+    }
+    if (openSidebarButton) {
+      openSidebarButton.classList.toggle('d-none', !hidden);
+      openSidebarButton.setAttribute('aria-hidden', hidden ? 'false' : 'true');
+      openSidebarButton.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+    }
+    if (closeSidebarButton) {
+      closeSidebarButton.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+    }
+    if (!manageFocus) {
+      return;
+    }
+    if (hidden) {
+      if (openSidebarButton) {
+        openSidebarButton.focus({ preventScroll: true });
+      }
+    } else if (configNavigation) {
+      configNavigation.focus({ preventScroll: true });
+    }
+  };
+
+  if (closeSidebarButton) {
+    closeSidebarButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      applySidebarState(true);
+    });
+  }
+
+  if (openSidebarButton) {
+    openSidebarButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      applySidebarState(false);
+    });
+  }
+
+  applySidebarState(false, { manageFocus: false });
+
   const cssEscape = (value) => {
     if (window.CSS && typeof window.CSS.escape === 'function') {
       return window.CSS.escape(value);

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -186,6 +186,32 @@ body.login-page footer {
   overflow-y: auto;
 }
 
+.config-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.config-sidebar__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.config-sidebar__close {
+  flex-shrink: 0;
+}
+
+.config-sidebar__open {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .config-tree__heading {
   font-size: 0.75rem;
   font-weight: 600;

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -1347,3 +1347,13 @@ msgstr "Error"
 msgid "Role switching is not available for this account."
 msgstr "Role switching is not available for this account."
 
+
+msgid "Settings navigation"
+msgstr "Settings navigation"
+
+msgid "Hide navigation"
+msgstr "Hide navigation"
+
+msgid "Show navigation"
+msgstr "Show navigation"
+

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -3373,3 +3373,13 @@ msgstr "サーバー内部エラー"
 
 msgid "Error"
 msgstr "エラー"
+
+msgid "Settings navigation"
+msgstr "設定ナビゲーション"
+
+msgid "Hide navigation"
+msgstr "ナビゲーションを隠す"
+
+msgid "Show navigation"
+msgstr "ナビゲーションを表示"
+


### PR DESCRIPTION
## Summary
- add a close button to the admin configuration sidebar and provide a reopen control for the content area
- adjust the search form layout so the "Search settings" control is left-aligned and update related styles
- provide English and Japanese translations for the new navigation labels

## Testing
- pytest *(fails: tests/test_api_error_localization.py::{test_api_error_default_language,test_api_error_respects_accept_language,test_api_server_error_localized_message}, tests/test_local_import_duplicate_refresh.py::test_duplicate_refresh_realigns_playback_paths)*

------
https://chatgpt.com/codex/tasks/task_e_68f841bac8f0832391e67b106bf37723