### PR TITLE
Hide slideshow controls until interaction

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/album_slideshow.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/album_slideshow.html
@@ -48,9 +48,9 @@
   data-back-url="{{ url_for('photo_view.album_detail', album_id=album_id) }}"
   data-albums-url="{{ url_for('photo_view.albums') }}"
 >
-  <div id="album-slideshow-overlay" class="album-slideshow-overlay d-none" aria-hidden="true">
+  <div id="album-slideshow-overlay" class="album-slideshow-overlay d-none chrome-hidden" aria-hidden="true">
     <div class="album-slideshow-dialog">
-      <div class="album-slideshow-header">
+      <div class="album-slideshow-header album-slideshow-chrome">
         <div class="album-slideshow-actions">
           <a href="{{ url_for('photo_view.album_detail', album_id=album_id) }}" class="btn btn-outline-light btn-sm" id="album-slideshow-back">
             <i class="bi bi-arrow-left"></i> {{ _('Back to album') }}
@@ -59,9 +59,6 @@
             <i class="bi bi-collection"></i> {{ _('Albums') }}
           </a>
         </div>
-        <button type="button" class="album-slideshow-close" id="album-slideshow-close" aria-label="{{ _('Close') }}">
-          <i class="bi bi-x-lg"></i>
-        </button>
       </div>
       <div
         id="album-slideshow-loading"
@@ -85,7 +82,7 @@
       <div id="album-slideshow-empty" class="album-slideshow-empty d-none">
         {{ _('This album has no media yet.') }}
       </div>
-      <div class="album-slideshow-footer">
+      <div class="album-slideshow-footer album-slideshow-chrome">
         <div class="album-slideshow-info">
           <span class="album-title" id="album-slideshow-title"></span>
           <span class="album-meta" id="album-slideshow-meta"></span>
