### PR TITLE
Add guidance for album visibility settings

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/_album_form.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/_album_form.html
@@ -28,6 +28,14 @@
                   <option value="unlisted">{{ _('Unlisted') }}</option>
                   <option value="public">{{ _('Public') }}</option>
                 </select>
+                <div class="form-text small mt-2">
+                  <p class="mb-1">{{ _('Choose who can access the album.') }}</p>
+                  <ul class="mb-0 ps-3">
+                    <li><strong>{{ _('Unlisted') }}</strong> – {{ _('Only users explicitly linked to the album can view it.') }}</li>
+                    <li><strong>{{ _('Private') }}</strong> – {{ _('Hidden from everyone else. Only you can view it.') }}</li>
+                    <li><strong>{{ _('Public') }}</strong> – {{ _('Visible to anyone who can access the photo viewer and has the "album:view" permission.') }}</li>
+                  </ul>
+                </div>
               </div>
               <div class="mb-3">
                 <label class="form-label">{{ _('Album Cover') }}</label>

--- a/webapp/api/routes.py
+++ b/webapp/api/routes.py
@@ -1411,7 +1411,12 @@ def api_album_detail(album_id: int):
                 "visibility": {
                     "type": "string",
                     "enum": sorted(ALBUM_VISIBILITY_VALUES),
-                    "description": "Visibility of the album (public/private/unlisted).",
+                    "description": (
+                        "Visibility of the album. "
+                        "Use 'private' to keep it to yourself, "
+                        "'unlisted' to share only with linked users, "
+                        "or 'public' to allow any album:view user to see it."
+                    ),
                 },
                 "mediaIds": {
                     "type": "array",
@@ -1551,7 +1556,11 @@ def api_album_create():
                 "visibility": {
                     "type": "string",
                     "enum": sorted(ALBUM_VISIBILITY_VALUES),
-                    "description": "Album visibility mode.",
+                    "description": (
+                        "Album visibility mode. "
+                        "Choose 'private' for yourself only, 'unlisted' for linked users, "
+                        "or 'public' for any viewer with album:view."
+                    ),
                 },
                 "mediaIds": {
                     "type": "array",

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1523,6 +1523,18 @@ msgstr "限定公開"
 msgid "Public"
 msgstr "公開"
 
+msgid "Choose who can access the album."
+msgstr "アルバムを閲覧できる対象を選択します。"
+
+msgid "Only users explicitly linked to the album can view it."
+msgstr "アルバムに共有ユーザーとして紐づけた相手だけが閲覧できます。"
+
+msgid "Hidden from everyone else. Only you can view it."
+msgstr "他のユーザーには表示されません。閲覧できるのは自分だけです。"
+
+msgid "Visible to anyone who can access the photo viewer and has the \"album:view\" permission."
+msgstr "フォトビューアーにアクセスでき、かつ \"album:view\" 権限を持つユーザー全員に公開されます。"
+
 msgid "Album Cover"
 msgstr "表紙"
 


### PR DESCRIPTION
## Summary
- add contextual help beneath the album visibility selector so editors understand each option
- clarify the API schema documentation for album visibility values
- translate the new visibility guidance into Japanese

## Testing
- not run (UI text change only)

------
https://chatgpt.com/codex/tasks/task_e_6904d120c1e88323884337dce835f700