### PR TITLE
Adjust photo view navigation permissions

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -38,7 +38,9 @@
             {{ _('Photo View') }}
           </a>
           <ul class="dropdown-menu" aria-labelledby="photoNavDropdown">
+            {% if current_user.can('media:session') %}
             <li><a class="dropdown-item" href="{{ url_for('photo_view.session_home') }}">{{ _('Sessions') }}</a></li>
+            {% endif %}
             <li><a class="dropdown-item" href="{{ url_for('photo_view.media_list') }}">{{ _('Media Gallery') }}</a></li>
             {% if current_user.can('album:view') %}
             <li><a class="dropdown-item" href="{{ url_for('photo_view.albums') }}">{{ _('Albums') }}</a></li>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -46,7 +46,7 @@
           {% endif %}
           {% if current_user.can('media:view') %}
           <div class="col-md-4 mb-3">
-            <a href="{{ url_for('photo_view.session_home') }}" class="btn btn-success btn-lg w-100">
+            <a href="{{ url_for('photo_view.home') }}" class="btn btn-success btn-lg w-100">
               <i class="fas fa-images"></i><br>{{ _('Photo View') }}
             </a>
           </div>


### PR DESCRIPTION
## Summary
- hide the Photo View session menu entry unless the user can access sessions
- update the top page Photo View shortcut to point at the /photo-view/ entry route

## Testing
- pytest tests/test_photo_view_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_6904cb44ba1083238f52da98326766f2