### PR TITLE
Compute perceptual hash for Google Photos imports

### DIFF
--- a/tests/test_picker_import_item.py
+++ b/tests/test_picker_import_item.py
@@ -79,6 +79,12 @@ def test_picker_import_item_imports(monkeypatch, app, tmp_path):
     import importlib
     mod = importlib.import_module("core.tasks.picker_import")
 
+    monkeypatch.setattr(
+        mod,
+        "_compute_perceptual_hash",
+        lambda *_, **__: "deadbeef",
+    )
+
     content = b"hello"
     sha = hashlib.sha256(content).hexdigest()
 
@@ -119,6 +125,7 @@ def test_picker_import_item_imports(monkeypatch, app, tmp_path):
         assert pmi.lock_heartbeat_at is None
         assert Media.query.count() == 1
         assert media.source_type == "google_photos"
+        assert media.phash == "deadbeef"
         assert called_thumbs == [media.id]
         assert called_play == []
 


### PR DESCRIPTION
## Summary
- compute perceptual hashes when registering Google Photos media
- extend picker import test to confirm the hash is persisted

## Testing
- pytest tests/test_picker_import_item.py

------
https://chatgpt.com/codex/tasks/task_e_6907eee7877c8323b18a00d439d2734b