### PR TITLE
Rename photo session permission to media:session

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/home.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/home.html
@@ -343,6 +343,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const localImportBtn = document.getElementById('local-import-btn');
   const duplicateModeRadios = document.querySelectorAll('input[name="duplicate-regeneration"]');
   const isAdmin = {{ 'true' if is_admin else 'false' }};
+  const canViewSessions = {{ 'true' if can_view_sessions else 'false' }};
+  const sessionDetailTemplateUrl = "{{ url_for('photo_view.session_detail', session_id='__SESSION_ID__') }}";
 
   const uploadModalTrigger = document.getElementById('open-upload-modal');
   const uploadModalElement = document.getElementById('upload-modal');
@@ -479,6 +481,21 @@ document.addEventListener('DOMContentLoaded', () => {
     error: '{{ _("Error") }}',
     failed: '{{ _("Failed") }}'
   };
+
+  function encodeSessionIdForPath(sessionId) {
+    if (typeof sessionId !== 'string' || !sessionId) {
+      return '';
+    }
+    return sessionId
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+  }
+
+  function buildSessionDetailUrl(sessionId) {
+    const encoded = encodeSessionIdForPath(sessionId);
+    return sessionDetailTemplateUrl.replace('__SESSION_ID__', encoded);
+  }
 
   function formatCounts(counts) {
     if (!counts || Object.keys(counts).length === 0) return '-';
@@ -1000,6 +1017,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const stopButtonHtml = showStopButton
       ? `<button class="btn btn-sm btn-outline-danger btn-size-sm" onclick="stopLocalImport('${session.sessionId}')"><i class="bi bi-stop-circle"></i> ${stopLocalImportLabel}</button>`
       : '';
+    const detailButtonHtml = canViewSessions
+      ? `<a href="${buildSessionDetailUrl(session.sessionId)}" class="btn btn-sm btn-primary btn-size-sm">{{ _("View Details") }}</a>`
+      : `<button type="button" class="btn btn-sm btn-outline-secondary btn-size-sm" disabled>{{ _("View Details") }}</button>`;
     let localStatusMessage = '';
     if (session.isLocalImport) {
       if (session.status === 'canceled') {
@@ -1018,7 +1038,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <td><small>${formatDateTime(session.createdAt)}</small></td>
       <td><small>${formatDateTime(session.lastProgressAt)}</small></td>
       <td class="session-actions">
-        <a href="/photo-view?session_id=${session.sessionId}" class="btn btn-sm btn-primary btn-size-sm">{{ _("View Details") }}</a>
+        ${detailButtonHtml}
         ${(displayStatus === 'ready' && !session.isLocalImport) ? `<button class="btn btn-sm btn-success btn-size-sm" onclick="startImport('${session.sessionId}')">{{ _("Start Import") }}</button>` : ''}
         ${stopButtonHtml}
         ${localStatusMessage}
@@ -1240,9 +1260,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const sessionId = payload && payload.session_id;
         if (sessionId) {
+          if (canViewSessions) {
+            setTimeout(() => {
+              window.location.href = buildSessionDetailUrl(sessionId);
+            }, 1500);
+            return;
+          }
           setTimeout(() => {
-            window.location.href = `/photo-view?session_id=${encodeURIComponent(sessionId)}`;
-          }, 1500);
+            refreshSessions();
+          }, 2000);
           return;
         }
 

--- a/migrations/versions/a7d9c3e2b1f0_add_media_session_permission.py
+++ b/migrations/versions/a7d9c3e2b1f0_add_media_session_permission.py
@@ -1,0 +1,79 @@
+"""Add media session permission"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a7d9c3e2b1f0'
+down_revision = 'f3e2b1c4d5e6'
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_CODE = 'media:session'
+ADMIN_ROLE_NAME = 'admin'
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+
+    if perm_row is None:
+        conn.execute(
+            sa.text("INSERT INTO permission (code) VALUES (:code)"),
+            {"code": PERMISSION_CODE},
+        )
+        perm_row = conn.execute(
+            sa.text("SELECT id FROM permission WHERE code = :code"),
+            {"code": PERMISSION_CODE},
+        ).first()
+
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO role_permissions (role_id, perm_id)
+            SELECT r.id, :perm_id
+            FROM role r
+            WHERE r.name = :role_name
+              AND NOT EXISTS (
+                  SELECT 1 FROM role_permissions rp
+                  WHERE rp.role_id = r.id AND rp.perm_id = :perm_id
+              )
+            """
+        ),
+        {"perm_id": perm_id, "role_name": ADMIN_ROLE_NAME},
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    perm_row = conn.execute(
+        sa.text("SELECT id FROM permission WHERE code = :code"),
+        {"code": PERMISSION_CODE},
+    ).first()
+
+    if not perm_row:
+        return
+
+    perm_id = perm_row[0]
+
+    conn.execute(
+        sa.text("DELETE FROM role_permissions WHERE perm_id = :perm_id"),
+        {"perm_id": perm_id},
+    )
+    conn.execute(
+        sa.text("DELETE FROM permission WHERE id = :perm_id"),
+        {"perm_id": perm_id},
+    )

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -81,8 +81,8 @@ def app():
                     os.environ[key] = old_value
 
 
-class TestSessionDetailAPI:
-    """Session Detail API のテスト"""
+class AuthenticatedClientMixin:
+    """テストクライアントを認証状態にするためのヘルパーミックスイン"""
 
     @staticmethod
     def _login(client):
@@ -110,6 +110,10 @@ class TestSessionDetailAPI:
         with client.session_transaction() as sess:
             sess.update(persisted)
             sess.modified = True
+
+
+class TestSessionDetailAPI(AuthenticatedClientMixin):
+    """Session Detail API のテスト"""
 
     def test_picker_sessions_list_includes_local_import(self, app):
         """セッション一覧にローカルインポートセッションが含まれることをテスト"""
@@ -457,7 +461,7 @@ class TestSessionDetailAPI:
             assert metadata.get('session_id') == session_id
 
 
-class TestSessionDetailUI:
+class TestSessionDetailUI(AuthenticatedClientMixin):
     """Session Detail UI のテスト"""
     
     def test_session_detail_page_renders(self, app):
@@ -472,9 +476,9 @@ class TestSessionDetailUI:
             session_id = result['session_id']
         
         # セッション詳細ページ呼び出し
-        response = client.get(f'/photo-view?session_id={session_id}')
+        response = client.get(f'/photo-view/session/{session_id}')
         assert response.status_code == 200
-        
+
         html = response.get_data(as_text=True)
 
         # 必要なHTML要素が含まれていることを確認
@@ -510,7 +514,7 @@ class TestSessionDetailUI:
         assert 'Stop Local Import' in html
 
 
-class TestLocalImportIntegration:
+class TestLocalImportIntegration(AuthenticatedClientMixin):
     """ローカルインポート統合テスト"""
     
     def test_full_local_import_workflow(self, app):


### PR DESCRIPTION
## Summary
- rename the photo view session permission to `media:session` and require it for the detail route
- update the migration seeding to grant the new permission to the admin role
- share the authenticated client helper across picker UI tests to fix the missing `_login` method

## Testing
- pytest tests/test_local_import_ui.py::TestSessionDetailUI::test_session_detail_page_renders


------
https://chatgpt.com/codex/tasks/task_e_69047b14a60c8323bba8c42fb073e8ef