### PR TITLE
Fix passkey origin scheme handling

### DIFF
--- a/webapp/auth/routes.py
+++ b/webapp/auth/routes.py
@@ -268,7 +268,8 @@ def _resolve_passkey_origin() -> str:
     if not host:
         return candidate
 
-    derived = f"{request.scheme}://{host}".rstrip("/")
+    derived_scheme = determine_external_scheme(request)
+    derived = f"{derived_scheme}://{host}".rstrip("/")
 
     if candidate.rstrip("/") in _DEFAULT_ORIGIN_SENTINELS and derived not in _DEFAULT_ORIGIN_SENTINELS:
         return derived


### PR DESCRIPTION
## Summary
- ensure WebAuthn origin resolution uses the preferred external URL scheme
- add a regression test covering passkey origin derivation when an override is set

## Testing
- pytest tests/webapp/auth/test_passkey_routes.py -k preferred -q

------
https://chatgpt.com/codex/tasks/task_e_6904755d963c8323b132958ac58f8149