@@ -130,7 +127,6 @@ document.addEventListener('DOMContentLoaded', () => {
     pause: "{{ _('Pause')|escapejs }}",
     next: "{{ _('Next')|escapejs }}",
     previous: "{{ _('Previous')|escapejs }}",
-    close: "{{ _('Close')|escapejs }}",
     shotAt: "{{ _('Shot at')|escapejs }}",
     position: "{{ _('%(current)s / %(total)s', current='%(current)s', total='%(total)s')|escapejs }}",
     mediaCountSingular: "{{ ngettext('%(count)s photo', '%(count)s photos', 1, count='%(count)s')|escapejs }}",
@@ -237,11 +233,6 @@ document.addEventListener('DOMContentLoaded', () => {
     backButton.addEventListener('click', handleExit(backUrl));
   }
 
-  const closeButton = document.getElementById('album-slideshow-close');
-  if (closeButton) {
-    closeButton.addEventListener('click', handleExit(backUrl));
-  }
-
   const albumsButton = document.getElementById('album-slideshow-albums');
   if (albumsButton) {
     albumsButton.addEventListener('click', (event) => {
@@ -249,6 +240,34 @@ document.addEventListener('DOMContentLoaded', () => {
       navigateTo(albumsUrl);
     });
   }
+
+  const overlayElement = document.getElementById('album-slideshow-overlay');
+  let chromeVisible = false;
+
+  function setChromeVisibility(visible) {
+    chromeVisible = visible;
+    if (!overlayElement) {
+      return;
+    }
+    overlayElement.classList.toggle('chrome-hidden', !visible);
+  }
+
+  function toggleChromeVisibility() {
+    setChromeVisibility(!chromeVisible);
+  }
+
+  if (overlayElement) {
+    setChromeVisibility(false);
+    overlayElement.addEventListener('focusin', () => {
+      setChromeVisibility(true);
+    });
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Tab' && overlayElement && overlayElement.getAttribute('aria-hidden') === 'false') {
+      setChromeVisibility(true);
+    }
+  });
 
   const emptyElement = document.getElementById('album-slideshow-empty');
 
@@ -264,17 +283,18 @@ document.addEventListener('DOMContentLoaded', () => {
     playPauseButton: document.getElementById('album-slideshow-toggle'),
     prevButton: document.getElementById('album-slideshow-prev'),
     nextButton: document.getElementById('album-slideshow-next'),
-    closeButton,
     labels: {
       play: strings.play,
       pause: strings.pause,
       next: strings.next,
       previous: strings.previous,
-      close: strings.close,
       counter: strings.position,
       noMedia: strings.noMedia,
       shotAt: strings.shotAt,
       albumTitleFallback: strings.untitledAlbum,
+    },
+    onStageInteraction: () => {
+      toggleChromeVisibility();
     },
     imageUrlResolver: resolveImageUrl,
     metadataFormatter: (item, context) => {
@@ -314,6 +334,7 @@ document.addEventListener('DOMContentLoaded', () => {
       slideshow.setLoading(false);
 
       const normalizedIndex = Number.isInteger(startIndex) && startIndex >= 0 ? startIndex : 0;
+      setChromeVisibility(false);
       slideshow.open(normalizedIndex, { autoplay });
     } catch (error) {
       console.error('Failed to load slideshow', error);

--- a/webapp/static/js/album-slideshow.js
+++ b/webapp/static/js/album-slideshow.js
@@ -11,7 +11,6 @@ class AlbumSlideshow {
     this.playPauseButton = options.playPauseButton || null;
     this.prevButton = options.prevButton || null;
     this.nextButton = options.nextButton || null;
-    this.closeButton = options.closeButton || null;
     this.intervalMs = Number.isFinite(options.intervalMs) ? Number(options.intervalMs) : 5000;
     this.imageUrlResolver = typeof options.imageUrlResolver === 'function'
       ? options.imageUrlResolver
@@ -24,12 +23,15 @@ class AlbumSlideshow {
       pause: options.labels?.pause || 'Pause',
       next: options.labels?.next || 'Next',
       previous: options.labels?.previous || 'Previous',
-      close: options.labels?.close || 'Close',
       counter: options.labels?.counter || '%(current)s / %(total)s',
       noMedia: options.labels?.noMedia || 'No media items available.',
       shotAt: options.labels?.shotAt || 'Shot at',
       albumTitleFallback: options.labels?.albumTitleFallback || 'Album',
     };
+
+    this.onStageInteraction = typeof options.onStageInteraction === 'function'
+      ? options.onStageInteraction
+      : () => { this.togglePlay(); };
 
     this.mediaItems = [];
     this.albumTitle = this.labels.albumTitleFallback;
@@ -75,13 +77,6 @@ class AlbumSlideshow {
       this.nextButton.addEventListener('click', (event) => {
         event.preventDefault();
         this.showNext();
-      });
-    }
-
-    if (this.closeButton) {
-      this.closeButton.addEventListener('click', (event) => {
-        event.preventDefault();
-        this.hideOverlay();
       });
     }
 
@@ -416,7 +411,7 @@ class AlbumSlideshow {
     if (event.target.closest('.album-slideshow-nav')) {
       return;
     }
-    this.togglePlay();
+    this.onStageInteraction(event);
   }
 
   handleTouchStart(event) {
@@ -476,7 +471,7 @@ class AlbumSlideshow {
     if (Math.abs(deltaX) < tapThreshold && Math.abs(deltaY) < tapThreshold) {
       event.preventDefault();
       this.touchPreventClick = true;
-      this.togglePlay();
+      this.onStageInteraction(event);
     }
     this.touchStartTarget = null;
   }

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -919,24 +919,6 @@ body.login-page .login-card .language-selector {
   right: 18px;
 }
 
-.album-slideshow-close {
-  position: absolute;
-  top: 28px;
-  right: 28px;
-  background: rgba(15, 23, 42, 0.85);
-  border-radius: 50%;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  width: 42px;
-  height: 42px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #f8fafc;
-  cursor: pointer;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.35);
-  z-index: 2;
-}
-
 .album-slideshow-footer {
   margin-top: 18px;
   display: flex;
@@ -1003,6 +985,23 @@ body.login-page .login-card .language-selector {
   font-weight: 600;
 }
 
+.album-slideshow-chrome {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.album-slideshow-overlay.chrome-hidden .album-slideshow-chrome {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.album-slideshow-overlay.chrome-hidden .album-slideshow-header.album-slideshow-chrome {
+  transform: translateY(-16px);
+}
+
+.album-slideshow-overlay.chrome-hidden .album-slideshow-footer.album-slideshow-chrome {
+  transform: translateY(16px);
+}
+
 @media (max-width: 768px) {
   .album-slideshow-stage {
     min-height: 0;
@@ -1011,11 +1010,6 @@ body.login-page .login-card .language-selector {
   .album-slideshow-nav {
     width: 40px;
     height: 40px;
-  }
-
-  .album-slideshow-close {
-    top: 20px;
-    right: 20px;
   }
 
   .album-slideshow-info .album-title {


### PR DESCRIPTION
## Summary
- hide the slideshow header and footer chrome until the user interacts with the stage
- remove the redundant close button and prevent it from overlapping album navigation
- add a focus-aware toggle so keyboard users can expose the controls when needed

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_6904c4af2be88323bd509a3463a571bb