### PR TITLE
Display effective CORS origins in admin config

### DIFF
--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -94,10 +94,12 @@ def test_config_page_displays_current_settings(client):
     html = response.data.decode("utf-8")
     assert 'name="app_config_new[FEATURE_FLAG]"' in html
     assert 'name="cors_new[allowedOrigins]"' in html
-    assert 'id="cors-CORS_ALLOWED_ORIGINS"' in html
     assert 'name="cors_new[CORS_ALLOWED_ORIGINS]"' not in html
     assert "Updated automatically after saving allowedOrigins." in html
     assert "https://example.com" in html
+    assert 'data-cors-effective' in html
+    assert 'data-cors-key="allowedOrigins"' in html
+    assert 'data-app-key="CORS_ALLOWED_ORIGINS"' not in html
 
 
 def test_update_application_config_field_success(client):

--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -508,6 +508,7 @@ def _serialize_config_context(context: Dict[str, Any]) -> Dict[str, Any]:
         "application_sections": context.get("application_sections", []),
         "application_fields": context.get("application_fields", []),
         "cors_fields": context.get("cors_fields", []),
+        "cors_effective_origins": context.get("cors_config", {}).get("CORS_ALLOWED_ORIGINS", []),
         "signing_setting": asdict(context["signing_setting"]) if context.get("signing_setting") else None,
         "builtin_signing_secret": context.get("builtin_signing_secret"),
         "timestamps": {

--- a/webapp/admin/system_settings_definitions.py
+++ b/webapp/admin/system_settings_definitions.py
@@ -408,15 +408,6 @@ _PLATFORM_DEFINITIONS: tuple[SettingFieldDefinition, ...] = (
         editable=False,
         multiline=True,
     ),
-    SettingFieldDefinition(
-        key="CORS_ALLOWED_ORIGINS",
-        label=_(u"Resolved CORS allowed origins"),
-        data_type="list",
-        required=True,
-        description=_(u"Effective origins after applying persisted configuration."),
-        editable=False,
-        multiline=True,
-    ),
 )
 
 _MEDIA_PROCESSING_DEFINITIONS: tuple[SettingFieldDefinition, ...] = (

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -530,7 +530,7 @@
       id="section-cors"
       class="config-block mt-4"
       data-config-block="cors"
-      data-search-text="{{ _('CORS Allowed Origins')|e }}"
+      data-search-text="{{ (_('CORS Allowed Origins') ~ ' ' ~ _('Effective allowed origins') ~ ' ' ~ _('Allowed origins'))|e }}"
     >
       <div class="card shadow-sm border-0">
         <div class="card-header bg-white border-0 pb-0">
@@ -540,118 +540,102 @@
           </p>
         </div>
         <div class="card-body">
+          {% set allowed_field = (cors_fields | selectattr('key', 'equalto', 'allowedOrigins') | list | first) %}
+          {% set effective_field = (cors_fields | selectattr('key', 'equalto', 'CORS_ALLOWED_ORIGINS') | list | first) %}
+          {% set effective_value = (effective_field.form_value if effective_field else '') %}
           <form method="post" class="config-form" data-ajax-config-form data-config-form="cors">
             <input type="hidden" name="action" value="update-cors">
-            <div class="table-responsive">
-              <table class="table table-sm align-middle mb-0">
-                <thead>
-                  <tr>
-                    <th scope="col">{{ _('Key') }}</th>
-                    <th scope="col">{{ _('Current value') }}</th>
-                    <th scope="col">{{ _('Default') }}</th>
-                    <th scope="col">{{ _('New value') }}</th>
-                    <th scope="col">{{ _('Required') }}</th>
-                    <th scope="col">{{ _('Description') }}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for field in cors_fields %}
-                  <tr
-                    id="cors-{{ field.key }}"
-                    data-config-row
-                    data-section="cors"
-                    data-search-text="{{ field.search_text|e }}"
-                    data-cors-key="{{ field.key }}"
+            <div class="row gy-4">
+              {% if effective_field %}
+              <div
+                class="col-12 col-lg-6"
+                id="cors-{{ effective_field.key }}"
+                data-search-text="{{ effective_field.search_text|e }}"
+              >
+                <label class="form-label">{{ effective_field.label }}</label>
+                {% if effective_field.description %}
+                <div class="text-muted small mb-2">{{ effective_field.description }}</div>
+                {% endif %}
+                <textarea
+                  class="form-control form-control-sm font-monospace"
+                  rows="6"
+                  readonly
+                  disabled
+                  data-cors-effective
+                >{{ effective_field.form_value }}</textarea>
+                <div
+                  class="form-text text-muted{% if effective_value|trim %} d-none{% endif %}"
+                  data-cors-effective-empty
+                >
+                  {{ _('No origins are currently allowed.') }}
+                </div>
+                {% if effective_field.default_hint %}
+                <div class="form-text text-muted">{{ effective_field.default_hint }}</div>
+                {% else %}
+                <div class="form-text text-muted">{{ _('Updated automatically after saving allowedOrigins.') }}</div>
+                {% endif %}
+              </div>
+              {% endif %}
+
+              {% if allowed_field %}
+              <div
+                class="col-12 col-lg-6"
+                id="cors-{{ allowed_field.key }}"
+                data-cors-key="{{ allowed_field.key }}"
+                data-search-text="{{ allowed_field.search_text|e }}"
+              >
+                <div class="d-flex align-items-center gap-2 mb-1">
+                  <label class="form-label mb-0" for="cors-input-{{ allowed_field.key }}">
+                    {{ allowed_field.label }}
+                  </label>
+                  <span
+                    class="badge mt-0 {% if allowed_field.using_default %}bg-secondary{% else %}bg-info{% endif %}"
+                    data-field="status-badge"
+                    data-label-using-default="{{ _('Using default') }}"
+                    data-label-overridden="{{ _('Overridden') }}"
                   >
