### PR TITLE
Hide wiki count on dashboard for non-admins

### DIFF
--- a/webapp/dashboard/templates/dashboard/index.html
+++ b/webapp/dashboard/templates/dashboard/index.html
@@ -164,7 +164,9 @@
               <div>
                 <div class="fw-semibold">{{ _('Content overview') }}</div>
                 <div class="text-muted small">
+                  {% if current_user.can('wiki:admin') %}
                   {{ _('Wiki pages: %(count)s', count=stats.wiki_pages or 0) }}<br>
+                  {% endif %}
                   {{ _('Media items: %(count)s', count=stats.media_count or 0) }}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- hide the wiki page count in the dashboard content overview for users without the wiki:admin permission

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690486adfda083239a1627e18453527a