### PR TITLE
Allow multiple passkeys per user

### DIFF
--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -68,15 +68,17 @@
               </div>
               {% endfor %}
             </div>
-            <p class="form-text text-muted">{{ _('To add another passkey, remove the existing passkey first.') }}</p>
             {% else %}
             <p class="text-muted mb-3">{{ _('No passkeys registered yet.') }}</p>
-            <button type="button" class="btn btn-outline-primary" data-passkey-register>
-              <span class="spinner-border spinner-border-sm me-2 d-none" role="status" aria-hidden="true" data-passkey-spinner></span>
-              <i class="fas fa-key me-2" data-passkey-icon></i>
-              <span data-passkey-label>{{ _('Add a new passkey') }}</span>
-            </button>
             {% endif %}
+            <div class="d-flex flex-column flex-sm-row align-items-start gap-2">
+              <button type="button" class="btn btn-outline-primary" data-passkey-register>
+                <span class="spinner-border spinner-border-sm me-2 d-none" role="status" aria-hidden="true" data-passkey-spinner></span>
+                <i class="fas fa-key me-2" data-passkey-icon></i>
+                <span data-passkey-label>{{ _('Add a new passkey') }}</span>
+              </button>
+              <p class="form-text text-muted mb-0">{{ _('Register a passkey for each device you use.') }}</p>
+            </div>
           {% endif %}
         </div>
 

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -250,8 +250,8 @@ msgid "No passkeys registered yet."
 msgstr "No passkeys registered yet."
 
 #: webapp/auth/templates/auth/profile.html
-msgid "To add another passkey, remove the existing passkey first."
-msgstr "To add another passkey, remove the existing passkey first."
+msgid "Register a passkey for each device you use."
+msgstr "Register a passkey for each device you use."
 
 #: webapp/auth/templates/auth/profile.html
 msgid "Add a new passkey"

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -107,8 +107,8 @@ msgstr "現在時刻"
 msgid "Local time (Asia/Tokyo)"
 msgstr "日本時刻"
 
-msgid "To add another passkey, remove the existing passkey first."
-msgstr "別のパスキーを追加するには、現在のパスキーを削除してください。"
+msgid "Register a passkey for each device you use."
+msgstr "利用する各デバイス向けにパスキーを登録してください。"
 
 msgid "Manage how your account looks and feels."
 msgstr "アカウントの見た目と操作感を管理します。"
@@ -1330,8 +1330,8 @@ msgid "No passkeys registered yet."
 msgstr "登録されているパスキーはありません。"
 
 #: webapp/auth/templates/auth/profile.html
-msgid "To add another passkey, remove the existing passkey first."
-msgstr "別のパスキーを追加するには、既存のパスキーを削除してください。"
+msgid "Register a passkey for each device you use."
+msgstr "利用する各デバイス向けにパスキーを登録してください。"
 
 #: webapp/auth/templates/auth/profile.html
 msgid "Add a new passkey"

--- a/webapp/translations/messages.pot
+++ b/webapp/translations/messages.pot
@@ -1177,7 +1177,7 @@ msgid "No passkeys registered yet."
 msgstr ""
 
 #: webapp/auth/templates/auth/profile.html
-msgid "To add another passkey, remove the existing passkey first."
+msgid "Register a passkey for each device you use."
 msgstr ""
 
 #: webapp/auth/templates/auth/profile.html


### PR DESCRIPTION
## Summary
- keep the passkey registration button available even when credentials already exist
- update profile guidance copy and translations to encourage registering device-specific passkeys

## Testing
- pytest tests/webapp/auth/test_passkey_routes.py tests/shared/test_passkey_service.py

------
https://chatgpt.com/codex/tasks/task_e_6904bceb04b08323a51bb5b4b74371a0