### PR TITLE
Allow passkey re-registration for existing credentials

### DIFF
--- a/shared/application/passkey_service.py
+++ b/shared/application/passkey_service.py
@@ -62,17 +62,6 @@ class PasskeyService:
     ) -> tuple[dict, str]:
         """Return creation options and encoded challenge for *user*."""
 
-        exclude_credentials: list[PublicKeyCredentialDescriptor] = []
-        for credential in self.repository.list_for_user(user.id):
-            try:
-                descriptor = PublicKeyCredentialDescriptor(
-                    id=base64url_to_bytes(credential.credential_id),
-                    type=PublicKeyCredentialType.PUBLIC_KEY,
-                )
-            except Exception:  # pragma: no cover - defensive
-                continue
-            exclude_credentials.append(descriptor)
-
         options = generate_registration_options(
             rp_id=rp_id or settings.webauthn_rp_id,
             rp_name=rp_name or settings.webauthn_rp_name,
@@ -84,7 +73,6 @@ class PasskeyService:
                 resident_key=ResidentKeyRequirement.PREFERRED,
                 user_verification=UserVerificationRequirement.PREFERRED,
             ),
-            exclude_credentials=exclude_credentials,
         )
         challenge = bytes_to_base64url(options.challenge)
         options_json = json.loads(options_to_json(options))

--- a/tests/shared/test_passkey_service.py
+++ b/tests/shared/test_passkey_service.py
@@ -130,7 +130,9 @@ class DummyUser:
         self.display_name = display_name or email
 
 
-def test_generate_registration_options_excludes_existing_credentials(monkeypatch, service, repository):
+def test_generate_registration_options_does_not_exclude_existing_credentials(
+    monkeypatch, service, repository
+):
     existing = StubCredential(credential_id=bytes_to_base64url(b"existing-cred"))
     repository.credentials.append(existing)
 
