### PR TITLE
Add admin UI support for custom setting descriptions

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -452,10 +452,45 @@
                       </td>
                       <td>{% if field.required %}{{ _('Yes') }}{% else %}{{ _('No') }}{% endif %}</td>
                       <td class="small">
-                        {{ field.description }}
+                        <div data-field-description-text>{{ field.description }}</div>
+                        {% set default_label = _('Default description: %(description)s', description='__DEFAULT__') %}
+                        {% if field.custom_description and field.base_description %}
+                        <div
+                          class="text-muted small mt-1"
+                          data-field-description-default
+                          data-default-label="{{ default_label }}"
+                        >
+                          {{ _('Default description: %(description)s', description=field.base_description) }}
+                        </div>
+                        {% else %}
+                        <div
+                          class="text-muted small mt-1{% if not field.base_description %} d-none{% endif %}"
+                          data-field-description-default
+                          data-default-label="{{ default_label }}"
+                        >
+                          {% if field.base_description %}
+                          {{ _('Default description: %(description)s', description=field.base_description) }}
+                          {% endif %}
+                        </div>
+                        {% endif %}
                         {% if field.default_hint %}
                         <div class="text-muted">{{ field.default_hint }}</div>
                         {% endif %}
+                        <div class="mt-2">
+                          <label class="form-label mb-1" for="app-config-description-{{ field.key }}">
+                            {{ _('Custom description (optional)') }}
+                          </label>
+                          <textarea
+                            class="form-control form-control-sm"
+                            id="app-config-description-{{ field.key }}"
+                            name="app_config_description[{{ field.key }}]"
+                            rows="2"
+                            data-field-description-input
+                          >{{- field.custom_description_input|default('') -}}</textarea>
+                          <div class="form-text">
+                            {{ _('Leave blank to use the default description shown above.') }}
+                          </div>
+                        </div>
                       </td>
                       <td>
                         {% if field.editable %}

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -152,6 +152,35 @@
       const defaultCell = row.querySelector('[data-field="default"]');
       updateDefaultCell(defaultCell, field.default_json);
 
+      const descriptionText = row.querySelector('[data-field-description-text]');
+      if (descriptionText) {
+        descriptionText.textContent = field.description || '';
+      }
+
+      const defaultDescription = row.querySelector('[data-field-description-default]');
+      if (defaultDescription) {
+        const baseDescription = field.base_description || '';
+        const template = defaultDescription.dataset.defaultLabel || '';
+        if (baseDescription && template) {
+          defaultDescription.textContent = template.replace('__DEFAULT__', baseDescription);
+        } else if (baseDescription) {
+          defaultDescription.textContent = baseDescription;
+        } else {
+          defaultDescription.textContent = '';
+        }
+        const hasCustom = !!(field.custom_description && field.custom_description.length > 0);
+        const shouldHide = !baseDescription || !hasCustom;
+        defaultDescription.classList.toggle('d-none', shouldHide);
+      }
+
+      const descriptionInput = row.querySelector('[data-field-description-input]');
+      if (descriptionInput) {
+        updateInputValue(
+          descriptionInput,
+          field.custom_description_input ?? field.custom_description ?? ''
+        );
+      }
+
       const input = row.querySelector('[data-field-input]');
       updateInputValue(input, field.form_value);
 


### PR DESCRIPTION
## Summary
- persist per-setting description metadata in the system settings service and include it in serialized responses
- expose editable custom descriptions for application settings in the admin configuration UI and keep the frontend in sync
- extend admin configuration tests to cover adding and clearing setting descriptions

## Testing
- pytest tests/test_admin_config.py

------
https://chatgpt.com/codex/tasks/task_e_68fef666258c83238f948d3ba3619528