### PR TITLE
Move TestConfig to tests package

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,25 @@
+"""テスト専用の設定クラスを提供するモジュール。"""
+
+from sqlalchemy.pool import StaticPool
+
+from webapp.config import BaseApplicationSettings
+
+
+class TestConfig(BaseApplicationSettings):
+    """テスト用の設定クラス"""
+
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "connect_args": {"check_same_thread": False},
+        "poolclass": StaticPool,
+    }
+
+    SECRET_KEY = "test-secret-key"
+    JWT_SECRET_KEY = "test-jwt-secret"
+    GOOGLE_CLIENT_ID = ""
+    GOOGLE_CLIENT_SECRET = ""
+    SESSION_COOKIE_SECURE = False
+    MEDIA_UPLOAD_TEMP_DIRECTORY = "/tmp/test_upload/tmp"
+    MEDIA_UPLOAD_DESTINATION_DIRECTORY = "/tmp/test_upload/dest"
+    WIKI_UPLOAD_DIRECTORY = "/tmp/test_upload/wiki"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def app_context():
         importlib.reload(config_module)
 
         from webapp import create_app
-        from webapp.config import TestConfig
+        from .config import TestConfig
         from webapp.extensions import db
         from webapp.services.system_setting_service import SystemSettingService
         from webapp import _apply_persisted_settings

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -46,7 +46,7 @@ def app(tmp_path):
         importlib.reload(webapp_module)
         
         from webapp import create_app
-        from webapp.config import TestConfig
+        from .config import TestConfig
 
         app = create_app()
         app.config.from_object(TestConfig)

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -2,8 +2,6 @@ import os
 import sys
 from types import ModuleType
 
-from sqlalchemy.pool import StaticPool
-
 from dotenv import load_dotenv
 
 from core.system_settings_defaults import DEFAULT_APPLICATION_SETTINGS
@@ -87,26 +85,6 @@ class BaseApplicationSettings:
     MEDIA_NAS_ORIGINALS_DIRECTORY = _default("MEDIA_NAS_ORIGINALS_DIRECTORY")
 
     CORS_ALLOWED_ORIGINS: tuple[str, ...] = ()
-
-
-class TestConfig(BaseApplicationSettings):
-    """テスト用の設定クラス"""
-
-    TESTING = True
-    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
-    SQLALCHEMY_ENGINE_OPTIONS = {
-        "connect_args": {"check_same_thread": False},
-        "poolclass": StaticPool,
-    }
-
-    SECRET_KEY = "test-secret-key"
-    JWT_SECRET_KEY = "test-jwt-secret"
-    GOOGLE_CLIENT_ID = ""
-    GOOGLE_CLIENT_SECRET = ""
-    SESSION_COOKIE_SECURE = False
-    MEDIA_UPLOAD_TEMP_DIRECTORY = "/tmp/test_upload/tmp"
-    MEDIA_UPLOAD_DESTINATION_DIRECTORY = "/tmp/test_upload/dest"
-    WIKI_UPLOAD_DIRECTORY = "/tmp/test_upload/wiki"
 
 
 class _ReloadSafeModule(ModuleType):


### PR DESCRIPTION
## Summary
- move the TestConfig definition into a dedicated tests module so application config remains production-focused
- update test fixtures to import the relocated TestConfig

## Testing
- pytest tests/test_logging.py

------
https://chatgpt.com/codex/tasks/task_e_6900630c55e88323aa93c65c34d37409