### PR TITLE
Improve admin config layout responsiveness

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -328,7 +328,7 @@ body.login-page footer {
   position: sticky;
   bottom: 0.5rem;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   padding: 0.75rem 0.25rem 0.25rem;
   margin-top: 1rem;
   background: linear-gradient(
@@ -345,6 +345,17 @@ body.login-page footer {
 
 .config-section-actions .btn {
   min-width: 14rem;
+}
+
+.config-section-card .table-responsive,
+.config-block[data-config-block="cors"] .table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.config-section-card .table,
+.config-block[data-config-block="cors"] .table {
+  min-width: 48rem;
 }
 
 .config-block + .config-block {


### PR DESCRIPTION
## Summary
- allow the admin config tables to scroll horizontally on narrow screens
- align the section save buttons to the left for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffdc75ac20832384b1365320a89ae1