### PR TITLE
Add perceptual hash support to picker imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ ALWAYS_RUN = {
     "tests/test_local_import_results.py",
     "tests/test_celery_app.py",
     "tests/test_celery_context.py",
+    "tests/test_picker_import_item.py",
 }
 
 


### PR DESCRIPTION
## Summary
- compute perceptual hashes for media imported via the Google picker (single item and session paths)
- keep picker import tests active and add coverage for the new hash behaviour while simplifying post-processing stubs

## Testing
- pytest tests/test_picker_import_item.py -k "not manual" -vv

------
https://chatgpt.com/codex/tasks/task_e_6906977c2e1483239b7f12cac56e5b50