### PR TITLE
Adjust admin navigation to prioritize the groups tab

### DIFF
--- a/webapp/admin/templates/admin/admin_users.html
+++ b/webapp/admin/templates/admin/admin_users.html
@@ -16,6 +16,13 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -33,13 +40,6 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
-    </a>
-  </li>
-  {% endif %}
   {% endif %}
   {% if current_user.can('role:manage') %}
   <li class="nav-item">

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -10,6 +10,13 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -27,13 +34,6 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
-    </a>
-  </li>
-  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/google_accounts.html
+++ b/webapp/admin/templates/admin/google_accounts.html
@@ -14,6 +14,13 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -31,13 +38,6 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
-    </a>
-  </li>
-  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/group_edit.html
+++ b/webapp/admin/templates/admin/group_edit.html
@@ -16,6 +16,11 @@
     </a>
   </li>
   <li class="nav-item">
+    <a class="nav-link active" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
@@ -30,11 +35,6 @@
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.show_config') }}">
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link active" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
     </a>
   </li>
   <li class="nav-item">

--- a/webapp/admin/templates/admin/groups.html
+++ b/webapp/admin/templates/admin/groups.html
@@ -10,6 +10,11 @@
     </a>
   </li>
   <li class="nav-item">
+    <a class="nav-link active" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
     </a>
@@ -24,11 +29,6 @@
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.show_config') }}">
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link active" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
     </a>
   </li>
   <li class="nav-item">

--- a/webapp/admin/templates/admin/permissions.html
+++ b/webapp/admin/templates/admin/permissions.html
@@ -10,6 +10,13 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -27,13 +34,6 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
-    </a>
-  </li>
-  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/roles.html
+++ b/webapp/admin/templates/admin/roles.html
@@ -10,6 +10,13 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -27,13 +34,6 @@
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
     </a>
   </li>
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
-    </a>
-  </li>
-  {% endif %}
   <li class="nav-item">
     <a class="nav-link active" href="{{ url_for('admin.roles') }}">
       <i class="fas fa-user-tag"></i> {{ _('Roles') }}

--- a/webapp/admin/templates/admin/service_accounts.html
+++ b/webapp/admin/templates/admin/service_accounts.html
@@ -61,6 +61,15 @@
       <i class="fas fa-users"></i> {{ _('User Management') }}
     </a>
   </li>
+  {% endif %}
+  {% if current_user.can('group:manage') %}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('admin.groups') }}">
+      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
+    </a>
+  </li>
+  {% endif %}
+  {% if current_user.can('user:manage') %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.google_accounts') }}">
       <i class="fab fa-google"></i> {{ _('Google Accounts') }}
@@ -84,13 +93,6 @@
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('admin.show_config') }}">
       <i class="fas fa-cogs"></i> {{ _('Config Settings') }}
-    </a>
-  </li>
-  {% endif %}
-  {% if current_user.can('group:manage') %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('admin.groups') }}">
-      <i class="fas fa-layer-group"></i> {{ _('Groups') }}
     </a>
   </li>
   {% endif %}


### PR DESCRIPTION
## Summary
- move the Groups tab to follow the Users tab on every admin management page
- keep existing permission checks intact while reordering navigation links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905dc15893483239027428d3b12f9f4