### PR TITLE
Disable X-Accel redirects by default

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -550,7 +550,9 @@ class ApplicationSettings:
 
     @property
     def media_accel_redirect_enabled(self) -> bool:
-        return self.get_bool("MEDIA_ACCEL_REDIRECT_ENABLED", True)
+        # X-Accel-Redirect は環境設定が整っていないと 302 リダイレクトで動画再生が失敗する。
+        # そのためデフォルトでは無効化し、明示的に有効化した場合のみ利用する。
+        return self.get_bool("MEDIA_ACCEL_REDIRECT_ENABLED", False)
 
     # ------------------------------------------------------------------
     # Media URL configuration

--- a/core/system_settings_defaults.py
+++ b/core/system_settings_defaults.py
@@ -31,7 +31,8 @@ DEFAULT_APPLICATION_SETTINGS: dict[str, object] = {
     "MEDIA_NAS_THUMBNAILS_DIRECTORY": "/app/data/media/thumbs",
     "MEDIA_NAS_PLAYBACK_DIRECTORY": "/app/data/media/playback",
     "MEDIA_NAS_ORIGINALS_DIRECTORY": "/app/data/media/originals",
-    "MEDIA_ACCEL_REDIRECT_ENABLED": True,
+    # X-Accel-Redirect を使用しない構成をデフォルトとし、明示的な有効化のみ許可する
+    "MEDIA_ACCEL_REDIRECT_ENABLED": False,
     "MEDIA_ACCEL_THUMBNAILS_LOCATION": "/mnt/data/media/thumbs",
     "MEDIA_ACCEL_PLAYBACK_LOCATION": "/mnt/data/media/playback",
     "MEDIA_ACCEL_ORIGINALS_LOCATION": "/mnt/data/media/originals",

--- a/docs/synology-deployment.md
+++ b/docs/synology-deployment.md
@@ -129,7 +129,7 @@ MEDIA_NAS_THUMBNAILS_CONTAINER_DIRECTORY=/app/data/thumbs
 MEDIA_NAS_PLAYBACK_CONTAINER_DIRECTORY=/app/data/playback
 MEDIA_ACCEL_THUMBNAILS_LOCATION=/media/thumbs
 MEDIA_ACCEL_PLAYBACK_LOCATION=/media/playback
-MEDIA_ACCEL_REDIRECT_ENABLED=true
+MEDIA_ACCEL_REDIRECT_ENABLED=true  # デフォルトは false のため、X-Accel-Redirect を使う場合のみ true に設定
 ```
 
 **注意**: その他の設定項目（TZ、PUID、PGID等）はデフォルト値のまま使用可能です。

--- a/tests/test_media_api.py
+++ b/tests/test_media_api.py
@@ -1034,6 +1034,7 @@ def test_media_detail_prefers_completed_playback(client, app):
 def test_download_with_accel_redirect(client, seed_thumb_media, app):
     media_id, rel = seed_thumb_media
     login(client)
+    app.config["MEDIA_ACCEL_REDIRECT_ENABLED"] = True
     app.config["MEDIA_ACCEL_THUMBNAILS_LOCATION"] = "/protected/thumbs"
     res = client.post(f"/api/media/{media_id}/thumb-url", json={"size": 1024})
     assert res.status_code == 200
@@ -1049,6 +1050,7 @@ def test_download_with_accel_redirect(client, seed_thumb_media, app):
 def test_download_original_with_accel_redirect(client, seed_thumb_media, app):
     media_id, rel = seed_thumb_media
     login(client)
+    app.config["MEDIA_ACCEL_REDIRECT_ENABLED"] = True
     app.config["MEDIA_ACCEL_ORIGINALS_LOCATION"] = "/protected/originals"
     res = client.post(f"/api/media/{media_id}/original-url")
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- disable X-Accel-Redirect handling by default to avoid misconfigured redirects breaking media playback
- explain the default behaviour in the Synology deployment guide
- update download API tests to enable acceleration explicitly

## Testing
- pytest tests/test_media_api.py::test_download_with_accel_redirect tests/test_media_api.py::test_download_original_with_accel_redirect tests/test_media_api.py::test_download_without_accel_redirect


------
https://chatgpt.com/codex/tasks/task_e_690076c4edc48323b13c176cc0368e3c