### PR TITLE
Show slideshow overlay while loading

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/album_slideshow.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/album_slideshow.html
@@ -295,6 +295,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const apiClient = new APIClient();
 
   async function loadSlideshow() {
+    slideshow.showOverlay();
     slideshow.setLoading(true);
     try {
       const response = await apiClient.get(`/api/albums/${albumId}`);


### PR DESCRIPTION
## Summary
- show the slideshow overlay immediately before fetching album data so the loading spinner appears while content is being retrieved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690479cf5db883239aa2f321301bccbc