### PR TITLE
Improve admin config selection error message

### DIFF
--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -762,7 +762,11 @@ def show_config():
                 and request.form.get(f"app_config_use_default[{key}]") == "1"
             }
             if not app_selected:
-                errors.append(_(u"Select at least one setting to update."))
+                errors.append(
+                    _(
+                        u"To save changes, select at least one setting and check its \"Update\" box."
+                    )
+                )
             else:
                 updates: Dict[str, Any] = {}
                 remove_keys: list[str] = []

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -159,6 +159,10 @@ msgstr "Review uploaded photos and manage shared media assets."
 msgid "Open media view"
 msgstr "Open media view"
 
+#: webapp/admin/routes.py:767
+msgid "To save changes, select at least one setting and check its \"Update\" box."
+msgstr "To save changes, select at least one setting and check its \"Update\" box."
+
 #: webapp/dashboard/templates/dashboard/index.html:65
 msgid "No workspace tools are available for your current role."
 msgstr "No workspace tools are available for your current role."

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -157,6 +157,10 @@ msgstr "Googleアカウント"
 msgid "Certificate Management"
 msgstr "証明書管理"
 
+#: webapp/admin/routes.py:767
+msgid "To save changes, select at least one setting and check its \"Update\" box."
+msgstr "変更を保存するには、「Update」にチェックを入れて更新する設定を選択してください。"
+
 #: webapp/templates/base.html:68
 msgid "Certificates"
 msgstr "証明書"


### PR DESCRIPTION
## Summary
- clarify the error message shown when no configuration rows are selected for update
- add matching English and Japanese translations for the new message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff61e62228832387c2ee17134d3e6b