### PR TITLE
Add confirmation before clearing shooting date

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/media_detail.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/media_detail.html
@@ -476,6 +476,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const shotAtSaveLabel = '{{ _("Save")|escapejs }}';
   const shotAtCancelLabel = '{{ _("Cancel")|escapejs }}';
   const shotAtClearLabel = '{{ _("Clear")|escapejs }}';
+  const shotAtClearConfirmText = '{{ _("Are you sure you want to clear the shooting date? This change will be saved immediately.")|escapejs }}';
   const shotAtHelperText = '{{ _("Times are saved in UTC. Your local time will be converted automatically.")|escapejs }}';
   const shotAtUpdateSuccessText = '{{ _("Shooting date updated.")|escapejs }}';
   const shotAtClearedText = '{{ _("Shooting date removed.")|escapejs }}';
@@ -1073,6 +1074,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     clearBtn.addEventListener('click', async (event) => {
       event.preventDefault();
+      if (!window.confirm(shotAtClearConfirmText)) {
+        return;
+      }
       await applyUpdate(null);
     });
   }

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -2029,6 +2029,9 @@ msgstr "撮影日時を編集"
 msgid "Clear"
 msgstr "クリア"
 
+msgid "Are you sure you want to clear the shooting date? This change will be saved immediately."
+msgstr "撮影日時をクリアしてよろしいですか？この変更はすぐに保存されます。"
+
 msgid "Times are saved in UTC. Your local time will be converted automatically."
 msgstr "時刻はUTCで保存されます。ローカル時刻は自動的に変換されます。"
 


### PR DESCRIPTION
## Summary
- prompt for confirmation before clearing the shooting date so the action is intentional
- add a Japanese translation for the new confirmation message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690415ab7c188323ab78410ac4800c0c