### PR TITLE
Move photo view session dashboard to /photo-view/session and redirect root

### DIFF
--- a/features/photonest/presentation/photo_view/routes.py
+++ b/features/photonest/presentation/photo_view/routes.py
@@ -58,7 +58,16 @@ def _build_local_import_info():
 @bp.route("/", strict_slashes=False)
 @require_perms("media:view")
 def home():
-    """Photo view home page."""
+    """Redirect the legacy home page to the albums view."""
+
+    return redirect(url_for("photo_view.albums"))
+
+
+@bp.route("/session", strict_slashes=False)
+@require_perms("media:view")
+def session_home():
+    """Photo view session overview page."""
+
     if not app_settings.login_disabled and not current_user.can("media:session"):
         return redirect(url_for("index"))
 

--- a/features/photonest/presentation/photo_view/templates/photo-view/session_detail.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/session_detail.html
@@ -12,7 +12,7 @@
     <h1 id="session-title" class="mb-1">{{ _("Session Details") }}</h1>
     <p id="session-subtitle" class="text-muted small mb-0 d-none"></p>
   </div>
-  <a href="/photo-view" class="btn btn-outline-secondary btn-sm">
+  <a href="/photo-view/session" class="btn btn-outline-secondary btn-sm">
     <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
   </a>
 </div>
@@ -152,13 +152,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const pickerSessionId = resolveSessionId();
   if (!pickerSessionId) {
-    window.location.href = '/photo-view';
+    window.location.href = '/photo-view/session';
     return;
   }
 
   if (/^\d+$/.test(pickerSessionId)) {
     console.warn('Numeric session ID detected, redirecting to sessions list');
-    window.location.href = '/photo-view';
+    window.location.href = '/photo-view/session';
     return;
   }
 
