### PR TITLE
Handle flattened passkey payloads

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -319,7 +319,7 @@ document.addEventListener('DOMContentLoaded', function() {
             throw new Error('abort');
           }
 
-          const credentialPayload = {
+          const requestPayload = {
             id: assertion.id,
             type: assertion.type,
             rawId: bufferToBase64Url(assertion.rawId),
@@ -336,15 +336,17 @@ document.addEventListener('DOMContentLoaded', function() {
               : {},
           };
 
+          const nextValue = storedRedirectPath || resolveNextValue();
+          if (nextValue) {
+            requestPayload.next = nextValue;
+          }
+
           const verifyResponse = await fetch('{{ url_for('auth.passkey_verify_login') }}', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-              credential: credentialPayload,
-              next: storedRedirectPath || resolveNextValue(),
-            }),
+            body: JSON.stringify(requestPayload),
           });
 
           if (!verifyResponse.ok) {

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -322,7 +322,7 @@
               throw new Error('abort');
             }
 
-            const credentialPayload = {
+            const requestPayload = {
               id: credential.id,
               type: credential.type,
               rawId: bufferToBase64Url(credential.rawId),
@@ -339,17 +339,17 @@
             };
 
             const labelInput = prompt('{{ _('Give this passkey a name (optional)') }}', '');
-            const labelValue = labelInput && labelInput.trim().length > 0 ? labelInput.trim() : null;
+            const labelValue = typeof labelInput === 'string' ? labelInput.trim() : '';
+            if (labelValue.length > 0) {
+              requestPayload.label = labelValue;
+            }
 
             const verifyResponse = await fetch('{{ url_for('auth.passkey_verify_register') }}', {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
               },
-              body: JSON.stringify({
-                credential: credentialPayload,
-                label: labelValue,
-              }),
+              body: JSON.stringify(requestPayload),
             });
 
             if (!verifyResponse.ok) {


### PR DESCRIPTION
## Summary
- normalize passkey registration and authentication payloads on the server while logging invalid requests
- update the passkey registration and login front-end flows to send flattened credential payloads
- refresh the passkey route tests to cover both flattened requests and backwards compatibility

## Testing
- pytest tests/webapp/auth/test_passkey_routes.py

------
https://chatgpt.com/codex/tasks/task_e_6904690831ac832386520c41f31a6be6