### PR TITLE
Update media detail back navigation to use list route

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/media_detail.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/media_detail.html
@@ -310,9 +310,9 @@
         <p class="text-muted mb-0" id="media-meta">Loading media details...</p>
       </div>
       <div class="d-flex flex-wrap gap-2 justify-content-end">
-        <button class="btn btn-outline-secondary" onclick="history.back()">
+        <a class="btn btn-outline-secondary" href="{{ url_for('photo_view.media_list') }}">
           <i class="fas fa-arrow-left"></i> {{ _("Back") }}
-        </button>
+        </a>
         <div class="btn-group" id="download-controls" role="group">
           <button class="btn btn-outline-primary" id="download-btn" type="button" data-download-type="original" disabled>
             <i class="fas fa-download"></i> {{ _("Download") }}
@@ -1457,7 +1457,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // キーボードナビゲーション
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
-      history.back();
+      window.location.href = '{{ url_for("photo_view.media_list")|escapejs }}';
     } else if (e.key === ' ') {
       e.preventDefault();
       toggleZoom();


### PR DESCRIPTION
## Summary
- replace the media detail back control with a direct link to the media list route
- update the Escape key handling to navigate to the media list route instead of relying on browser history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69045ef5d3988323937e556d1bbf10a7