### PR TITLE
Add JSON import/export tools to admin config page

### DIFF
--- a/tests/webapp/admin/test_config_routes.py
+++ b/tests/webapp/admin/test_config_routes.py
@@ -1,0 +1,90 @@
+import io
+import json
+
+import pytest
+
+from webapp.services.system_setting_service import SystemSettingService
+
+
+class _MockAdminUser:
+    def __init__(self):
+        self.is_authenticated = True
+
+    def can(self, permission: str) -> bool:
+        return permission == "system:manage"
+
+    def get_id(self) -> str:
+        return "admin"
+
+
+@pytest.fixture
+def client(app_context):
+    return app_context.test_client()
+
+
+def test_export_config_excludes_hidden_keys(client, app_context, monkeypatch):
+    admin = _MockAdminUser()
+    monkeypatch.setattr("flask_login.utils._get_user", lambda: admin)
+
+    with app_context.app_context():
+        SystemSettingService.update_application_settings(
+            {"SITE_NAME": "Example App", "JWT_SECRET_KEY": "top-secret"}
+        )
+
+    response = client.post("/admin/config", data={"action": "export-config"})
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/json"
+    assert "attachment;" in response.headers.get("Content-Disposition", "")
+
+    payload = json.loads(response.data.decode("utf-8"))
+    assert payload["version"] == 1
+    assert payload["application"]["SITE_NAME"] == "Example App"
+    assert "JWT_SECRET_KEY" not in payload["application"]
+
+
+def test_import_config_updates_settings(client, app_context, monkeypatch):
+    admin = _MockAdminUser()
+    monkeypatch.setattr("flask_login.utils._get_user", lambda: admin)
+
+    with app_context.app_context():
+        SystemSettingService.update_application_settings(
+            {
+                "SITE_NAME": "Before Import",
+                "SESSION_COOKIE_SECURE": False,
+                "JWT_SECRET_KEY": "initial-secret",
+            }
+        )
+        SystemSettingService.update_cors_settings({"allowedOrigins": ["https://before.example"]})
+
+    payload = {
+        "version": 1,
+        "application": {
+            "SITE_NAME": "After Import",
+            "SESSION_COOKIE_SECURE": True,
+        },
+        "cors": {"allowedOrigins": ["https://after.example"]},
+    }
+
+    data = {
+        "action": "import-config",
+        "config_file": (io.BytesIO(json.dumps(payload).encode("utf-8")), "config.json"),
+    }
+
+    response = client.post(
+        "/admin/config",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+
+    with app_context.app_context():
+        stored_application = SystemSettingService.load_application_config_payload()
+        stored_cors = SystemSettingService.load_cors_config_payload()
+
+    assert stored_application["SITE_NAME"] == "After Import"
+    assert stored_application["SESSION_COOKIE_SECURE"] is True
+    assert stored_application["JWT_SECRET_KEY"] == "initial-secret"
+    assert stored_cors["allowedOrigins"] == ["https://after.example"]

--- a/webapp/admin/templates/admin/config_view.html
+++ b/webapp/admin/templates/admin/config_view.html
@@ -79,6 +79,14 @@
             >
               <a class="config-tree__link" href="#section-signing">{{ _('Access Token Signing') }}</a>
             </li>
+            <li
+              class="config-tree__item"
+              data-config-tree-node
+              data-target="#section-import-export"
+              data-search-text="{{ (_('Import configuration') ~ ' ' ~ _('Export configuration'))|e }}"
+            >
+              <a class="config-tree__link" href="#section-import-export">{{ _('Import / Export') }}</a>
+            </li>
             <li class="config-tree__heading">{{ _('Application configuration') }}</li>
             <li
               class="config-tree__item"
@@ -176,6 +184,67 @@
     <div class="alert alert-info d-none" data-config-empty-state>
       {{ _('No settings match your search. Try a different keyword.') }}
     </div>
+
+    <section
+      id="section-import-export"
+      class="config-block"
+      data-config-block="import-export"
+      data-search-text="{{ (_('Import configuration') ~ ' ' ~ _('Export configuration') ~ ' JSON')|e }}"
+    >
+      <div class="card shadow-sm border-0">
+        <div class="card-header bg-white border-0 pb-0">
+          <h4 class="card-title mb-1">{{ _('Import / Export') }}</h4>
+          <p class="text-muted small mb-0">
+            {{ _('Download the current configuration as JSON or import a JSON file to update settings.') }}
+          </p>
+        </div>
+        <div class="card-body">
+          <div class="row gy-4">
+            <div class="col-12 col-lg-6">
+              <h5 class="h6">{{ _('Export configuration') }}</h5>
+              <p class="text-muted small">
+                {{ _('Download the application and CORS settings as a JSON file.') }}
+              </p>
+              <form method="post" action="{{ url_for('admin.show_config') }}">
+                <input type="hidden" name="action" value="export-config">
+                <button type="submit" class="btn btn-outline-primary">
+                  <i class="fas fa-download me-1" aria-hidden="true"></i>
+                  {{ _('Export JSON') }}
+                </button>
+              </form>
+            </div>
+            <div class="col-12 col-lg-6">
+              <h5 class="h6">{{ _('Import configuration') }}</h5>
+              <p class="text-muted small">
+                {{ _('Upload a JSON export to apply configuration changes. Existing secrets that are not included will be preserved.') }}
+              </p>
+              <form
+                method="post"
+                action="{{ url_for('admin.show_config') }}"
+                enctype="multipart/form-data"
+              >
+                <input type="hidden" name="action" value="import-config">
+                <div class="mb-3">
+                  <label class="form-label" for="config-import-file">{{ _('Configuration file (.json)') }}</label>
+                  <input
+                    class="form-control"
+                    type="file"
+                    id="config-import-file"
+                    name="config_file"
+                    accept="application/json"
+                    required
+                  >
+                </div>
+                <button type="submit" class="btn btn-primary">
+                  <i class="fas fa-upload me-1" aria-hidden="true"></i>
+                  {{ _('Import JSON') }}
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
 
     {% set signing_search_terms = [_('Access Token Signing')] %}
     {% for group in server_signing_groups or [] %}


### PR DESCRIPTION
## Summary
- add JSON export handling and import validation for admin configuration management
- extend the configuration UI with JSON import/export controls
- cover the new flows with admin configuration tests

## Testing
- pytest tests/webapp/admin/test_config_routes.py

------
https://chatgpt.com/codex/tasks/task_e_6907fa32841083238f00598abe7c2c15