### PR TITLE
Ensure passkey login returns user-bound credentials

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -285,6 +285,21 @@ document.addEventListener('DOMContentLoaded', function() {
         passkeyButton.classList.add('loading');
         passkeyButton.disabled = true;
 
+        const emailField = document.getElementById('email');
+        const emailInputValue = (emailField?.value || '').trim();
+        if (!emailInputValue) {
+          if (emailField) {
+            if (typeof emailField.reportValidity === 'function') {
+              emailField.reportValidity();
+            } else {
+              emailField.focus();
+            }
+          }
+          passkeyButton.classList.remove('loading');
+          passkeyButton.disabled = false;
+          return;
+        }
+
         const storedRedirectPath = localStorage.getItem('redirect_after_login');
 
         try {
@@ -293,6 +308,7 @@ document.addEventListener('DOMContentLoaded', function() {
             headers: {
               'Content-Type': 'application/json',
             },
+            body: JSON.stringify({ email: emailInputValue }),
           });
 
           if (!optionsResponse.ok) {


### PR DESCRIPTION
## Summary
- resolve the passkey login options request to the intended user and surface allowCredentials
- extend the passkey service to build credential descriptors including stored transports
- require the login UI to send the email for passkey auth and cover the flow with tests

## Testing
- pytest tests/shared/test_passkey_service.py tests/webapp/auth/test_passkey_routes.py

------
https://chatgpt.com/codex/tasks/task_e_6905dbcd587883239325d9884e985892