### PR TITLE
Reclassify encryption key settings under security section

### DIFF
--- a/webapp/admin/system_settings_definitions.py
+++ b/webapp/admin/system_settings_definitions.py
@@ -85,6 +85,24 @@ _SECURITY_DEFINITIONS: tuple[SettingFieldDefinition, ...] = (
         required=True,
         description=_(u"Audience (`aud`) claim enforced for access tokens."),
     ),
+    SettingFieldDefinition(
+        key="ENCRYPTION_KEY",
+        label=_(u"Token encryption key"),
+        data_type="string",
+        required=False,
+        description=_(u"PEM encoded key used for token encryption."),
+        allow_empty=True,
+        allow_null=True,
+    ),
+    SettingFieldDefinition(
+        key="ENCRYPTION_KEY_FILE",
+        label=_(u"Token encryption key file"),
+        data_type="string",
+        required=False,
+        description=_(u"Path to a PEM file used for token encryption."),
+        allow_empty=True,
+        allow_null=True,
+    ),
 )
 
 _SESSION_DEFINITIONS: tuple[SettingFieldDefinition, ...] = (
@@ -186,24 +204,6 @@ _OAUTH_DEFINITIONS: tuple[SettingFieldDefinition, ...] = (
         required=False,
         description=_(u"Client secret for Google sign-in."),
         allow_empty=True,
-    ),
-    SettingFieldDefinition(
-        key="ENCRYPTION_KEY",
-        label=_(u"Token encryption key"),
-        data_type="string",
-        required=False,
-        description=_(u"PEM encoded key used for token encryption."),
-        allow_empty=True,
-        allow_null=True,
-    ),
-    SettingFieldDefinition(
-        key="ENCRYPTION_KEY_FILE",
-        label=_(u"Token encryption key file"),
-        data_type="string",
-        required=False,
-        description=_(u"Path to a PEM file used for token encryption."),
-        allow_empty=True,
-        allow_null=True,
     ),
 )
 
@@ -435,7 +435,7 @@ APPLICATION_SETTING_SECTIONS: tuple[SettingDefinitionSection, ...] = (
     SettingDefinitionSection(
         identifier="security",
         label=_(u"Security & Signing"),
-        description=_(u"Secrets, issuers, and token signing settings."),
+        description=_(u"Secrets, encryption keys, issuers, and token signing settings."),
         fields=_SECURITY_DEFINITIONS,
     ),
     SettingDefinitionSection(


### PR DESCRIPTION
## Summary
- move ENCRYPTION_KEY and ENCRYPTION_KEY_FILE definitions from the Identity Providers group into the Security & Signing group
- note the expanded scope of the Security & Signing section description

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690044f82dc08323b225dfb91d5d58be