### PR TITLE
Adjust album filter controls and enable media detail long-press

### DIFF
--- a/features/photonest/presentation/photo_view/templates/photo-view/_album_form.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/_album_form.html
@@ -90,11 +90,11 @@
                     </div>
                   </div>
                   <div class="d-flex flex-wrap gap-2">
-                    <button type="button" class="btn btn-outline-secondary btn-sm" id="album-reset-filters">
-                      <i class="bi bi-arrow-counterclockwise me-1"></i>{{ _('Reset') }}
-                    </button>
                     <button type="button" class="btn btn-primary btn-sm" id="apply-media-filter">
                       <i class="bi bi-funnel me-1"></i>{{ _('Apply filters') }}
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="album-reset-filters">
+                      <i class="bi bi-arrow-counterclockwise me-1"></i>{{ _('Reset') }}
                     </button>
                   </div>
                 </div>

--- a/features/photonest/presentation/photo_view/templates/photo-view/albums.html
+++ b/features/photonest/presentation/photo_view/templates/photo-view/albums.html
@@ -1603,9 +1603,52 @@ document.addEventListener('DOMContentLoaded', () => {
     tile.appendChild(meta);
 
     if (hasValidId) {
+      const openMediaDetail = () => {
+        const detailUrl = `/photo-view/media/${id}`;
+        window.open(detailUrl, '_blank', 'noopener,noreferrer');
+      };
+
+      let longPressTimer = null;
+      let longPressTriggered = false;
+
       tile.addEventListener('click', (event) => {
+        if (longPressTriggered) {
+          event.preventDefault();
+          longPressTriggered = false;
+          return;
+        }
         event.preventDefault();
         toggleMediaSelection(media);
+      });
+
+      tile.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        longPressTriggered = true;
+        openMediaDetail();
+      });
+
+      tile.addEventListener('pointerdown', (event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+        longPressTriggered = false;
+        if (longPressTimer) {
+          window.clearTimeout(longPressTimer);
+        }
+        longPressTimer = window.setTimeout(() => {
+          longPressTriggered = true;
+          longPressTimer = null;
+          openMediaDetail();
+        }, 600);
+      });
+
+      ['pointerup', 'pointerleave', 'pointercancel'].forEach((type) => {
+        tile.addEventListener(type, () => {
+          if (longPressTimer) {
+            window.clearTimeout(longPressTimer);
+            longPressTimer = null;
+          }
+        });
       });
     }
 

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -659,10 +659,6 @@ body.login-page .login-card .language-selector {
     font-size: 1.75rem;
   }
 
-  .form-control {
-    padding: 10px 12px 10px 40px;
-  }
-
   .input-icon {
     left: 12px;
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- remove the mobile-specific form control padding that caused excess spacing on small screens
- reorder the album filter action buttons so Apply appears on the left and Reset on the right
- allow right-click or touch long-press on album media tiles to open the media detail view in a new window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904dde0e0d883239bb3cf9f0535a5c0