### PR TITLE
Sync media perceptual hash schema baseline

### DIFF
--- a/core/models/photo_models.py
+++ b/core/models/photo_models.py
@@ -56,6 +56,7 @@ class Media(db.Model):
     thumbnail_rel_path: Mapped[str | None] = mapped_column(db.String(255), nullable=True)
     filename: Mapped[str | None] = mapped_column(db.String(255), nullable=True)
     hash_sha256: Mapped[str | None] = mapped_column(db.CHAR(64), nullable=True)
+    phash: Mapped[str | None] = mapped_column(db.String(64), nullable=True)
     bytes: Mapped[int | None] = mapped_column(BigInt, nullable=True)
 
     # メディア情報

--- a/db/init/01_initialize.sql
+++ b/db/init/01_initialize.sql
@@ -422,6 +422,7 @@ CREATE TABLE `media` (
   `local_rel_path` varchar(255) DEFAULT NULL,
   `filename` varchar(255) DEFAULT NULL,
   `hash_sha256` char(64) DEFAULT NULL,
+  `phash` varchar(64) DEFAULT NULL,
   `bytes` bigint(20) DEFAULT NULL,
   `mime_type` varchar(255) DEFAULT NULL,
   `width` int(11) DEFAULT NULL,
@@ -441,6 +442,7 @@ CREATE TABLE `media` (
   `thumbnail_rel_path` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `account_id` (`account_id`),
+  KEY `ix_media_phash_dimensions` (`phash`,`shot_at`,`width`,`height`,`duration_ms`,`is_video`),
   CONSTRAINT `media_ibfk_1` FOREIGN KEY (`account_id`) REFERENCES `google_account` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/features/photonest/application/local_import/file_importer.py
+++ b/features/photonest/application/local_import/file_importer.py
@@ -39,7 +39,7 @@ class PostProcessService(Protocol):
 
 
 class DuplicateChecker(Protocol):
-    def __call__(self, file_hash: str, file_size: int) -> Optional[Media]:
+    def __call__(self, analysis: MediaFileAnalysis) -> Optional[Media]:
         ...
 
 
@@ -225,9 +225,7 @@ class LocalImportFileImporter:
                 return outcome.as_dict()
 
             analysis = self._analysis_service(file_path)
-            existing_media = self._duplicate_checker(
-                analysis.file_hash, analysis.file_size
-            )
+            existing_media = self._duplicate_checker(analysis)
             if existing_media:
                 return self._handle_duplicate(
                     outcome,

--- a/features/photonest/domain/local_import/media_entities.py
+++ b/features/photonest/domain/local_import/media_entities.py
@@ -111,6 +111,7 @@ def build_media_from_analysis(
         local_rel_path=relative_path,
         filename=analysis.source.name,
         hash_sha256=analysis.file_hash,
+        phash=analysis.perceptual_hash,
         bytes=analysis.file_size,
         mime_type=analysis.mime_type,
         width=analysis.width,
@@ -137,6 +138,7 @@ def apply_analysis_to_media_entity(media: Media, analysis: MediaFileAnalysis) ->
 
     media.mime_type = analysis.mime_type
     media.hash_sha256 = analysis.file_hash
+    media.phash = analysis.perceptual_hash
     media.bytes = analysis.file_size
     if analysis.width is not None:
         media.width = analysis.width

--- a/migrations/versions/c7d8e9f0a1b2_add_media_phash_column.py
+++ b/migrations/versions/c7d8e9f0a1b2_add_media_phash_column.py
@@ -1,0 +1,26 @@
+"""Add perceptual hash support for media duplicates."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c7d8e9f0a1b2"
+down_revision = "a7d9c3e2b1f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("media", sa.Column("phash", sa.String(length=64), nullable=True))
+    op.create_index(
+        "ix_media_phash_dimensions",
+        "media",
+        ["phash", "shot_at", "width", "height", "duration_ms", "is_video"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_media_phash_dimensions", table_name="media")
+    op.drop_column("media", "phash")

--- a/tests/test_local_import_duplicate_refresh.py
+++ b/tests/test_local_import_duplicate_refresh.py
@@ -180,6 +180,7 @@ def test_duplicate_import_updates_relative_path(monkeypatch, tmp_path, app_conte
                 video_metadata={"fps": 30.0},
                 destination_filename=Path(rel_path).name,
                 relative_path=rel_path,
+                perceptual_hash="video-phash",
             )
 
     analyzer = DummyAnalyzer()
@@ -333,6 +334,7 @@ def test_duplicate_refresh_realigns_playback_paths(
                 video_metadata={"fps": 30.0},
                 destination_filename=Path(self.relative_path).name,
                 relative_path=self.relative_path,
+                perceptual_hash="video-phash",
             )
 
     analyzer = DummyAnalyzer()

--- a/tests/test_local_import_services.py
+++ b/tests/test_local_import_services.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -21,8 +22,17 @@ class DummyAnalysis:
         self.file_hash = file_hash
         self.file_size = file_size
         self.is_video = is_video
+        self.width = 800
+        self.height = 600
+        self.duration_ms = 0 if not is_video else 1000
+        self.orientation = None
+        self.shot_at = datetime.now(timezone.utc)
+        self.exif_data = {}
+        self.video_metadata = {}
+        self.mime_type = "image/jpeg" if not is_video else "video/mp4"
         self.destination_filename = "sample.jpg"
         self.relative_path = "sample/sample.jpg"
+        self.perceptual_hash = "dummy-phash"
 
 
 class DummyMedia:


### PR DESCRIPTION
## Summary
- add the media.phash column to the initial schema dump
- seed the ix_media_phash_dimensions index in the baseline SQL

## Testing
- pytest tests/test_local_import_services.py tests/test_local_import_duplicate_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_69062aea0a74832399ef751fb9a8d68b