### PR TITLE
Add UI login session cookie tests

### DIFF
--- a/tests/test_gui_access_cookie.py
+++ b/tests/test_gui_access_cookie.py
@@ -1,0 +1,86 @@
+import uuid
+
+import pytest
+
+
+@pytest.fixture()
+def app(app_context):
+    app = app_context
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _create_gui_user(app):
+    from webapp.extensions import db
+    from core.models.user import Permission, Role, User
+
+    with app.app_context():
+        gui_perm = Permission(code="gui:view")
+        dashboard_perm = Permission(code="dashboard:view")
+        role = Role(name=f"gui-{uuid.uuid4().hex[:8]}")
+        role.permissions.extend([gui_perm, dashboard_perm])
+        user = User(email=f"cookie-{uuid.uuid4().hex[:8]}@example.com")
+        user.set_password("pass")
+        user.roles.append(role)
+        db.session.add_all([gui_perm, dashboard_perm, role, user])
+        db.session.commit()
+        return user.email
+
+
+def _extract_access_cookie(response):
+    for header in response.headers.getlist("Set-Cookie"):
+        if header.startswith("access_token="):
+            return header
+    return ""
+
+
+def test_access_cookie_not_secure_for_local_http_when_secure_enforced(app, client):
+    app.config["SESSION_COOKIE_SECURE"] = True
+    email = _create_gui_user(app)
+
+    response = client.post(
+        "/api/login",
+        json={"email": email, "password": "pass", "scope": "gui:view dashboard:view"},
+        base_url="http://localhost",
+    )
+
+    assert response.status_code == 200
+    cookie_header = _extract_access_cookie(response)
+    assert cookie_header
+    assert "Secure" not in cookie_header
+
+
+def test_access_cookie_remains_secure_on_https_when_enforced(app, client):
+    app.config["SESSION_COOKIE_SECURE"] = True
+    email = _create_gui_user(app)
+
+    response = client.post(
+        "/api/login",
+        json={"email": email, "password": "pass", "scope": "gui:view"},
+        base_url="https://example.com",
+    )
+
+    assert response.status_code == 200
+    cookie_header = _extract_access_cookie(response)
+    assert cookie_header
+    assert "Secure" in cookie_header
+
+
+def test_access_cookie_secure_on_https_even_without_flag(app, client):
+    app.config["SESSION_COOKIE_SECURE"] = False
+    email = _create_gui_user(app)
+
+    response = client.post(
+        "/api/login",
+        json={"email": email, "password": "pass", "scope": "gui:view"},
+        base_url="https://example.com",
+    )
+
+    assert response.status_code == 200
+    cookie_header = _extract_access_cookie(response)
+    assert cookie_header
+    assert "Secure" in cookie_header

--- a/tests/webapp/auth/test_login_route.py
+++ b/tests/webapp/auth/test_login_route.py
@@ -1,0 +1,82 @@
+"""UI向けの通常ログインフローを検証するテスト群。"""
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from urllib.parse import urlsplit
+
+import pytest
+
+from core.models.user import User
+from webapp.extensions import db
+
+
+@pytest.fixture
+def client(app_context):
+    return app_context.test_client()
+
+
+def _create_user(email: str = "ui-user@example.com", password: str = "password123") -> User:
+    user = User(email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_auth_login_sets_session_cookie_and_allows_ui_access(client):
+    """/auth/login でのログインがセッションクッキーを発行し、UIアクセスが可能になること。"""
+    user = _create_user()
+
+    response = client.post(
+        "/auth/login",
+        data={"email": user.email, "password": "password123"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+
+    cookies = response.headers.getlist("Set-Cookie")
+    session_cookie_name = client.application.config.get("SESSION_COOKIE_NAME", "session")
+
+    cookie_jar = SimpleCookie()
+    for header in cookies:
+        cookie_jar.load(header)
+
+    assert session_cookie_name in cookie_jar, "セッションクッキーが発行されていません"
+    session_cookie = cookie_jar[session_cookie_name]
+    assert session_cookie.value, "セッションクッキーの値が空です"
+    assert session_cookie.get("httponly") is True
+
+    with client.session_transaction() as session_state:
+        expected_identifier = f"individual:{user.id}"
+        assert session_state.get("_user_id") == expected_identifier
+        assert session_state.get("_fresh") is True
+
+    profile_response = client.get("/auth/profile")
+    assert profile_response.status_code == 200
+
+
+def test_auth_login_honours_next_parameter_and_persists_session(client):
+    """next パラメータが指定された場合に期待通りリダイレクトし、セッションが維持されること。"""
+    user = _create_user(email="next-user@example.com")
+
+    response = client.post(
+        "/auth/login",
+        query_string={"next": "/auth/profile"},
+        data={"email": user.email, "password": "password123"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+
+    location = response.headers.get("Location")
+    assert location, "Location ヘッダが返却されていません"
+    redirected_path = urlsplit(location).path or location
+    assert redirected_path == "/auth/profile"
+
+    with client.session_transaction() as session_state:
+        expected_identifier = f"individual:{user.id}"
+        assert session_state.get("_user_id") == expected_identifier
+
+    profile_response = client.get("/auth/profile")
+    assert profile_response.status_code == 200


### PR DESCRIPTION
## Summary
- add regression tests that exercise the /auth/login browser flow and assert a Flask session cookie is issued
- verify the next parameter redirect while keeping the authenticated session active

## Testing
- pytest tests/webapp/auth/test_login_route.py

------
https://chatgpt.com/codex/tasks/task_e_6908d30424388323bd9c0bb66cbd4d53