@@ -158,11 +160,7 @@ def test_generate_registration_options_excludes_existing_credentials(monkeypatch
 
     assert challenge == bytes_to_base64url(b"reg-challenge")
     assert options == {"challenge": "serialized"}
-    assert "exclude_credentials" in captured
-    assert len(captured["exclude_credentials"]) == 1
-    descriptor = captured["exclude_credentials"][0]
-    assert descriptor.id == b"existing-cred"
-    assert descriptor.type is PublicKeyCredentialType.PUBLIC_KEY
+    assert "exclude_credentials" not in captured
 
 
 def test_generate_authentication_options_uses_allow_credentials(monkeypatch, service, repository):

--- a/webapp/auth/templates/auth/profile.html
+++ b/webapp/auth/templates/auth/profile.html
@@ -76,7 +76,6 @@
                 type="button"
                 class="btn btn-outline-primary"
                 data-passkey-register
-                data-passkey-existing-count="{{ passkey_credentials|length if passkey_credentials is not none else 0 }}"
               >
                 <span class="spinner-border spinner-border-sm me-2 d-none" role="status" aria-hidden="true" data-passkey-spinner></span>
                 <i class="fas fa-key me-2" data-passkey-icon></i>
@@ -289,9 +288,6 @@
       const spinner = registerButton.querySelector('[data-passkey-spinner]');
       const icon = registerButton.querySelector('[data-passkey-icon]');
       const duplicateMessage = "{{ _('This passkey is already registered for your account.')|escapejs }}";
-      const existingCountRaw = registerButton.getAttribute('data-passkey-existing-count');
-      const existingCount = existingCountRaw ? Number.parseInt(existingCountRaw, 10) || 0 : 0;
-      const hadExistingCredentialsAtLoad = existingCount > 0;
 
       if (!window.PublicKeyCredential || typeof navigator.credentials === 'undefined') {
         registerButton.disabled = true;
@@ -394,9 +390,15 @@
               : undefined;
             const errorMessage = (error && typeof error.message === 'string') ? error.message : '';
 
-            const shouldTreatAsDuplicate = hadExcludedCredentials || hadExistingCredentialsAtLoad;
+            const shouldTreatAsDuplicate = hadExcludedCredentials;
 
-            if ((errorMessage === 'abort' || errorName === 'AbortError') && shouldTreatAsDuplicate) {
+            if (errorName === 'InvalidStateError') {
+              if (typeof showWarningToast === 'function') {
+                showWarningToast(duplicateMessage);
+              } else if (typeof alert === 'function') {
+                alert(duplicateMessage);
+              }
+            } else if ((errorMessage === 'abort' || errorName === 'AbortError') && shouldTreatAsDuplicate) {
               if (typeof showWarningToast === 'function') {
                 showWarningToast(duplicateMessage);
               } else if (typeof alert === 'function') {
@@ -409,10 +411,21 @@
                 alert(duplicateMessage);
               }
             } else if (errorName === 'NotAllowedError') {
+              const normalizedMessage = (typeof errorMessage === 'string')
+                ? errorMessage.toLowerCase()
+                : '';
+              let notAllowedMessage;
+              if (normalizedMessage.includes('timed out') || normalizedMessage.includes('timeout')) {
+                notAllowedMessage = '{{ _('Passkey registration timed out before the authenticator responded. Please try again and confirm the prompt on your device.') }}';
+              } else if (normalizedMessage.includes('cancel') || normalizedMessage.includes('dismiss')) {
+                notAllowedMessage = '{{ _('Passkey registration was cancelled from the authenticator prompt. Please retry and complete the device approval.') }}';
+              } else {
+                notAllowedMessage = '{{ _('Passkey registration was cancelled or timed out before completion. Please retry after completing the authenticator prompt.') }}';
+              }
               if (typeof showErrorToast === 'function') {
-                showErrorToast('{{ _('Passkey registration was cancelled before completion.') }}');
+                showErrorToast(notAllowedMessage);
               } else if (typeof alert === 'function') {
-                alert('{{ _('Passkey registration was cancelled before completion.') }}');
+                alert(notAllowedMessage);
               }
             } else if (errorMessage === 'options') {
               if (typeof showErrorToast === 'function') {

--- a/webapp/translations/en/LC_MESSAGES/messages.po
+++ b/webapp/translations/en/LC_MESSAGES/messages.po
@@ -274,8 +274,16 @@ msgid "Passkey registration options could not be retrieved."
 msgstr "Passkey registration options could not be retrieved."
 
 #: webapp/auth/templates/auth/profile.html
-msgid "Passkey registration was cancelled before completion."
-msgstr "Passkey registration was cancelled before completion."
+msgid "Passkey registration timed out before the authenticator responded. Please try again and confirm the prompt on your device."
+msgstr "Passkey registration timed out before the authenticator responded. Please try again and confirm the prompt on your device."
+
+#: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled from the authenticator prompt. Please retry and complete the device approval."
+msgstr "Passkey registration was cancelled from the authenticator prompt. Please retry and complete the device approval."
+
+#: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled or timed out before completion. Please retry after completing the authenticator prompt."
+msgstr "Passkey registration was cancelled or timed out before completion. Please retry after completing the authenticator prompt."
 
 #: webapp/auth/templates/auth/profile.html
 msgid "Passkey registration failed. Please try again."

--- a/webapp/translations/ja/LC_MESSAGES/messages.po
+++ b/webapp/translations/ja/LC_MESSAGES/messages.po
@@ -1354,8 +1354,16 @@ msgid "Passkey registration options could not be retrieved."
 msgstr "パスキー登録のオプションを取得できませんでした。"
 
 #: webapp/auth/templates/auth/profile.html
-msgid "Passkey registration was cancelled before completion."
-msgstr "パスキーの登録が完了する前にキャンセルされました。"
+msgid "Passkey registration timed out before the authenticator responded. Please try again and confirm the prompt on your device."
+msgstr "認証器からの応答前にパスキー登録がタイムアウトしました。デバイスのプロンプトを確認してから再度お試しください。"
+
+#: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled from the authenticator prompt. Please retry and complete the device approval."
+msgstr "認証器のプロンプトでパスキー登録がキャンセルされました。デバイスで承認を完了してから再度お試しください。"
+
+#: webapp/auth/templates/auth/profile.html
+msgid "Passkey registration was cancelled or timed out before completion. Please retry after completing the authenticator prompt."
+msgstr "パスキー登録は完了前にキャンセルまたはタイムアウトしました。認証器の操作を完了してから再度お試しください。"
 
 #: webapp/auth/templates/auth/profile.html
 msgid "Passkey registration failed. Please try again."


### PR DESCRIPTION
## Summary
- stop sending excludeCredentials during passkey registration so authenticators can reuse an existing credential for the same user
- cover the new registration option behaviour in the shared passkey service tests
- surface duplicate messaging for InvalidStateError without misidentifying cancellations on the profile passkey flow

## Testing
- pytest tests/shared/test_passkey_service.py
- pytest tests/webapp/auth/test_passkey_routes.py

------
https://chatgpt.com/codex/tasks/task_e_6905fb98851c8323b95da6013a28ad48