### PR TITLE
Handle duplicate passkey registration attempts

### DIFF
--- a/shared/infrastructure/passkey_repository.py
+++ b/shared/infrastructure/passkey_repository.py
@@ -85,3 +85,47 @@ class SqlAlchemyPasskeyRepository:
     def delete(self, credential: PasskeyCredential) -> None:
         self._session.delete(credential)
         self._session.commit()
+
+    def update_existing(
+        self,
+        credential: PasskeyCredential,
+        *,
+        public_key: str | None = None,
+        sign_count: int | None = None,
+        transports: Iterable[str] | None = None,
+        name: str | None = None,
+        attestation_format: str | None = None,
+        aaguid: str | None = None,
+        backup_eligible: bool | None = None,
+        backup_state: bool | None = None,
+    ) -> PasskeyCredential:
+        """Persist updated metadata for an existing credential."""
+
+        if public_key is not None:
+            credential.public_key = public_key
+
+        if sign_count is not None:
+            credential.sign_count = sign_count
+
+        if transports is not None:
+            credential.transports = list(transports) if transports else None
+
+        if name is not None:
+            credential.name = name
+
+        if attestation_format is not None:
+            credential.attestation_format = attestation_format
+
+        if aaguid is not None:
+            credential.aaguid = aaguid
+
+        if backup_eligible is not None:
+            credential.backup_eligible = backup_eligible
+
+        if backup_state is not None:
+            credential.backup_state = backup_state
+
+        credential.touch()
+        self._session.commit()
+        self._session.refresh(credential)
+        return credential

--- a/tests/shared/test_passkey_repository.py
+++ b/tests/shared/test_passkey_repository.py
@@ -51,3 +51,49 @@ def test_delete_allows_re_registering_same_credential(app_context):
         rows = repository.list_for_user(user.id)
         assert len(rows) == 1
         assert rows[0].id == recreated.id
+
+
+def test_update_existing_overwrites_metadata(app_context):
+    """Updating an existing credential should persist new metadata values."""
+
+    with app_context.app_context():
+        user = User(email="update-user@example.com", username="update-user")
+        user.set_password("secret")
+        db.session.add(user)
+        db.session.commit()
+
+        repository = SqlAlchemyPasskeyRepository(db.session)
+
+        record = repository.add(
+            user=user,
+            credential_id="initial-id",
+            public_key="initial-key",
+            sign_count=1,
+            transports=["internal"],
+            name="Initial",
+            attestation_format="packed",
+            aaguid="initial-aaguid",
+            backup_eligible=False,
+            backup_state=False,
+        )
+
+        updated = repository.update_existing(
+            record,
+            public_key="updated-key",
+            sign_count=5,
+            transports=["internal", "hybrid"],
+            name="Updated",
+            attestation_format="packed",
+            aaguid="updated-aaguid",
+            backup_eligible=True,
+            backup_state=True,
+        )
+
+        assert updated.id == record.id
+        assert updated.public_key == "updated-key"
+        assert updated.sign_count == 5
+        assert updated.transports == ["internal", "hybrid"]
+        assert updated.name == "Updated"
+        assert updated.aaguid == "updated-aaguid"
+        assert updated.backup_eligible is True
+        assert updated.backup_state is True


### PR DESCRIPTION
## Summary
- allow duplicate passkey registrations for the same user to reuse and refresh the stored credential instead of erroring
- add a repository helper to persist metadata updates when an existing credential is reused
- extend service and repository unit tests to cover duplicate registration flows

## Testing
- pytest tests/shared/test_passkey_service.py tests/shared/test_passkey_repository.py

------
https://chatgpt.com/codex/tasks/task_e_6905f8a2eea88323b4a3689c0f2122fc