### PR TITLE
Hide JWT secret from custom admin settings

### DIFF
--- a/webapp/admin/routes.py
+++ b/webapp/admin/routes.py
@@ -62,6 +62,9 @@ from webapp.admin.system_settings_definitions import (
     READONLY_APPLICATION_SETTING_KEYS,
     SettingFieldDefinition,
 )
+
+
+_HIDDEN_APPLICATION_SETTING_KEYS: frozenset[str] = frozenset({"JWT_SECRET_KEY"})
 from webapp.services.system_setting_service import (
     AccessTokenSigningSetting,
     AccessTokenSigningValidationError,
@@ -135,7 +138,11 @@ def _collect_application_definitions(
     stored_payload: Dict[str, Any],
 ) -> Dict[str, SettingFieldDefinition]:
     definitions: Dict[str, SettingFieldDefinition] = dict(APPLICATION_SETTING_DEFINITIONS)
-    keys = set(DEFAULT_APPLICATION_SETTINGS) | set(effective_config) | set(stored_payload)
+    keys = (
+        set(DEFAULT_APPLICATION_SETTINGS)
+        | set(effective_config)
+        | set(stored_payload)
+    ) - set(_HIDDEN_APPLICATION_SETTING_KEYS)
     for key in keys:
         if key not in definitions:
             sample = stored_payload.get(key, effective_config.get(key))


### PR DESCRIPTION
## Summary
- exclude JWT_SECRET_KEY from the generated application setting definitions so it no longer appears under Custom keys in the admin UI
- ensure the built-in signing section remains the sole place to manage the JWT secret

## Testing
- pytest tests/test_admin_config.py

------
https://chatgpt.com/codex/tasks/task_e_690063bd5d308323bf5707e5aa8effc7