@@ -928,7 +928,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const resp = await window.apiClient.get(`/api/picker/session/${encodeURIComponent(pickerSessionId)}`);
       if (resp.status === 404) {
-        window.location.href = '/photo-view';
+        window.location.href = '/photo-view/session';
         return null;
       }
       if (resp.status === 401 || resp.status === 302) {

--- a/features/photonest/presentation/photo_view/templates/photo-view/settings.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/settings.html
@@ -12,7 +12,7 @@
                 {% endif %}
             </p>
         </div>
-        <a href="{{ url_for('photo_view.home') }}" class="btn btn-outline-secondary btn-sm">
+        <a href="{{ url_for('photo_view.session_home') }}" class="btn btn-outline-secondary btn-sm">
             <i class="bi bi-arrow-left"></i> {{ _("Back to Sessions") }}
         </a>
     </div>

--- a/tests/test_local_import_ui.py
+++ b/tests/test_local_import_ui.py
@@ -502,7 +502,7 @@ class TestSessionDetailUI(AuthenticatedClientMixin):
             session_id = result['session_id']
         
         # ホームページ呼び出し
-        response = client.get('/photo-view')
+        response = client.get('/photo-view/session')
         assert response.status_code == 200
         
         html = response.get_data(as_text=True)

--- a/tests/test_photo_view_permissions.py
+++ b/tests/test_photo_view_permissions.py
@@ -111,21 +111,21 @@ def test_settings_page_available_with_admin_permission(client):
     assert "Local Import Overview" in html
 
 
-def test_home_hides_settings_button_without_admin_permission(client):
+def test_session_home_hides_settings_button_without_admin_permission(client):
     """The photo view home page hides settings when admin scope is missing."""
 
     user = _create_user_with_permissions("media:view", "media:session")
     _login(client, user)
 
     with _require_auth_checks(client):
-        response = client.get("/photo-view/")
+        response = client.get("/photo-view/session")
 
     assert response.status_code == 200
     html = response.data.decode("utf-8")
     assert "/photo-view/settings" not in html
 
 
-def test_home_shows_settings_button_with_admin_permission(client):
+def test_session_home_shows_settings_button_with_admin_permission(client):
     """When the admin scope is granted the settings button becomes visible."""
 
     user = _create_user_with_permissions(
@@ -134,21 +134,21 @@ def test_home_shows_settings_button_with_admin_permission(client):
     _login(client, user)
 
     with _require_auth_checks(client):
-        response = client.get("/photo-view/")
+        response = client.get("/photo-view/session")
 
     assert response.status_code == 200
     html = response.data.decode("utf-8")
     assert "/photo-view/settings" in html
 
 
-def test_home_redirects_without_session_permission(client):
-    """Users lacking media:session cannot open the home page."""
+def test_session_home_redirects_without_session_permission(client):
+    """Users lacking media:session cannot open the session page."""
 
     user = _create_user_with_permissions("media:view")
     _login(client, user)
 
     with _require_auth_checks(client):
-        response = client.get("/photo-view/")
+        response = client.get("/photo-view/session")
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/")
@@ -166,4 +166,17 @@ def test_media_page_available_without_session_permission(client):
     assert response.status_code == 200
     html = response.data.decode("utf-8")
     assert "Media Gallery" in html
+
+
+def test_root_redirects_to_albums(client):
+    """Accessing /photo-view/ redirects to the albums view."""
+
+    user = _create_user_with_permissions("media:view")
+    _login(client, user)
+
+    with _require_auth_checks(client):
+        response = client.get("/photo-view/", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/photo-view/albums")
 

--- a/webapp/auth/templates/auth/picker.html
+++ b/webapp/auth/templates/auth/picker.html
@@ -47,7 +47,7 @@
                 {{ _('Check status now') }}
               </button>
               <button type="button" class="btn btn-success flex-grow-1" id="open-photo-view-btn" disabled
-                      data-photo-view-url="{{ url_for('photo_view.home', session_id=session_id) }}">
+                      data-photo-view-url="{{ url_for('photo_view.session_home', session_id=session_id) }}">
                 {{ _('Open Photo View') }}
               </button>
             </div>

--- a/webapp/dashboard/templates/dashboard/index.html
+++ b/webapp/dashboard/templates/dashboard/index.html
@@ -51,7 +51,7 @@
                 <p class="card-text text-muted">
                   {{ _('Review uploaded photos and manage shared media assets.') }}
                 </p>
-                <a href="{{ url_for('photo_view.home') }}" class="btn btn-success mt-auto">
+                <a href="{{ url_for('photo_view.session_home') }}" class="btn btn-success mt-auto">
                   <i class="fas fa-arrow-right"></i> {{ _('Open media view') }}
                 </a>
               </div>

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -38,7 +38,7 @@
             {{ _('Photo View') }}
           </a>
           <ul class="dropdown-menu" aria-labelledby="photoNavDropdown">
-            <li><a class="dropdown-item" href="{{ url_for('photo_view.home') }}">{{ _('Sessions') }}</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('photo_view.session_home') }}">{{ _('Sessions') }}</a></li>
             <li><a class="dropdown-item" href="{{ url_for('photo_view.media_list') }}">{{ _('Media Gallery') }}</a></li>
             {% if current_user.can('album:view') %}
             <li><a class="dropdown-item" href="{{ url_for('photo_view.albums') }}">{{ _('Albums') }}</a></li>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -46,7 +46,7 @@
           {% endif %}
           {% if current_user.can('media:view') %}
           <div class="col-md-4 mb-3">
-            <a href="{{ url_for('photo_view.home') }}" class="btn btn-success btn-lg w-100">
+            <a href="{{ url_for('photo_view.session_home') }}" class="btn btn-success btn-lg w-100">
               <i class="fas fa-images"></i><br>{{ _('Photo View') }}
             </a>
           </div>


### PR DESCRIPTION
## Summary
- serve the session management UI from the new /photo-view/session endpoint and redirect the old root to the albums view
- update navigation links, templates, and picker launch URLs to point at the new session endpoint
- adjust automated tests to cover the new routing behavior

## Testing
- pytest tests/test_photo_view_permissions.py tests/test_local_import_ui.py

------
https://chatgpt.com/codex/tasks/task_e_6904bc57bf948323a22b944061ba5766