### PR TITLE
Fix session table button alignment

### DIFF
--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -455,6 +455,15 @@ body.login-page footer {
   max-width: 12rem;
 }
 
+/* Use more compact spacing for small buttons inside tabular layouts */
+.table td .btn-size-sm,
+.table th .btn-size-sm {
+  min-width: 0;
+  max-width: none;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+}
+
 .btn-login {
   width: 100%;
   padding: 14px;


### PR DESCRIPTION
## Summary
- adjust the compact button utility spacing when rendered inside tables
- allow action buttons in picker session list to align with the other columns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6906905e900083238600a83d9f57b14b