### PR TITLE
Fix WebAuthn binary conversion for passkey flows

### DIFF
--- a/webapp/auth/templates/auth/login.html
+++ b/webapp/auth/templates/auth/login.html
@@ -118,11 +118,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const originalFormAction = form.action;
 
-  const bufferToBase64Url = (buffer) => {
-    if (!(buffer instanceof ArrayBuffer)) {
+  const bufferToBase64Url = (input) => {
+    let bytes;
+    if (input instanceof ArrayBuffer) {
+      bytes = new Uint8Array(input);
+    } else if (ArrayBuffer.isView(input)) {
+      bytes = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+    } else {
       return '';
     }
-    const bytes = new Uint8Array(buffer);
     let binary = '';
     for (let i = 0; i < bytes.length; i += 1) {
       binary += String.fromCharCode(bytes[i]);
@@ -132,18 +136,17 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const base64UrlToBuffer = (value) => {
     if (typeof value !== 'string' || value.length === 0) {
-      return new ArrayBuffer(0);
+      return new Uint8Array();
     }
     const padded = value.replace(/-/g, '+').replace(/_/g, '/');
     const padLength = (4 - (padded.length % 4)) % 4;
     const normalized = padded + '='.repeat(padLength);
     const binary = window.atob(normalized);
-    const buffer = new ArrayBuffer(binary.length);
-    const bytes = new Uint8Array(buffer);
+    const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i += 1) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return buffer;
+    return bytes;
   };
 
   const resolveNextValue = () => {

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -190,11 +190,15 @@
     const userEmail = (form?.dataset.userEmail || '').trim().toLowerCase();
     const storageKey = userEmail ? `login_scope:${userEmail}` : null;
 
-    const bufferToBase64Url = (buffer) => {
-      if (!(buffer instanceof ArrayBuffer)) {
+    const bufferToBase64Url = (input) => {
+      let bytes;
+      if (input instanceof ArrayBuffer) {
+        bytes = new Uint8Array(input);
+      } else if (ArrayBuffer.isView(input)) {
+        bytes = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+      } else {
         return '';
       }
-      const bytes = new Uint8Array(buffer);
       let binary = '';
       for (let i = 0; i < bytes.length; i += 1) {
         binary += String.fromCharCode(bytes[i]);
@@ -204,18 +208,17 @@
 
     const base64UrlToBuffer = (value) => {
       if (typeof value !== 'string' || value.length === 0) {
-        return new ArrayBuffer(0);
+        return new Uint8Array();
       }
       const padded = value.replace(/-/g, '+').replace(/_/g, '/');
       const padLength = (4 - (padded.length % 4)) % 4;
       const normalized = padded + '='.repeat(padLength);
       const binary = window.atob(normalized);
-      const buffer = new ArrayBuffer(binary.length);
-      const bytes = new Uint8Array(buffer);
+      const bytes = new Uint8Array(binary.length);
       for (let i = 0; i < binary.length; i += 1) {
         bytes[i] = binary.charCodeAt(i);
       }
-      return buffer;
+      return bytes;
     };
 
     if (form && select && storageKey) {


### PR DESCRIPTION
## Summary
- ensure the passkey registration and login flows convert WebAuthn challenges, user IDs, and credential IDs into Uint8Array instances before invoking the API
- allow the shared helper to serialise ArrayBufferView responses so that WebAuthn results can be posted back to the server reliably

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_6905eaa5d5088323b811b271341d7e9f