-                    <td>
-                      <div><code>{{ field.key }}</code></div>
-                      <div class="text-muted small">{{ field.label }}</div>
-                      <span
-                        class="badge mt-1 {% if field.using_default %}bg-secondary{% else %}bg-info{% endif %}"
-                        data-field="status-badge"
-                        data-label-using-default="{{ _('Using default') }}"
-                        data-label-overridden="{{ _('Overridden') }}"
-                      >
-                        {% if field.using_default %}
-                        {{ _('Using default') }}
-                        {% else %}
-                        {{ _('Overridden') }}
-                        {% endif %}
-                      </span>
-                    </td>
-                    <td class="font-monospace small" data-field="current">{{ field.current_json }}</td>
-                    <td
-                      class="font-monospace small{% if not field.default_json %} text-muted{% endif %}"
-                      data-field="default"
-                      data-none-label="{{ _('None') }}"
-                    >
-                      {% if field.default_json %}
-                        {{ field.default_json }}
-                      {% else %}
-                        {{ _('None') }}
-                      {% endif %}
-                    </td>
-                    <td>
-                      {% if field.editable %}
-                        {% if field.data_type == 'list' %}
-                        <textarea
-                          class="form-control form-control-sm font-monospace"
-                          name="cors_new[{{ field.key }}]"
-                          rows="3"
-                          data-cors-input
-                        >{{ field.form_value }}</textarea>
-                        <div class="form-text">{{ _('One value per line. Use "*" to allow any origin.') }}</div>
-                        {% else %}
-                        <input
-                          type="text"
-                          class="form-control form-control-sm"
-                          name="cors_new[{{ field.key }}]"
-                          value="{{ field.form_value }}"
-                          data-cors-input
-                        >
-                        {% endif %}
-                        <div class="form-check mt-2">
-                          <input
-                            class="form-check-input"
-                            type="checkbox"
-                            id="cors-use-default-{{ field.key }}"
-                            name="cors_use_default[{{ field.key }}]"
-                            value="1"
-                            {% if field.use_default %}checked{% endif %}
-                            data-cors-use-default
-                          >
-                          <label class="form-check-label" for="cors-use-default-{{ field.key }}">
-                            {{ _('Revert to default value') }}
-                          </label>
-                        </div>
-                      {% else %}
-                        {% if field.multiline %}
-                        <textarea class="form-control form-control-sm font-monospace" rows="3" readonly disabled>{{ field.form_value }}</textarea>
-                        {% else %}
-                        <input
-                          type="text"
-                          class="form-control form-control-sm"
-                          value="{{ field.form_value }}"
-                          readonly
-                          disabled
-                        >
-                        {% endif %}
-                        <div class="form-text text-muted">{{ _('This setting is read-only and cannot be changed from the admin UI.') }}</div>
-                      {% endif %}
-                    </td>
-                    <td>{% if field.required %}{{ _('Yes') }}{% else %}{{ _('No') }}{% endif %}</td>
-                    <td class="small">
-                      {{ field.description }}
-                      {% if field.default_hint %}
-                      <div class="text-muted">{{ field.default_hint }}</div>
-                      {% endif %}
-                    </td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
+                    {% if allowed_field.using_default %}
+                    {{ _('Using default') }}
+                    {% else %}
+                    {{ _('Overridden') }}
+                    {% endif %}
+                  </span>
+                </div>
+                <div class="text-muted small mb-2">{{ allowed_field.description }}</div>
+                <textarea
+                  class="form-control form-control-sm font-monospace"
+                  id="cors-input-{{ allowed_field.key }}"
+                  name="cors_new[{{ allowed_field.key }}]"
+                  rows="6"
+                  data-cors-input
+                >{{ allowed_field.form_value }}</textarea>
+                <div class="form-text">{{ _('One value per line. Use "*" to allow any origin.') }}</div>
+                <div class="form-check mt-2">
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    id="cors-use-default-{{ allowed_field.key }}"
+                    name="cors_use_default[{{ allowed_field.key }}]"
+                    value="1"
+                    {% if allowed_field.use_default %}checked{% endif %}
+                    data-cors-use-default
+                  >
+                  <label class="form-check-label" for="cors-use-default-{{ allowed_field.key }}">
+                    {{ _('Revert to default value') }}
+                  </label>
+                </div>
+                <div class="mt-3">
+                  <div class="small fw-semibold">{{ _('Default') }}</div>
+                  <pre
+                    class="form-control form-control-sm font-monospace bg-light{{ ' text-muted' if not allowed_field.default_json else '' }}"
+                    data-field="default"
+                    data-none-label="{{ _('None') }}"
+                  >{% if allowed_field.default_json %}{{ allowed_field.default_json }}{% else %}{{ _('None') }}{% endif %}</pre>
+                </div>
+              </div>
+              {% endif %}
             </div>
