### PR TITLE
Fix WebAuthn registration options serialization for existing passkeys

### DIFF
--- a/shared/application/passkey_service.py
+++ b/shared/application/passkey_service.py
@@ -22,6 +22,7 @@ from webauthn.helpers.structs import (
     AuthenticatorSelectionCriteria,
     AuthenticatorTransport,
     PublicKeyCredentialDescriptor,
+    PublicKeyCredentialType,
     RegistrationCredential,
     ResidentKeyRequirement,
     UserVerificationRequirement,
@@ -66,7 +67,7 @@ class PasskeyService:
             try:
                 descriptor = PublicKeyCredentialDescriptor(
                     id=base64url_to_bytes(credential.credential_id),
-                    type="public-key",
+                    type=PublicKeyCredentialType.PUBLIC_KEY,
                 )
             except Exception:  # pragma: no cover - defensive
                 continue

--- a/tests/shared/test_passkey_service.py
+++ b/tests/shared/test_passkey_service.py
@@ -15,6 +15,7 @@ from webauthn.helpers.structs import (
     AuthenticationCredential,
     AuthenticatorAssertionResponse,
     AuthenticatorAttestationResponse,
+    PublicKeyCredentialType,
     RegistrationCredential,
 )
 
@@ -109,7 +110,7 @@ def test_generate_registration_options_excludes_existing_credentials(monkeypatch
     assert len(captured["exclude_credentials"]) == 1
     descriptor = captured["exclude_credentials"][0]
     assert descriptor.id == b"existing-cred"
-    assert descriptor.type == "public-key"
+    assert descriptor.type is PublicKeyCredentialType.PUBLIC_KEY
 
 
 def test_register_passkey_persists_repository(monkeypatch, service, repository):


### PR DESCRIPTION
## Summary
- ensure existing credentials use the PublicKeyCredentialType enum when generating WebAuthn registration options
- update the passkey service unit test to assert the enum is used

## Testing
- pytest tests/shared/test_passkey_service.py

------
https://chatgpt.com/codex/tasks/task_e_6904ca4029d08323b7073f29962f0e3a