### PR TITLE
Improve passkey re-registration feedback

### DIFF
--- a/tests/shared/test_passkey_repository.py
+++ b/tests/shared/test_passkey_repository.py
@@ -1,0 +1,53 @@
+"""Tests for the SQLAlchemy passkey repository implementation."""
+from __future__ import annotations
+
+from core.db import db
+from core.models.user import User
+from shared.infrastructure.passkey_repository import SqlAlchemyPasskeyRepository
+
+
+def test_delete_allows_re_registering_same_credential(app_context):
+    """Deleting a passkey should allow registering the same credential again."""
+
+    with app_context.app_context():
+        user = User(email="passkey-user@example.com", username="passkey-user")
+        user.set_password("secret")
+        db.session.add(user)
+        db.session.commit()
+
+        repository = SqlAlchemyPasskeyRepository(db.session)
+
+        record = repository.add(
+            user=user,
+            credential_id="test-credential-id",
+            public_key="test-public-key",
+            sign_count=1,
+            transports=["internal"],
+            name="Laptop",
+            attestation_format="packed",
+            aaguid="test-aaguid",
+            backup_eligible=True,
+            backup_state=False,
+        )
+
+        repository.delete(record)
+
+        recreated = repository.add(
+            user=user,
+            credential_id="test-credential-id",
+            public_key="test-public-key",
+            sign_count=1,
+            transports=["internal"],
+            name="Laptop",
+            attestation_format="packed",
+            aaguid="test-aaguid",
+            backup_eligible=True,
+            backup_state=False,
+        )
+
+        assert recreated.id is not None
+        assert recreated.credential_id == "test-credential-id"
+
+        rows = repository.list_for_user(user.id)
+        assert len(rows) == 1
+        assert rows[0].id == recreated.id

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -72,7 +72,12 @@
             <p class="text-muted mb-3">{{ _('No passkeys registered yet.') }}</p>
             {% endif %}
             <div class="d-flex flex-column flex-sm-row align-items-start gap-2">
-              <button type="button" class="btn btn-outline-primary" data-passkey-register>
+              <button
+                type="button"
+                class="btn btn-outline-primary"
+                data-passkey-register
+                data-passkey-existing-count="{{ passkey_credentials|length if passkey_credentials is not none else 0 }}"
+              >
                 <span class="spinner-border spinner-border-sm me-2 d-none" role="status" aria-hidden="true" data-passkey-spinner></span>
                 <i class="fas fa-key me-2" data-passkey-icon></i>
                 <span data-passkey-label>{{ _('Add a new passkey') }}</span>
@@ -284,6 +289,9 @@
       const spinner = registerButton.querySelector('[data-passkey-spinner]');
       const icon = registerButton.querySelector('[data-passkey-icon]');
       const duplicateMessage = "{{ _('This passkey is already registered for your account.')|escapejs }}";
+      const existingCountRaw = registerButton.getAttribute('data-passkey-existing-count');
+      const existingCount = existingCountRaw ? Number.parseInt(existingCountRaw, 10) || 0 : 0;
+      const hadExistingCredentialsAtLoad = existingCount > 0;
 
       if (!window.PublicKeyCredential || typeof navigator.credentials === 'undefined') {
         registerButton.disabled = true;
@@ -386,13 +394,25 @@
               : undefined;
             const errorMessage = (error && typeof error.message === 'string') ? error.message : '';
 
-            if (errorMessage === 'abort' || errorName === 'AbortError') {
-              // user cancelled, ignore
-            } else if (errorName === 'NotAllowedError' && hadExcludedCredentials) {
+            const shouldTreatAsDuplicate = hadExcludedCredentials || hadExistingCredentialsAtLoad;
+
+            if ((errorMessage === 'abort' || errorName === 'AbortError') && shouldTreatAsDuplicate) {
               if (typeof showWarningToast === 'function') {
                 showWarningToast(duplicateMessage);
               } else if (typeof alert === 'function') {
                 alert(duplicateMessage);
+              }
+            } else if (errorName === 'NotAllowedError' && shouldTreatAsDuplicate) {
+              if (typeof showWarningToast === 'function') {
+                showWarningToast(duplicateMessage);
+              } else if (typeof alert === 'function') {
+                alert(duplicateMessage);
+              }
+            } else if (errorName === 'NotAllowedError') {
+              if (typeof showErrorToast === 'function') {
+                showErrorToast('{{ _('Passkey registration was cancelled before completion.') }}');
+              } else if (typeof alert === 'function') {
+                alert('{{ _('Passkey registration was cancelled before completion.') }}');
               }
             } else if (errorMessage === 'options') {
               if (typeof showErrorToast === 'function') {
@@ -407,8 +427,6 @@
                 alert(duplicateMessage);
               }
               window.location.reload();
-            } else if (errorName === 'NotAllowedError') {
-              // treated as user cancellation when browser reports a generic NotAllowedError
             } else {
               if (typeof showErrorToast === 'function') {
                 showErrorToast('{{ _('Passkey registration failed. Please try again.') }}');

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -274,6 +274,10 @@ msgid "Passkey registration options could not be retrieved."
 msgstr "Passkey registration options could not be retrieved."
 
 #: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled before completion."
+msgstr "Passkey registration was cancelled before completion."
+
+#: webapp/auth/templates/auth/profile.html
 msgid "Passkey registration failed. Please try again."
 msgstr "Passkey registration failed. Please try again."
 

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1354,6 +1354,10 @@ msgid "Passkey registration options could not be retrieved."
 msgstr "パスキー登録のオプションを取得できませんでした。"
 
 #: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled before completion."
+msgstr "パスキーの登録が完了する前にキャンセルされました。"
+
+#: webapp/auth/templates/auth/profile.html
 msgid "Passkey registration failed. Please try again."
 msgstr "パスキーの登録に失敗しました。もう一度お試しください。"
 


### PR DESCRIPTION
## Summary
- surface duplicate warnings for aborted passkey registrations when credentials already exist and show a cancellation notice otherwise
- annotate the profile register button with the existing credential count and translate the new cancellation message
- add a repository test to ensure a deleted passkey credential can be registered again

## Testing
- pytest tests/shared/test_passkey_repository.py tests/webapp/auth/test_passkey_routes.py -q


------
https://chatgpt.com/codex/tasks/task_e_6905f52cbf708323b957ea41ce2de6ad