### PR TITLE
Fix duplicate-only picker sessions stuck in processing

### DIFF
--- a/webapp/api/picker_session_service.py
+++ b/webapp/api/picker_session_service.py
@@ -1027,8 +1027,13 @@ class PickerSessionService:
             saved, dup, new_pmis = PickerSessionService._fetch_and_store_items(
                 ps, headers, session_id, cursor
             )
-            new_count = len(new_pmis) if isinstance(new_pmis, list) else None
-            PickerSessionService._enqueue_new_items(ps, new_pmis)
+            if not isinstance(new_pmis, list):
+                new_pmis = list(new_pmis)
+            new_count = len(new_pmis)
+            if new_pmis:
+                PickerSessionService._enqueue_new_items(ps, new_pmis)
+            elif saved or dup:
+                db.session.commit()
             current_app.logger.info(
                 json.dumps(
                     {


### PR DESCRIPTION
## Summary
- commit picker session updates when only duplicate media items are found so status polling can progress
- cover duplicate-only ingestion with a regression test to ensure sessions transition to imported

## Testing
- pytest tests/test_session_service_media_items.py

------
https://chatgpt.com/codex/tasks/task_e_69068fd1edd08323a8bee4c50ab5259a