### PR TITLE
Fix type hint imports across models and settings

### DIFF
--- a/core/models/celery_task.py
+++ b/core/models/celery_task.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from __future__ import annotations
-
 import enum
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.job_sync import JobSync
 
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
@@ -157,11 +158,10 @@ class CeleryTaskRecord(db.Model):
 
         if record is None:
             obj_type, obj_id = object_identity or (None, None)
-            record = cls(
-                task_name=task_name,
-                object_type=obj_type,
-                object_id=obj_id,
-            )
+            record = cls()
+            record.task_name = task_name
+            record.object_type = obj_type
+            record.object_id = obj_id
             scoped_db.session.add(record)
 
         if celery_task_id and record.celery_task_id != celery_task_id:

--- a/core/models/google_account.py
+++ b/core/models/google_account.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
 from core.crypto import decrypt
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.user import User
+    from core.models.picker_session import PickerSession
+    from core.models.photo_models import Media
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
 

--- a/core/models/job_sync.py
+++ b/core/models/job_sync.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.celery_task import CeleryTaskRecord
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
 

--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -2,10 +2,15 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.google_account import GoogleAccount
+    from core.models.picker_session import PickerSession
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
 

--- a/core/models/picker_session.py
+++ b/core/models/picker_session.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from sqlalchemy import event, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.google_account import GoogleAccount
+    from core.models.photo_models import PickerSelection
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
 

--- a/core/models/service_account.py
+++ b/core/models/service_account.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, TYPE_CHECKING
 
 from sqlalchemy.orm import DynamicMapped, Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.service_account_api_key import ServiceAccountApiKey
 
 # Align BIGINT usage with other models to keep SQLite compatibility
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")

--- a/core/models/service_account_api_key.py
+++ b/core/models/service_account_api_key.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, List
+from typing import Iterable, List, TYPE_CHECKING
 
 from sqlalchemy.orm import DynamicMapped, Mapped, mapped_column, relationship
 from werkzeug.security import check_password_hash
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.service_account import ServiceAccount
 
 # Align BIGINT usage with other models to keep SQLite compatibility
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")

--- a/core/models/totp.py
+++ b/core/models/totp.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.user import User
 
 # SQLite 互換の BigInt 定義
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Optional
+from typing import Iterable, Optional, TYPE_CHECKING
 
 from flask import has_request_context, session, g
 from flask_login import UserMixin
@@ -9,6 +9,11 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
 from werkzeug.security import generate_password_hash, check_password_hash
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.google_account import GoogleAccount
+    from core.models.totp import TOTPCredential
 
 
 # Define BIGINT type compatible with SQLite auto increment

--- a/core/models/wiki/models.py
+++ b/core/models/wiki/models.py
@@ -2,12 +2,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.db import db
 
 BigInt = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models.user import User
 
 
 # Wiki ページとカテゴリの中間テーブル

--- a/core/storage_service.py
+++ b/core/storage_service.py
@@ -6,7 +6,17 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Optional, Protocol, Sequence, runtime_checkable
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
 
 from domain.storage import StorageDomain, StorageIntent, StorageResolution
 
@@ -74,7 +84,7 @@ class StorageService(Protocol):
     def remove_tree(self, path: str) -> None:
         ...
 
-    def open(self, path: str, mode: str = "rb", **kwargs: Any):
+    def open(self, path: str, mode: str = "rb", **kwargs: Any) -> IO[Any]:
         ...
 
     def walk(self, top: str) -> Iterator[tuple[str, list[str], list[str]]]:
@@ -261,7 +271,7 @@ class LocalFilesystemStorageService:
     def remove_tree(self, path: str) -> None:
         shutil.rmtree(path)
 
-    def open(self, path: str, mode: str = "rb", **kwargs: Any):
+    def open(self, path: str, mode: str = "rb", **kwargs: Any) -> IO[Any]:
         if any(flag in mode for flag in ("w", "a", "+")):
             self.ensure_parent(path)
         return open(path, mode, **kwargs)


### PR DESCRIPTION
## Summary
- add TYPE_CHECKING imports to SQLAlchemy models to resolve forward reference errors
- adjust Celery task factory logic and storage settings helpers to satisfy Pylance typing
- tighten StorageService protocol return annotations to match LocalFilesystemStorageService implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb3660703083238c80c9c880f90939