### PR TITLE
Adjust admin config table column wrapping

### DIFF
--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -348,7 +348,7 @@
                       data-search-text="{{ field.search_text|e }}"
                       data-app-key="{{ field.key }}"
                     >
-                      <td>
+                      <td class="config-table__cell config-table__cell--key">
                         <div><code>{{ field.key }}</code></div>
                         <div class="text-muted small">{{ field.label }}</div>
                         <span
@@ -364,9 +364,14 @@
                           {% endif %}
                         </span>
                       </td>
-                      <td class="font-monospace small" data-field="current">{{ field.current_json }}</td>
                       <td
-                        class="font-monospace small{% if not field.default_json %} text-muted{% endif %}"
+                        class="config-table__cell config-table__cell--current font-monospace small"
+                        data-field="current"
+                      >
+                        {{ field.current_json }}
+                      </td>
+                      <td
+                        class="config-table__cell config-table__cell--default font-monospace small{% if not field.default_json %} text-muted{% endif %}"
                         data-field="default"
                         data-none-label="{{ _('None') }}"
                       >

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -358,6 +358,33 @@ body.login-page footer {
   min-width: 48rem;
 }
 
+.config-table__cell {
+  vertical-align: top;
+}
+
+.config-table__cell--key {
+  min-width: 12rem;
+  max-width: 20rem;
+}
+
+.config-table__cell--key code,
+.config-table__cell--key .text-muted {
+  display: inline-block;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.config-table__cell--current,
+.config-table__cell--default {
+  min-width: 12rem;
+  max-width: 24rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .config-block + .config-block {
   margin-top: 2rem;
 }


### PR DESCRIPTION
## Summary
- add column-specific classes to the admin configuration table markup
- constrain column widths and allow long identifiers to wrap without stretching the layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69000fae25148323a359074092f3ad28