-            <div class="config-section-actions">
+            <div class="config-section-actions mt-4">
               <button type="submit" class="btn btn-primary">
                 {{ _('Save CORS settings') }}
               </button>

--- a/webapp/static/js/admin-config.js
+++ b/webapp/static/js/admin-config.js
@@ -255,6 +255,19 @@
     });
   }
 
+  function updateCorsEffective(origins) {
+    const textarea = document.querySelector('[data-cors-effective]');
+    if (!textarea) {
+      return;
+    }
+    const values = Array.isArray(origins) ? origins.filter((value) => !!value) : [];
+    textarea.value = values.join('\n');
+    const emptyHint = document.querySelector('[data-cors-effective-empty]');
+    if (emptyHint) {
+      emptyHint.classList.toggle('d-none', values.length > 0);
+    }
+  }
+
   function updateApplicationSections(sections) {
     if (!Array.isArray(sections)) {
       return;
@@ -535,6 +548,7 @@
     updateApplicationSections(data.application_sections);
     updateApplicationRows(data.application_fields);
     updateCorsRows(data.cors_fields);
+    updateCorsEffective(data.cors_effective_origins);
     updateSigningSetting(data.signing_setting);
     updateBuiltinSecret(data.builtin_signing_secret);
     toggleBuiltinSecretState();


### PR DESCRIPTION
## Summary
- surface the effective `CORS_ALLOWED_ORIGINS` value alongside the editable `allowedOrigins` entry in the admin UI
- normalise and expose the applied origins in the configuration context while keeping update handling scoped to editable keys
- refresh the CORS settings template and regression test to cover the read-only display and updated messaging

## Testing
- pytest tests/test_admin_config.py::test_config_page_displays_current_settings tests/test_admin_config.py::test_update_cors_config_success

------
https://chatgpt.com/codex/tasks/task_e_69001546bff08323b795950e7887bcc9