### PR TITLE
Align selection highlight styling across admin and album views

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/albums.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/albums.html
@@ -259,7 +259,8 @@
     padding: 0;
     background: #0f172a;
     cursor: pointer;
-    transition: transform 0.12s ease, box-shadow 0.12s ease;
+    transition: transform 0.12s ease, box-shadow 0.12s ease, outline-color 0.12s ease, background-color 0.12s ease;
+    outline: 2px solid transparent;
   }
 
   .album-media-tile:hover {
@@ -268,9 +269,9 @@
   }
 
   .album-media-tile.selected {
-    outline: 3px solid rgba(var(--bs-primary-rgb));
-    outline-offset: 0;
-    box-shadow: 0 0.75rem 1.5rem rgba(var(--bs-primary-rgb), 0.1);
+    outline: solid 2px rgba(var(--bs-primary-rgb));
+    background-color: rgba(var(--bs-primary-rgb), 0.3);
+    box-shadow: 0 1.25rem 2.5rem rgba(var(--bs-primary-rgb), 0.18);
   }
 
   .album-media-thumb {
@@ -281,6 +282,19 @@
     background-size: cover;
     background-position: center;
     background-color: #1e293b;
+  }
+
+  .album-media-thumb::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: rgba(var(--bs-primary-rgb), 0.3);
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+
+  .album-media-tile.selected .album-media-thumb::before {
+    opacity: 1;
   }
 
   .album-media-thumb.is-loading::after {
@@ -334,7 +348,7 @@
   }
 
   .album-media-tile.selected .album-media-overlay {
-    background-color: rgba(var(--bs-primary-rgb), 0.);
+    background: linear-gradient(180deg, rgba(var(--bs-primary-rgb), 0.2) 0%, rgba(var(--bs-primary-rgb), 0.45) 100%);
   }
 
   .album-media-meta {

--- a/webapp/admin/templates/admin/role_edit.html
+++ b/webapp/admin/templates/admin/role_edit.html
@@ -11,8 +11,10 @@
     overflow-y: auto;
   }
   .permission-item {
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    background: var(--bs-body-bg);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, outline-color 0.2s ease;
+    background-color: var(--bs-body-bg);
+    outline: 2px solid transparent;
+    outline-offset: -2px;
   }
   .permission-item:hover {
     border-color: rgba(13, 110, 253, 0.35);
@@ -27,6 +29,12 @@
   }
   .permission-item .form-check-input:checked + .form-check-label .fw-semibold {
     color: var(--bs-primary);
+  }
+
+  .permission-item-wrapper.capability-selector-item-selected .permission-item {
+    outline: solid 2px rgba(var(--bs-primary-rgb));
+    background-color: rgba(var(--bs-primary-rgb), 0.3);
+    box-shadow: 0 1.25rem 2.5rem rgba(var(--bs-primary-rgb), 0.18);
   }
   @media (max-width: 991.98px) {
     .permission-list {

--- a/webapp/static/js/capability_selector.js
+++ b/webapp/static/js/capability_selector.js
@@ -19,6 +19,7 @@
       this.toggleHandler = null;
       this.mutationObserver = null;
       this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
+      this.updateItemSelectionClasses = this.updateItemSelectionClasses.bind(this);
     }
 
     init({ onFilter = null, onSelectionChanged = null, onToggle = null } = {}) {
@@ -65,7 +66,19 @@
       if (typeof this.changeHandler === 'function') {
         this.changeHandler(event);
       }
+      this.updateItemSelectionClasses();
       this.updateToggleState();
+    }
+
+    updateItemSelectionClasses() {
+      (this.items || []).forEach((item) => {
+        if (!item) {
+          return;
+        }
+        const checkbox = item.querySelector('input[type="checkbox"]');
+        const isChecked = checkbox ? checkbox.checked : false;
+        item.classList.toggle('capability-selector-item-selected', isChecked);
+      });
     }
 
     refreshItems() {
@@ -74,6 +87,7 @@
         return;
       }
       this.items = Array.from(this.listContainer.querySelectorAll('[data-capability-selector-item]'));
+      this.updateItemSelectionClasses();
       this.updateToggleState();
     }
 
@@ -140,6 +154,7 @@
         this.toggleHandler({ shouldSelect, changed });
       }
 
+      this.updateItemSelectionClasses();
       this.updateToggleState();
     }
 


### PR DESCRIPTION
## Summary
- highlight selected capability cards in the role editor with the same outline and tinted background used on the user role picker
- update the capability selector JavaScript to toggle a selection class so the styling follows checkbox state changes
- refresh the album media selection styles to reuse the primary outline and overlay tint when creating albums

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6904c958965c8323bda27930a64bc069