### PR TITLE
Fix passkey registration attestation preference handling

### DIFF
--- a/shared/application/passkey_service.py
+++ b/shared/application/passkey_service.py
@@ -15,6 +15,7 @@ from webauthn import (
 from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
 from webauthn.helpers.structs import (
     AuthenticationCredential,
+    AttestationConveyancePreference,
     AuthenticatorSelectionCriteria,
     PublicKeyCredentialDescriptor,
     RegistrationCredential,
@@ -64,7 +65,7 @@ class PasskeyService:
             user_id=str(user.id).encode("utf-8"),
             user_name=user.email,
             user_display_name=getattr(user, "display_name", user.email),
-            attestation="none",
+            attestation=AttestationConveyancePreference.NONE,
             authenticator_selection=AuthenticatorSelectionCriteria(
                 resident_key=ResidentKeyRequirement.PREFERRED,
                 user_verification=UserVerificationRequirement.PREFERRED,


### PR DESCRIPTION
## Summary
- use the WebAuthn AttestationConveyancePreference enum when generating registration options
- prevent the server error triggered by returning a raw string for the attestation value

## Testing
- pytest tests/shared/test_passkey_service.py

------
https://chatgpt.com/codex/tasks/task_e_69044cc9bde88323a599a4f72ca62487