### PR TITLE
Add session diagnostics to unauthorized access logging

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -240,6 +240,15 @@ def test_unauthorized_logging_records_context(app):
         assert payload["request"]["user_agent"] == "pytest-agent"
         assert payload["message"] == "Redirected to login due to unauthorized access."
 
+        session_payload = payload["session"]
+        assert session_payload["cookie_name"] == app.config.get("SESSION_COOKIE_NAME", "session")
+        assert session_payload["cookie_present"] is False
+        assert session_payload["session_new"] is False
+        assert session_payload["session_permanent"] is False
+        assert session_payload["fresh_login"] is None
+        assert session_payload["remember_token_present"] is False
+        assert session_payload["user_id_present"] is True
+
 
 def test_status_change_logged(client):
     """Statusフィールドの変更がログに記録されることを確認する。"""

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1284,6 +1284,18 @@ def create_app():
         if not client_ip:
             client_ip = request.remote_addr
 
+        session_cookie_name = app.config.get("SESSION_COOKIE_NAME", "session")
+        session_cookie_value = request.cookies.get(session_cookie_name)
+        session_info = {
+            "cookie_name": session_cookie_name,
+            "cookie_present": session_cookie_value is not None,
+            "session_new": getattr(session, "new", None),
+            "session_permanent": session.permanent,
+            "fresh_login": session.get("_fresh"),
+            "remember_token_present": "_remember" in session,
+            "user_id_present": raw_user_id is not None,
+        }
+
         log_payload = {
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "id": request_id,
@@ -1301,6 +1313,7 @@ def create_app():
                 "forwarded_for": forwarded_for,
                 "user_agent": request.user_agent.string,
             },
+            "session": session_info,
         }
 
         app.logger.warning(


### PR DESCRIPTION
## Summary
- log additional session context, including cookie presence and freshness flags, when unauthorized users are redirected to login
- extend the unauthorized logging test to validate the new session diagnostics payload

## Testing
- pytest tests/test_logging.py::test_unauthorized_logging_records_context

------
https://chatgpt.com/codex/tasks/task_e_68ff634f229c8323ac7629522e467d64