### PR TITLE
Fix API key reveal modal to require explicit confirmation

### DIFF
--- a/webapp/admin/templates/admin/service_account_api_keys.html
+++ b/webapp/admin/templates/admin/service_account_api_keys.html
@@ -222,12 +222,11 @@
 </div>
 
 <!-- Reveal API Key Modal -->
-<div class="modal fade" id="revealApiKeyModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="revealApiKeyModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">{{ _('New API Key Created') }}</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
       </div>
       <div class="modal-body">
         <p class="mb-3 text-muted">{{ _('Copy and store this API key securely. It will not be shown again.') }}</p>


### PR DESCRIPTION
## Summary
- prevent the API key reveal modal from closing due to backdrop or keyboard interactions
- remove the header close button so the modal stays open until the confirmation button is pressed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690157aef0fc8323bdfe285ac2b06b67