### PR TITLE
Use anchor elements for media cards

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/media_list.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/media_list.html
@@ -201,12 +201,15 @@
   }
   
   .media-card {
+    display: block;
     position: relative;
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     transition: transform 0.2s, box-shadow 0.2s;
     cursor: pointer;
+    text-decoration: none;
+    color: inherit;
   }
   
   .media-card:hover {
@@ -846,8 +849,9 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   function createMediaCard(media) {
-    const card = document.createElement('div');
+    const card = document.createElement('a');
     card.className = 'media-card';
+    card.href = `/photo-view/media/${media.id}`;
 
     // Determine whether the media is a video
     const isVideo = media.isVideo || media.is_video;
@@ -887,11 +891,6 @@ document.addEventListener('DOMContentLoaded', () => {
         <p class="media-meta">${metaLine}</p>
       </div>
     `;
-    
-    // Navigate to the media detail page on click
-    card.addEventListener('click', () => {
-      window.location.href = `/photo-view/media/${media.id}`;
-    });
     
     return card;
   }


### PR DESCRIPTION
## Summary
- render media gallery cards as anchor elements linking directly to the detail view
- keep lazy-loaded thumbnails inside the anchor while preserving existing styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901fc35e6d08323b6cb525162715abe