### PR TITLE
Fix photo view home shortcut for media-only users

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -46,7 +46,7 @@
           {% endif %}
           {% if current_user.can('media:view') %}
           <div class="col-md-4 mb-3">
-            <a href="{{ url_for('photo_view.home') }}" class="btn btn-success btn-lg w-100">
+            <a href="{{ url_for('photo_view.media_list') }}" class="btn btn-success btn-lg w-100">
               <i class="fas fa-images"></i><br>{{ _('Photo View') }}
             </a>
           </div>


### PR DESCRIPTION
## Summary
- update the home page Photo View button to point at the media list so media-only users are not redirected to album pages requiring extra permission

## Testing
- pytest tests/test_photo_view_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_6904d29a75f48323a29c372bc3146573