### PR TITLE
Ensure remember cookie inherits secure session setting

### DIFF
--- a/tests/test_remember_cookie_secure.py
+++ b/tests/test_remember_cookie_secure.py
@@ -29,3 +29,46 @@ def test_remember_cookie_secure_inherits_session(monkeypatch):
 
     assert app.config["SESSION_COOKIE_SECURE"] is True
     assert app.config["REMEMBER_COOKIE_SECURE"] is True
+
+
+def test_remember_cookie_secure_updates_with_session_changes(monkeypatch):
+    from webapp.services import system_setting_service
+
+    def _load_cors_config(cls) -> Dict[str, Any]:
+        return {"allowedOrigins": []}
+
+    monkeypatch.setattr(
+        system_setting_service.SystemSettingService,
+        "load_cors_config",
+        classmethod(_load_cors_config),
+    )
+
+    def _load_application_config_false(cls) -> Dict[str, Any]:
+        return {"SESSION_COOKIE_SECURE": False}
+
+    monkeypatch.setattr(
+        system_setting_service.SystemSettingService,
+        "load_application_config",
+        classmethod(_load_application_config_false),
+    )
+
+    from webapp import _apply_persisted_settings, create_app
+
+    app = create_app()
+
+    assert app.config["SESSION_COOKIE_SECURE"] is False
+    assert app.config["REMEMBER_COOKIE_SECURE"] is False
+
+    def _load_application_config_true(cls) -> Dict[str, Any]:
+        return {"SESSION_COOKIE_SECURE": True}
+
+    monkeypatch.setattr(
+        system_setting_service.SystemSettingService,
+        "load_application_config",
+        classmethod(_load_application_config_true),
+    )
+
+    _apply_persisted_settings(app)
+
+    assert app.config["SESSION_COOKIE_SECURE"] is True
+    assert app.config["REMEMBER_COOKIE_SECURE"] is True

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -722,7 +722,7 @@ def _apply_persisted_settings(app: Flask) -> None:
         else:
             app.config[key] = value
 
-    if "REMEMBER_COOKIE_SECURE" not in app.config:
+    if "REMEMBER_COOKIE_SECURE" not in config_payload:
         app.config["REMEMBER_COOKIE_SECURE"] = bool(
             app.config.get("SESSION_COOKIE_SECURE", False)
         )


### PR DESCRIPTION
## Summary
- propagate the persisted SESSION_COOKIE_SECURE value to Flask-Login remember cookies
- add a regression test to ensure REMEMBER_COOKIE_SECURE mirrors the session flag

## Testing
- pytest tests/test_remember_cookie_secure.py

------
https://chatgpt.com/codex/tasks/task_e_690012ca792c8323a1b916eaa505f654