### PR TITLE
Use i18n strings for admin config toasts

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -635,5 +635,12 @@
 
 {% block extra_scripts %}
 {{ super() }}
+<script>
+  window.i18nStrings = Object.assign(window.i18nStrings || {}, {
+    'admin.config.update.success': "{{ _('Configuration updated successfully.') }}",
+    'admin.config.update.failure': "{{ _('Configuration update failed.') }}",
+    'admin.config.request.failure': "{{ _('Failed to submit the request.') }}",
+  });
+</script>
 <script src="{{ url_for('static', filename='js/admin-config.js') }}"></script>
 {% endblock %}

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -9,6 +9,22 @@
   const showSuccess = window.showSuccessToast || ((msg) => console.log(msg));
   const showError = window.showErrorToast || ((msg) => console.error(msg));
   const showWarning = window.showWarningToast || ((msg) => console.warn(msg));
+  const translate =
+    typeof window._ === 'function' ? window._ : (key, fallback = key) => fallback;
+  const i18nMessages = {
+    updateSuccess: translate(
+      'admin.config.update.success',
+      'Configuration updated successfully.'
+    ),
+    updateFailure: translate(
+      'admin.config.update.failure',
+      'Configuration update failed.'
+    ),
+    requestFailure: translate(
+      'admin.config.request.failure',
+      'Failed to submit the request.'
+    ),
+  };
 
   let reapplySearchFilter = null;
 
@@ -543,7 +559,7 @@
 
         const data = await response.json().catch(() => null);
         if (!response.ok || !data || data.status !== 'success') {
-          const message = data && data.message ? data.message : '設定の更新に失敗しました。';
+          const message = data && data.message ? data.message : i18nMessages.updateFailure;
           showError(message);
           if (data && Array.isArray(data.errors)) {
             data.errors.slice(1).forEach((msg) => showError(msg));
@@ -551,14 +567,14 @@
           return;
         }
 
-        showSuccess(data.message || '設定を更新しました。');
+        showSuccess(data.message || i18nMessages.updateSuccess);
         if (Array.isArray(data.warnings)) {
           data.warnings.forEach((msg) => showWarning(msg));
         }
         applyContext(data);
       } catch (error) {
         console.error('Failed to submit config form', error);
-        showError('リクエストの送信に失敗しました。');
+        showError(i18nMessages.requestFailure);
       } finally {
         if (submitButton) {
           submitButton.disabled = false;

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -115,6 +115,18 @@ msgstr "Registration successful. Please log in."
 msgid "Logged out"
 msgstr "Logged out"
 
+#: webapp/static/js/admin-config.js
+msgid "Configuration updated successfully."
+msgstr "Configuration updated successfully."
+
+#: webapp/static/js/admin-config.js
+msgid "Configuration update failed."
+msgstr "Configuration update failed."
+
+#: webapp/static/js/admin-config.js
+msgid "Failed to submit the request."
+msgstr "Failed to submit the request."
+
 #: webapp/dashboard/templates/dashboard/index.html:6
 msgid "Workspace dashboard"
 msgstr "Workspace dashboard"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -756,6 +756,18 @@ msgstr "サービスアカウントのプロフィール詳細は管理者が管
 msgid "Logged out"
 msgstr "ログアウトしました"
 
+#: webapp/static/js/admin-config.js
+msgid "Configuration updated successfully."
+msgstr "設定を更新しました。"
+
+#: webapp/static/js/admin-config.js
+msgid "Configuration update failed."
+msgstr "設定の更新に失敗しました。"
+
+#: webapp/static/js/admin-config.js
+msgid "Failed to submit the request."
+msgstr "リクエストの送信に失敗しました。"
+
 #: webapp/auth/routes.py:292
 #, python-format
 msgid "Google OAuth error: %(msg)s"


### PR DESCRIPTION
## Summary
- load admin config toast messaging from translation resources instead of hardcoded strings
- expose the required translation keys in the admin config template with sensible fallbacks
- add English and Japanese translations for the new configuration status messages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff6c55f3fc8323afaec1a01f67e518