### PR TITLE
Add placeholder storage services for unimplemented backends

### DIFF
--- a/domain/storage/__init__.py
+++ b/domain/storage/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from unittest.mock import DEFAULT
 
 
 class StorageDomain(Enum):
@@ -25,6 +24,14 @@ class StorageIntent(Enum):
     WRITE = "write"
     LIST = "list"
     DELETE = "delete"
+
+
+class StorageBackendType(Enum):
+    """サポートされるストレージ実装の種類."""
+
+    LOCAL = "local"
+    AZURE_BLOB = "azure_blob"
+    EXTERNAL_REST = "external_rest"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- register default factories for Azure Blob and external REST storage backends
- add placeholder storage service implementations that raise NotImplementedError
- extend storage service tests to cover the placeholder backends

## Testing
- pytest tests/test_storage_service.py

------
https://chatgpt.com/codex/tasks/task_e_6902e3a7e9f48323bb4526b23fa26589